### PR TITLE
feat: add expandable action bar

### DIFF
--- a/components/motion/expandable-action-bar.tsx
+++ b/components/motion/expandable-action-bar.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { LayoutGroup, motion, useReducedMotion, type Transition } from "motion/react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+export type ExpandableActionBarSize = "sm" | "md";
+
+export type ExpandableActionBarItem = {
+  id: string;
+  label: ReactNode;
+  icon: ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  active?: boolean;
+  badge?: ReactNode;
+  shortcut?: ReactNode;
+};
+
+export type ExpandableActionBarClassNames = {
+  root?: string;
+  track?: string;
+  item?: string;
+  activeItem?: string;
+  icon?: string;
+  label?: string;
+  badge?: string;
+  shortcut?: string;
+};
+
+export interface ExpandableActionBarProps {
+  items: ExpandableActionBarItem[];
+  expanded?: boolean;
+  defaultExpanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+  activeId?: string;
+  onAction?: (item: ExpandableActionBarItem) => void;
+  size?: ExpandableActionBarSize;
+  expandOnHover?: boolean;
+  expandOnFocus?: boolean;
+  collapseDelay?: number;
+  className?: string;
+  classNames?: ExpandableActionBarClassNames;
+  renderItem?: (item: ExpandableActionBarItem, state: { expanded: boolean; active: boolean }) => ReactNode;
+}
+
+const ITEM_TRANSITION: Transition = {
+  type: "spring",
+  stiffness: 460,
+  damping: 34,
+  mass: 0.62,
+};
+
+const LABEL_TRANSITION: Transition = {
+  type: "spring",
+  stiffness: 380,
+  damping: 32,
+  mass: 0.7,
+};
+
+const SIZE_CLASS: Record<ExpandableActionBarSize, string> = {
+  sm: "min-h-9 gap-1 p-1 text-xs",
+  md: "min-h-11 gap-1.5 p-1.5 text-sm",
+};
+
+const ITEM_SIZE_CLASS: Record<ExpandableActionBarSize, string> = {
+  sm: "h-7 min-w-7 px-1.5",
+  md: "h-8 min-w-8 px-2",
+};
+
+const ICON_SIZE_CLASS: Record<ExpandableActionBarSize, string> = {
+  sm: "h-3.5 w-3.5",
+  md: "h-4 w-4",
+};
+
+function useControllableExpanded({
+  expanded,
+  defaultExpanded,
+  onExpandedChange,
+}: {
+  expanded?: boolean;
+  defaultExpanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+}) {
+  const [internalExpanded, setInternalExpanded] = useState(defaultExpanded ?? false);
+  const isControlled = expanded !== undefined;
+  const value = expanded ?? internalExpanded;
+
+  const setValue = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternalExpanded(next);
+      onExpandedChange?.(next);
+    },
+    [isControlled, onExpandedChange],
+  );
+
+  return [value, setValue] as const;
+}
+
+export function ExpandableActionBar({
+  items,
+  expanded,
+  defaultExpanded = false,
+  onExpandedChange,
+  activeId,
+  onAction,
+  size = "md",
+  expandOnHover = true,
+  expandOnFocus = true,
+  collapseDelay = 90,
+  className,
+  classNames,
+  renderItem,
+}: ExpandableActionBarProps) {
+  const reduce = useReducedMotion();
+  const layoutId = useId();
+  const [isExpanded, setIsExpanded] = useControllableExpanded({
+    expanded,
+    defaultExpanded,
+    onExpandedChange,
+  });
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const collapseTimer = useRef<number | null>(null);
+
+  const clearCollapseTimer = useCallback(() => {
+    if (collapseTimer.current) window.clearTimeout(collapseTimer.current);
+    collapseTimer.current = null;
+  }, []);
+
+  const open = useCallback(() => {
+    clearCollapseTimer();
+    setIsExpanded(true);
+  }, [clearCollapseTimer, setIsExpanded]);
+
+  const close = useCallback(() => {
+    clearCollapseTimer();
+    const timer = window.setTimeout(() => {
+      setIsExpanded(false);
+      setHoveredId(null);
+    }, collapseDelay);
+    collapseTimer.current = timer;
+  }, [clearCollapseTimer, collapseDelay, setIsExpanded]);
+
+  useEffect(() => clearCollapseTimer, [clearCollapseTimer]);
+
+  const onRootMouseEnter = () => {
+    if (expandOnHover) open();
+  };
+
+  const onRootMouseLeave = () => {
+    setHoveredId(null);
+    if (expandOnHover) close();
+  };
+
+  const onRootFocus = () => {
+    if (expandOnFocus) open();
+  };
+
+  const onRootBlur = (event: FocusEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.contains(event.relatedTarget as Node) && expandOnFocus) {
+      close();
+    }
+  };
+
+  const activeItemId = activeId ?? items.find((item) => item.active)?.id;
+  const highlightId = hoveredId ?? activeItemId;
+
+  return (
+    <LayoutGroup id={layoutId}>
+      <motion.div
+        layout="size"
+        onMouseEnter={onRootMouseEnter}
+        onMouseLeave={onRootMouseLeave}
+        onFocus={onRootFocus}
+        onBlur={onRootBlur}
+        transition={ITEM_TRANSITION}
+        className={cn("inline-flex", classNames?.root, className)}
+      >
+        <motion.div
+          layout="size"
+          className={cn(
+            "relative inline-flex items-center overflow-hidden rounded-full border border-(--color-border) bg-(--color-bg-elev)/90 shadow-[0_18px_50px_-30px_rgb(0_0_0/0.55)] backdrop-blur-xl",
+            SIZE_CLASS[size],
+            classNames?.track,
+          )}
+          transition={ITEM_TRANSITION}
+        >
+          {items.map((item) => {
+            const isActive = item.active || activeId === item.id;
+            const isHighlighted = highlightId === item.id;
+
+            return (
+              <motion.button
+                key={item.id}
+                layout="position"
+                type="button"
+                disabled={item.disabled}
+                title={typeof item.label === "string" ? item.label : undefined}
+                onMouseEnter={() => {
+                  clearCollapseTimer();
+                  setHoveredId(item.id);
+                }}
+                onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                  event.currentTarget.blur();
+                  item.onClick?.();
+                  onAction?.(item);
+                }}
+                whileTap={reduce || item.disabled ? undefined : { scale: 0.96 }}
+                transition={ITEM_TRANSITION}
+                className={cn(
+                  "relative isolate inline-flex items-center justify-center overflow-hidden rounded-full font-medium text-(--color-fg-muted) outline-none transition-[color,background-color] duration-150 ease-out",
+                  "focus-visible:text-(--color-fg) disabled:pointer-events-none disabled:opacity-40",
+                  isHighlighted && "text-(--color-fg)",
+                  ITEM_SIZE_CLASS[size],
+                  classNames?.item,
+                  isActive && classNames?.activeItem,
+                )}
+              >
+                {isHighlighted ? (
+                  <motion.span
+                    layoutId="action-bar-highlight"
+                    className="absolute inset-0 -z-10 rounded-full bg-(--color-fg)/[0.07]"
+                    transition={ITEM_TRANSITION}
+                  />
+                ) : null}
+
+                {renderItem ? (
+                  renderItem(item, { expanded: isExpanded, active: isActive })
+                ) : (
+                  <>
+                    <span
+                      className={cn(
+                        "inline-flex shrink-0 items-center justify-center",
+                        ICON_SIZE_CLASS[size],
+                        classNames?.icon,
+                      )}
+                    >
+                      {item.icon}
+                    </span>
+
+                    <motion.span
+                      aria-hidden={!isExpanded}
+                      animate={
+                        reduce
+                          ? {
+                              width: isExpanded ? "auto" : 0,
+                              opacity: isExpanded ? 1 : 0,
+                              marginLeft: isExpanded ? 8 : 0,
+                            }
+                          : {
+                              width: isExpanded ? "auto" : 0,
+                              opacity: isExpanded ? 1 : 0,
+                              x: isExpanded ? 0 : -4,
+                              marginLeft: isExpanded ? 8 : 0,
+                              filter: isExpanded ? "blur(0px)" : "blur(3px)",
+                            }
+                      }
+                      transition={LABEL_TRANSITION}
+                      className={cn(
+                        "inline-block overflow-hidden whitespace-nowrap",
+                        classNames?.label,
+                      )}
+                    >
+                      {item.label}
+                    </motion.span>
+
+                    {item.shortcut ? (
+                      <motion.span
+                        aria-hidden={!isExpanded}
+                        animate={{
+                          width: isExpanded ? "auto" : 0,
+                          opacity: isExpanded ? 1 : 0,
+                          marginLeft: isExpanded ? 4 : 0,
+                        }}
+                        transition={LABEL_TRANSITION}
+                        className={cn(
+                          "hidden overflow-hidden whitespace-nowrap text-[10px] text-(--color-fg-muted) sm:inline-block",
+                          classNames?.shortcut,
+                        )}
+                      >
+                        {item.shortcut}
+                      </motion.span>
+                    ) : null}
+
+                    {item.badge ? (
+                      <span
+                        className={cn(
+                          "ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-(--color-danger) px-1 text-[10px] leading-none text-white",
+                          !isExpanded && "absolute right-0.5 top-0.5",
+                          classNames?.badge,
+                        )}
+                      >
+                        {item.badge}
+                      </span>
+                    ) : null}
+                  </>
+                )}
+              </motion.button>
+            );
+          })}
+        </motion.div>
+      </motion.div>
+    </LayoutGroup>
+  );
+}
+
+export function useExpandableActionBar(items: ExpandableActionBarItem[]) {
+  const [expanded, setExpanded] = useState(false);
+  const [activeId, setActiveId] = useState(items[0]?.id);
+
+  const activeItem = useMemo(
+    () => items.find((item) => item.id === activeId),
+    [activeId, items],
+  );
+
+  return useMemo(
+    () => ({ expanded, setExpanded, activeId, setActiveId, activeItem }),
+    [activeId, activeItem, expanded],
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -19,6 +19,7 @@ import { ButtonStatefulPreview } from "./motion/button-stateful.preview";
 import { ButtonMagneticPreview } from "./motion/button-magnetic.preview";
 import { AnimatedBadgePreview } from "./motion/animated-badge.preview";
 import { AnimatedToastStackPreview } from "./motion/animated-toast-stack.preview";
+import { ExpandableActionBarPreview } from "./motion/expandable-action-bar.preview";
 
 export const previews: Record<string, () => ReactNode> = {
   "motion/tilt-card": TiltCardPreview,
@@ -28,6 +29,7 @@ export const previews: Record<string, () => ReactNode> = {
   "motion/number-ticker": NumberTickerPreview,
   "motion/animated-badge": AnimatedBadgePreview,
   "motion/animated-toast-stack": AnimatedToastStackPreview,
+  "motion/expandable-action-bar": ExpandableActionBarPreview,
   "motion/bottom-sheet": BottomSheetPreview,
   "motion/tabs": TabsPreview,
   "motion/switch": SwitchPreview,

--- a/components/previews/motion/expandable-action-bar.preview.tsx
+++ b/components/previews/motion/expandable-action-bar.preview.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import {
+  Archive,
+  Bell,
+  Check,
+  Copy,
+  Download,
+  Send,
+  Settings,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  ExpandableActionBar,
+  type ExpandableActionBarItem,
+} from "@/components/motion/expandable-action-bar";
+
+const ACTIONS: ExpandableActionBarItem[] = [
+  {
+    id: "send",
+    label: "Send",
+    icon: <Send className="h-4 w-4" />,
+    shortcut: "S",
+  },
+  {
+    id: "copy",
+    label: "Copy",
+    icon: <Copy className="h-4 w-4" />,
+    shortcut: "C",
+  },
+  {
+    id: "download",
+    label: "Export",
+    icon: <Download className="h-4 w-4" />,
+    shortcut: "E",
+  },
+  {
+    id: "archive",
+    label: "Archive",
+    icon: <Archive className="h-4 w-4" />,
+  },
+  {
+    id: "alerts",
+    label: "Alerts",
+    icon: <Bell className="h-4 w-4" />,
+    badge: "3",
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    icon: <Settings className="h-4 w-4" />,
+  },
+];
+
+export function ExpandableActionBarPreview() {
+  const [expanded, setExpanded] = useState(false);
+  const [activeId, setActiveId] = useState("send");
+
+  const items = useMemo(
+    () =>
+      ACTIONS.map((item) => ({
+        ...item,
+        active: item.id === activeId,
+      })),
+    [activeId],
+  );
+
+  return (
+    <div className="flex min-h-72 w-full flex-col items-center justify-center gap-6">
+      <div className="flex min-h-24 items-center justify-center">
+        <ExpandableActionBar
+          items={items}
+          expanded={expanded}
+          onExpandedChange={setExpanded}
+          activeId={activeId}
+          onAction={(item) => setActiveId(item.id)}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={() => setExpanded((current) => !current)}
+          className="inline-flex h-9 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-4 text-xs font-medium text-(--color-fg) transition-colors press hover:border-(--color-border-strong)"
+        >
+          {expanded ? <Check className="h-3.5 w-3.5" /> : null}
+          {expanded ? "Expanded" : "Expand"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -168,6 +168,12 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/animated-toast-stack.tsx",
       },
       {
+        slug: "expandable-action-bar",
+        name: "Expandable Action Bar",
+        description: "Compact icon actions that expand into labeled controls on hover or focus with shared layout motion.",
+        file: "components/motion/expandable-action-bar.tsx",
+      },
+      {
         slug: "number-ticker",
         name: "Number Ticker",
         description: "Slot-machine rolling digits with staggered entry.",


### PR DESCRIPTION
## Summary
- add a customizable expandable action bar with hover/focus expansion and controlled state support
- add smooth shared-layout hover highlighting, badges, shortcuts, active state, and render/class overrides
- register the component in the motion registry and preview map

## Checks
- bunx tsc --noEmit
- git diff --check