### PR TITLE
Dynamic Island component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local working notes
+/docs/

--- a/components/motion/dynamic-island.tsx
+++ b/components/motion/dynamic-island.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { createContext, useContext, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { EASE_OUT, SPRING_SWAP } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 
@@ -11,14 +18,33 @@ type IslandContextValue = {
 
 const IslandContext = createContext<IslandContextValue | null>(null);
 
-// Apple-style life on the shell morph — a hint of overshoot without wobbling
-// the clip while the pill squeezes back down.
+// Shell resize physics — a hint of overshoot without wobbling the clip.
+// The shell animates real width/height (not transforms), so slots are never
+// scale-distorted while it resizes. Classic measured-container pattern.
 const ISLAND_SPRING = {
   type: "spring",
   stiffness: 420,
   damping: 30,
   mass: 0.65,
 } as const;
+
+/** Tracks the natural size of the content so the shell can spring to it. */
+function useContentSize() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      setSize({ width: el.offsetWidth, height: el.offsetHeight });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, size] as const;
+}
 
 function Slot({
   keyId,
@@ -33,14 +59,10 @@ function Slot({
   return (
     <motion.div
       key={keyId}
-      // layout="position" keeps this slot from being stretched per-frame
-      // while the shell resizes around it.
-      layout={reduce ? false : "position"}
       initial={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.9, filter: "blur(6px)" }}
       animate={reduce ? { opacity: 1 } : { opacity: 1, scale: 1, filter: "blur(0px)" }}
       // Exit fast and blur-free: the leaving slot is popped out of layout at
-      // its old size, so anything slow or paint-heavy flickers while the
-      // shell shrinks over it.
+      // its old size while the shell shrinks over it.
       exit={
         reduce
           ? { opacity: 0, transition: { duration: 0.1 } }
@@ -76,30 +98,42 @@ export function DynamicIsland({
 }: DynamicIslandProps) {
   const reduce = useReducedMotion();
   const expanded = view !== null;
+  const [sizerRef, size] = useContentSize();
 
   return (
     <IslandContext.Provider value={{ view }}>
       <motion.div
-        layout={!reduce}
         role="status"
         aria-live="polite"
-        transition={ISLAND_SPRING}
-        style={{ borderRadius: expanded ? 28 : 999 }}
+        initial={false}
+        animate={
+          size
+            ? {
+                width: size.width,
+                height: size.height,
+                borderRadius: expanded ? 28 : 999,
+              }
+            : { borderRadius: expanded ? 28 : 999 }
+        }
+        transition={reduce ? { duration: 0 } : ISLAND_SPRING}
         className={cn(
-          "relative inline-flex min-h-9 items-center justify-center overflow-hidden",
-          "bg-foreground text-background shadow-2xl will-change-transform",
-          expanded ? "px-5 py-3" : "px-4 py-1.5",
+          "relative inline-flex items-center justify-center overflow-hidden",
+          "bg-foreground text-background shadow-2xl",
           className,
         )}
       >
-        <AnimatePresence mode="popLayout" initial={false}>
-          {!expanded && compact ? (
-            <Slot keyId="compact" className="gap-2 text-xs font-medium">
-              {compact}
-            </Slot>
-          ) : null}
-        </AnimatePresence>
-        {children}
+        {/* w-max keeps this at the natural size of the active content; the
+            shell springs toward it. */}
+        <div ref={sizerRef} className="w-max">
+          <AnimatePresence mode="popLayout" initial={false}>
+            {!expanded && compact ? (
+              <Slot keyId="compact" className="min-h-9 gap-2 px-4 py-1.5 text-xs font-medium">
+                {compact}
+              </Slot>
+            ) : null}
+          </AnimatePresence>
+          {children}
+        </div>
       </motion.div>
     </IslandContext.Provider>
   );
@@ -120,7 +154,7 @@ export function DynamicIslandView({ id, children, className }: DynamicIslandView
   return (
     <AnimatePresence mode="popLayout" initial={false}>
       {active ? (
-        <Slot keyId={id} className={className}>
+        <Slot keyId={id} className={cn("px-5 py-3", className)}>
           {children}
         </Slot>
       ) : null}

--- a/components/motion/dynamic-island.tsx
+++ b/components/motion/dynamic-island.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { EASE_OUT, SPRING_SWAP } from "@/lib/ease";
+import { EASE_OUT } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 
 type IslandContextValue = {
@@ -18,14 +18,29 @@ type IslandContextValue = {
 
 const IslandContext = createContext<IslandContextValue | null>(null);
 
-// Shell resize physics — a hint of overshoot without wobbling the clip.
-// The shell animates real width/height (not transforms), so slots are never
-// scale-distorted while it resizes. Classic measured-container pattern.
-const ISLAND_SPRING = {
+// Shell physics, Apple style: expansion blooms out of the pill with a visible
+// overshoot; collapse snaps back tighter. The shell animates real
+// width/height (not transforms), so slots are never scale-distorted.
+const EXPAND_SPRING = {
   type: "spring",
-  stiffness: 420,
+  stiffness: 400,
+  damping: 22,
+  mass: 0.55,
+} as const;
+
+const COLLAPSE_SPRING = {
+  type: "spring",
+  stiffness: 480,
   damping: 30,
-  mass: 0.65,
+  mass: 0.6,
+} as const;
+
+// Content pops from the pill core just after the shell starts moving.
+const CONTENT_SPRING = {
+  type: "spring",
+  stiffness: 500,
+  damping: 26,
+  mass: 0.5,
 } as const;
 
 /** Tracks the natural size of the content so the shell can spring to it. */
@@ -50,29 +65,49 @@ function Slot({
   keyId,
   children,
   className,
+  scaleFrom = 0.6,
+  delay = 0.05,
 }: {
   keyId: string;
   children: ReactNode;
   className?: string;
+  /** Scale the content emerges from — everything originates in the pill core. */
+  scaleFrom?: number;
+  /** Lets the shell lead the bloom before content appears. */
+  delay?: number;
 }) {
   const reduce = useReducedMotion();
   return (
     <motion.div
       key={keyId}
-      initial={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.9, filter: "blur(6px)" }}
+      initial={
+        reduce
+          ? { opacity: 0 }
+          : { opacity: 0, scale: scaleFrom, filter: "blur(8px)" }
+      }
       animate={reduce ? { opacity: 1 } : { opacity: 1, scale: 1, filter: "blur(0px)" }}
-      // Exit fast and blur-free: the leaving slot is popped out of layout at
-      // its old size while the shell shrinks over it.
+      // Exit gets sucked back into the pill core — fast, blur-free, before the
+      // shrinking shell can clip it.
       exit={
         reduce
           ? { opacity: 0, transition: { duration: 0.1 } }
           : {
               opacity: 0,
-              scale: 0.95,
-              transition: { duration: 0.12, ease: EASE_OUT },
+              scale: 0.7,
+              transition: { duration: 0.1, ease: EASE_OUT },
             }
       }
-      transition={reduce ? { duration: 0.15 } : SPRING_SWAP}
+      transition={
+        reduce
+          ? { duration: 0.15 }
+          : {
+              ...CONTENT_SPRING,
+              delay,
+              opacity: { duration: 0.2, ease: EASE_OUT, delay },
+              filter: { duration: 0.25, ease: EASE_OUT, delay },
+            }
+      }
+      style={{ transformOrigin: "center" }}
       className={cn("flex items-center justify-center", className)}
     >
       {children}
@@ -111,11 +146,13 @@ export function DynamicIsland({
             ? {
                 width: size.width,
                 height: size.height,
-                borderRadius: expanded ? 28 : 999,
+                borderRadius: expanded ? 24 : 999,
               }
-            : { borderRadius: expanded ? 28 : 999 }
+            : { borderRadius: expanded ? 24 : 999 }
         }
-        transition={reduce ? { duration: 0 } : ISLAND_SPRING}
+        transition={
+          reduce ? { duration: 0 } : expanded ? EXPAND_SPRING : COLLAPSE_SPRING
+        }
         className={cn(
           "relative inline-flex items-center justify-center overflow-hidden",
           "bg-foreground text-background shadow-2xl",
@@ -127,7 +164,13 @@ export function DynamicIsland({
         <div ref={sizerRef} className="w-max">
           <AnimatePresence mode="popLayout" initial={false}>
             {!expanded && compact ? (
-              <Slot keyId="compact" className="min-h-9 gap-2 px-4 py-1.5 text-xs font-medium">
+              <Slot
+                keyId="compact"
+                scaleFrom={0.8}
+                delay={0.08}
+                // iPhone pill proportions: ~126 x 37.
+                className="min-h-[37px] min-w-[126px] gap-2 px-4 py-1.5 text-xs font-medium"
+              >
                 {compact}
               </Slot>
             ) : null}
@@ -154,7 +197,7 @@ export function DynamicIslandView({ id, children, className }: DynamicIslandView
   return (
     <AnimatePresence mode="popLayout" initial={false}>
       {active ? (
-        <Slot keyId={id} className={cn("px-5 py-3", className)}>
+        <Slot keyId={id} className={cn("px-6 py-4", className)}>
           {children}
         </Slot>
       ) : null}

--- a/components/motion/dynamic-island.tsx
+++ b/components/motion/dynamic-island.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { createContext, useContext, type ReactNode } from "react";
+import { EASE_OUT, SPRING_SWAP } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+type IslandContextValue = {
+  view: string | null;
+};
+
+const IslandContext = createContext<IslandContextValue | null>(null);
+
+// Apple-style bounce on the shell morph — slightly underdamped on purpose so
+// the island lands with a hint of overshoot.
+const ISLAND_SPRING = {
+  type: "spring",
+  stiffness: 420,
+  damping: 28,
+  mass: 0.7,
+} as const;
+
+function Slot({
+  keyId,
+  children,
+  className,
+}: {
+  keyId: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const reduce = useReducedMotion();
+  return (
+    <motion.div
+      key={keyId}
+      initial={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.9, filter: "blur(6px)" }}
+      animate={reduce ? { opacity: 1 } : { opacity: 1, scale: 1, filter: "blur(0px)" }}
+      exit={
+        reduce
+          ? { opacity: 0, transition: { duration: 0.1 } }
+          : {
+              opacity: 0,
+              scale: 0.9,
+              filter: "blur(6px)",
+              transition: { duration: 0.18, ease: EASE_OUT },
+            }
+      }
+      transition={reduce ? { duration: 0.15 } : SPRING_SWAP}
+      className={cn("flex items-center justify-center", className)}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export interface DynamicIslandProps {
+  /** Active view id. `null` shows the compact pill. */
+  view: string | null;
+  /** Compact pill content, shown when no view is active. */
+  compact?: ReactNode;
+  /** DynamicIslandView elements. */
+  children?: ReactNode;
+  className?: string;
+}
+
+export function DynamicIsland({
+  view,
+  compact,
+  children,
+  className,
+}: DynamicIslandProps) {
+  const reduce = useReducedMotion();
+  const expanded = view !== null;
+
+  return (
+    <IslandContext.Provider value={{ view }}>
+      <motion.div
+        layout={!reduce}
+        role="status"
+        aria-live="polite"
+        transition={ISLAND_SPRING}
+        style={{ borderRadius: expanded ? 28 : 999 }}
+        className={cn(
+          "relative inline-flex min-h-9 items-center justify-center overflow-hidden",
+          "bg-foreground text-background shadow-2xl will-change-transform",
+          expanded ? "px-5 py-3" : "px-4 py-1.5",
+          className,
+        )}
+      >
+        <AnimatePresence mode="popLayout" initial={false}>
+          {!expanded && compact ? (
+            <Slot keyId="compact" className="gap-2 text-xs font-medium">
+              {compact}
+            </Slot>
+          ) : null}
+        </AnimatePresence>
+        {children}
+      </motion.div>
+    </IslandContext.Provider>
+  );
+}
+
+export interface DynamicIslandViewProps {
+  /** Matches the parent `view` prop when active. */
+  id: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function DynamicIslandView({ id, children, className }: DynamicIslandViewProps) {
+  const ctx = useContext(IslandContext);
+  if (!ctx) throw new Error("DynamicIslandView must be used inside <DynamicIsland>");
+  const active = ctx.view === id;
+
+  return (
+    <AnimatePresence mode="popLayout" initial={false}>
+      {active ? (
+        <Slot keyId={id} className={className}>
+          {children}
+        </Slot>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/components/motion/dynamic-island.tsx
+++ b/components/motion/dynamic-island.tsx
@@ -11,13 +11,13 @@ type IslandContextValue = {
 
 const IslandContext = createContext<IslandContextValue | null>(null);
 
-// Apple-style bounce on the shell morph — slightly underdamped on purpose so
-// the island lands with a hint of overshoot.
+// Apple-style life on the shell morph — a hint of overshoot without wobbling
+// the clip while the pill squeezes back down.
 const ISLAND_SPRING = {
   type: "spring",
   stiffness: 420,
-  damping: 28,
-  mass: 0.7,
+  damping: 30,
+  mass: 0.65,
 } as const;
 
 function Slot({
@@ -33,16 +33,21 @@ function Slot({
   return (
     <motion.div
       key={keyId}
+      // layout="position" keeps this slot from being stretched per-frame
+      // while the shell resizes around it.
+      layout={reduce ? false : "position"}
       initial={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.9, filter: "blur(6px)" }}
       animate={reduce ? { opacity: 1 } : { opacity: 1, scale: 1, filter: "blur(0px)" }}
+      // Exit fast and blur-free: the leaving slot is popped out of layout at
+      // its old size, so anything slow or paint-heavy flickers while the
+      // shell shrinks over it.
       exit={
         reduce
           ? { opacity: 0, transition: { duration: 0.1 } }
           : {
               opacity: 0,
-              scale: 0.9,
-              filter: "blur(6px)",
-              transition: { duration: 0.18, ease: EASE_OUT },
+              scale: 0.95,
+              transition: { duration: 0.12, ease: EASE_OUT },
             }
       }
       transition={reduce ? { duration: 0.15 } : SPRING_SWAP}

--- a/components/motion/dynamic-island.tsx
+++ b/components/motion/dynamic-island.tsx
@@ -19,8 +19,9 @@ type IslandContextValue = {
 const IslandContext = createContext<IslandContextValue | null>(null);
 
 // Shell physics, Apple style: expansion blooms out of the pill with a visible
-// overshoot; collapse snaps back tighter. The shell animates real
-// width/height (not transforms), so slots are never scale-distorted.
+// overshoot, and collapse returns with the same life — the pill squeezes a
+// touch past its size and springs back. The shell animates real width/height
+// (not transforms), so slots are never scale-distorted.
 const EXPAND_SPRING = {
   type: "spring",
   stiffness: 550,
@@ -30,9 +31,9 @@ const EXPAND_SPRING = {
 
 const COLLAPSE_SPRING = {
   type: "spring",
-  stiffness: 620,
-  damping: 32,
-  mass: 0.5,
+  stiffness: 520,
+  damping: 24,
+  mass: 0.45,
 } as const;
 
 // Content pops from the pill core just after the shell starts moving.

--- a/components/motion/dynamic-island.tsx
+++ b/components/motion/dynamic-island.tsx
@@ -65,13 +65,13 @@ function Slot({
   keyId,
   children,
   className,
-  scaleFrom = 0.6,
-  delay = 0.05,
+  scaleFrom = 0.8,
+  delay = 0.04,
 }: {
   keyId: string;
   children: ReactNode;
   className?: string;
-  /** Scale the content emerges from — everything originates in the pill core. */
+  /** Scale the content emerges from — everything originates at the pill. */
   scaleFrom?: number;
   /** Lets the shell lead the bloom before content appears. */
   delay?: number;
@@ -83,17 +83,22 @@ function Slot({
       initial={
         reduce
           ? { opacity: 0 }
-          : { opacity: 0, scale: scaleFrom, filter: "blur(8px)" }
+          : { opacity: 0, scale: scaleFrom, y: -8, filter: "blur(8px)" }
       }
-      animate={reduce ? { opacity: 1 } : { opacity: 1, scale: 1, filter: "blur(0px)" }}
-      // Exit gets sucked back into the pill core — fast, blur-free, before the
+      animate={
+        reduce
+          ? { opacity: 1 }
+          : { opacity: 1, scale: 1, y: 0, filter: "blur(0px)" }
+      }
+      // Exit gets sucked up into the pill — fast, blur-free, before the
       // shrinking shell can clip it.
       exit={
         reduce
           ? { opacity: 0, transition: { duration: 0.1 } }
           : {
               opacity: 0,
-              scale: 0.7,
+              scale: 0.85,
+              y: -6,
               transition: { duration: 0.1, ease: EASE_OUT },
             }
       }
@@ -107,7 +112,9 @@ function Slot({
               filter: { duration: 0.25, ease: EASE_OUT, delay },
             }
       }
-      style={{ transformOrigin: "center" }}
+      // Anchored to the pill line: content unfurls downward out of it and is
+      // sucked back up into it.
+      style={{ transformOrigin: "top center" }}
       className={cn("flex items-center justify-center", className)}
     >
       {children}
@@ -153,8 +160,11 @@ export function DynamicIsland({
         transition={
           reduce ? { duration: 0 } : expanded ? EXPAND_SPRING : COLLAPSE_SPRING
         }
+        // items-start pins content to the top edge while the shell springs, so
+        // expansion reads as unfurling downward out of the pill. Top-align the
+        // island in its parent (like under a notch) to complete the effect.
         className={cn(
-          "relative inline-flex items-center justify-center overflow-hidden",
+          "relative inline-flex items-start justify-center overflow-hidden",
           "bg-foreground text-background shadow-2xl",
           className,
         )}
@@ -166,8 +176,8 @@ export function DynamicIsland({
             {!expanded && compact ? (
               <Slot
                 keyId="compact"
-                scaleFrom={0.8}
-                delay={0.08}
+                scaleFrom={0.85}
+                delay={0.06}
                 // iPhone pill proportions: ~126 x 37.
                 className="min-h-[37px] min-w-[126px] gap-2 px-4 py-1.5 text-xs font-medium"
               >

--- a/components/motion/dynamic-island.tsx
+++ b/components/motion/dynamic-island.tsx
@@ -5,7 +5,6 @@ import {
   createContext,
   useContext,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -25,22 +24,22 @@ const IslandContext = createContext<IslandContextValue | null>(null);
 const EXPAND_SPRING = {
   type: "spring",
   stiffness: 550,
-  damping: 23,
+  damping: 25,
   mass: 0.5,
 } as const;
 
 const COLLAPSE_SPRING = {
   type: "spring",
   stiffness: 620,
-  damping: 29,
+  damping: 32,
   mass: 0.5,
 } as const;
 
-// Content moves with the shell — no delay, same family of physics.
+// Content pops from the pill core just after the shell starts moving.
 const CONTENT_SPRING = {
   type: "spring",
   stiffness: 560,
-  damping: 26,
+  damping: 28,
   mass: 0.5,
 } as const;
 
@@ -52,20 +51,10 @@ const RADIUS_COMPACT = 18.5;
 const RADIUS_EXPANDED = 24;
 
 /** Tracks the natural size of the content so the shell can spring to it. */
-function useContentSize(contentKey: string | null) {
+function useContentSize() {
   const ref = useRef<HTMLDivElement | null>(null);
   const [size, setSize] = useState<{ width: number; height: number } | null>(null);
 
-  // Measure synchronously on every content swap, before paint — waiting for
-  // ResizeObserver costs frames and the press feels sticky.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: contentKey drives remeasure on view swaps.
-  useLayoutEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    setSize({ width: el.offsetWidth, height: el.offsetHeight });
-  }, [contentKey]);
-
-  // ResizeObserver covers async drift: fonts, live content like tickers.
   useEffect(() => {
     const el = ref.current;
     if (!el || typeof ResizeObserver === "undefined") return;
@@ -84,7 +73,7 @@ function Slot({
   children,
   className,
   scaleFrom = 0.8,
-  delay = 0,
+  delay = 0.04,
 }: {
   keyId: string;
   children: ReactNode;
@@ -126,8 +115,8 @@ function Slot({
           : {
               ...CONTENT_SPRING,
               delay,
-              opacity: { duration: 0.15, ease: EASE_OUT, delay },
-              filter: { duration: 0.18, ease: EASE_OUT, delay },
+              opacity: { duration: 0.18, ease: EASE_OUT, delay },
+              filter: { duration: 0.22, ease: EASE_OUT, delay },
             }
       }
       // Anchored to the pill line: content unfurls downward out of it and is
@@ -158,7 +147,7 @@ export function DynamicIsland({
 }: DynamicIslandProps) {
   const reduce = useReducedMotion();
   const expanded = view !== null;
-  const [sizerRef, size] = useContentSize(view);
+  const [sizerRef, size] = useContentSize();
 
   return (
     <IslandContext.Provider value={{ view }}>
@@ -200,7 +189,7 @@ export function DynamicIsland({
               <Slot
                 keyId="compact"
                 scaleFrom={0.85}
-                delay={0.02}
+                delay={0.06}
                 // iPhone pill proportions: ~126 x 37.
                 className="min-h-[37px] min-w-[126px] gap-2 px-4 py-1.5 text-xs font-medium"
               >

--- a/components/motion/dynamic-island.tsx
+++ b/components/motion/dynamic-island.tsx
@@ -5,6 +5,7 @@ import {
   createContext,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -24,22 +25,22 @@ const IslandContext = createContext<IslandContextValue | null>(null);
 const EXPAND_SPRING = {
   type: "spring",
   stiffness: 550,
-  damping: 25,
+  damping: 23,
   mass: 0.5,
 } as const;
 
 const COLLAPSE_SPRING = {
   type: "spring",
   stiffness: 620,
-  damping: 32,
+  damping: 29,
   mass: 0.5,
 } as const;
 
-// Content pops from the pill core just after the shell starts moving.
+// Content moves with the shell — no delay, same family of physics.
 const CONTENT_SPRING = {
   type: "spring",
   stiffness: 560,
-  damping: 28,
+  damping: 26,
   mass: 0.5,
 } as const;
 
@@ -51,10 +52,20 @@ const RADIUS_COMPACT = 18.5;
 const RADIUS_EXPANDED = 24;
 
 /** Tracks the natural size of the content so the shell can spring to it. */
-function useContentSize() {
+function useContentSize(contentKey: string | null) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [size, setSize] = useState<{ width: number; height: number } | null>(null);
 
+  // Measure synchronously on every content swap, before paint — waiting for
+  // ResizeObserver costs frames and the press feels sticky.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: contentKey drives remeasure on view swaps.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    setSize({ width: el.offsetWidth, height: el.offsetHeight });
+  }, [contentKey]);
+
+  // ResizeObserver covers async drift: fonts, live content like tickers.
   useEffect(() => {
     const el = ref.current;
     if (!el || typeof ResizeObserver === "undefined") return;
@@ -73,7 +84,7 @@ function Slot({
   children,
   className,
   scaleFrom = 0.8,
-  delay = 0.04,
+  delay = 0,
 }: {
   keyId: string;
   children: ReactNode;
@@ -115,8 +126,8 @@ function Slot({
           : {
               ...CONTENT_SPRING,
               delay,
-              opacity: { duration: 0.18, ease: EASE_OUT, delay },
-              filter: { duration: 0.22, ease: EASE_OUT, delay },
+              opacity: { duration: 0.15, ease: EASE_OUT, delay },
+              filter: { duration: 0.18, ease: EASE_OUT, delay },
             }
       }
       // Anchored to the pill line: content unfurls downward out of it and is
@@ -147,7 +158,7 @@ export function DynamicIsland({
 }: DynamicIslandProps) {
   const reduce = useReducedMotion();
   const expanded = view !== null;
-  const [sizerRef, size] = useContentSize();
+  const [sizerRef, size] = useContentSize(view);
 
   return (
     <IslandContext.Provider value={{ view }}>
@@ -189,7 +200,7 @@ export function DynamicIsland({
               <Slot
                 keyId="compact"
                 scaleFrom={0.85}
-                delay={0.06}
+                delay={0.02}
                 // iPhone pill proportions: ~126 x 37.
                 className="min-h-[37px] min-w-[126px] gap-2 px-4 py-1.5 text-xs font-medium"
               >

--- a/components/motion/dynamic-island.tsx
+++ b/components/motion/dynamic-island.tsx
@@ -23,25 +23,32 @@ const IslandContext = createContext<IslandContextValue | null>(null);
 // width/height (not transforms), so slots are never scale-distorted.
 const EXPAND_SPRING = {
   type: "spring",
-  stiffness: 400,
-  damping: 22,
-  mass: 0.55,
+  stiffness: 550,
+  damping: 25,
+  mass: 0.5,
 } as const;
 
 const COLLAPSE_SPRING = {
   type: "spring",
-  stiffness: 480,
-  damping: 30,
-  mass: 0.6,
+  stiffness: 620,
+  damping: 32,
+  mass: 0.5,
 } as const;
 
 // Content pops from the pill core just after the shell starts moving.
 const CONTENT_SPRING = {
   type: "spring",
-  stiffness: 500,
-  damping: 26,
+  stiffness: 560,
+  damping: 28,
   mass: 0.5,
 } as const;
+
+// Real radii, tweened separately from the size spring. Springing between a
+// fake huge radius and a small one makes corners glitch mid-resize; these two
+// values are close (18.5 is exactly half the 37px pill) so the corner shape
+// stays stable throughout.
+const RADIUS_COMPACT = 18.5;
+const RADIUS_EXPANDED = 24;
 
 /** Tracks the natural size of the content so the shell can spring to it. */
 function useContentSize() {
@@ -99,7 +106,7 @@ function Slot({
               opacity: 0,
               scale: 0.85,
               y: -6,
-              transition: { duration: 0.1, ease: EASE_OUT },
+              transition: { duration: 0.08, ease: EASE_OUT },
             }
       }
       transition={
@@ -108,8 +115,8 @@ function Slot({
           : {
               ...CONTENT_SPRING,
               delay,
-              opacity: { duration: 0.2, ease: EASE_OUT, delay },
-              filter: { duration: 0.25, ease: EASE_OUT, delay },
+              opacity: { duration: 0.18, ease: EASE_OUT, delay },
+              filter: { duration: 0.22, ease: EASE_OUT, delay },
             }
       }
       // Anchored to the pill line: content unfurls downward out of it and is
@@ -153,12 +160,17 @@ export function DynamicIsland({
             ? {
                 width: size.width,
                 height: size.height,
-                borderRadius: expanded ? 24 : 999,
+                borderRadius: expanded ? RADIUS_EXPANDED : RADIUS_COMPACT,
               }
-            : { borderRadius: expanded ? 24 : 999 }
+            : { borderRadius: expanded ? RADIUS_EXPANDED : RADIUS_COMPACT }
         }
         transition={
-          reduce ? { duration: 0 } : expanded ? EXPAND_SPRING : COLLAPSE_SPRING
+          reduce
+            ? { duration: 0 }
+            : {
+                ...(expanded ? EXPAND_SPRING : COLLAPSE_SPRING),
+                borderRadius: { duration: 0.2, ease: EASE_OUT },
+              }
         }
         // items-start pins content to the top edge while the shell springs, so
         // expansion reads as unfurling downward out of the pill. Top-align the

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -25,8 +25,10 @@ import { ExpandableActionBarPreview } from "./motion/expandable-action-bar.previ
 import { ActionSwapPreview } from "./motion/action-swap.preview";
 import { ActionSwapBlurPreview } from "./motion/action-swap-blur.preview";
 import { ActionSwapRollPreview } from "./motion/action-swap-roll.preview";
+import { DynamicIslandPreview } from "./motion/dynamic-island.preview";
 
 export const previews: Record<string, () => ReactNode> = {
+  "motion/dynamic-island": DynamicIslandPreview,
   "motion/tilt-card": TiltCardPreview,
   "motion/marquee": MarqueePreview,
   "motion/text-animation": TextAnimationPreview,

--- a/components/previews/motion/dynamic-island.preview.tsx
+++ b/components/previews/motion/dynamic-island.preview.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { Music, Phone, PhoneOff, Timer } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/motion/button";
+import { DynamicIsland, DynamicIslandView } from "@/components/motion/dynamic-island";
+import { NumberTicker } from "@/components/motion/number-ticker";
+
+type IslandView = "call" | "timer" | "music" | null;
+
+const BAR_DELAYS = [0, 0.18, 0.09, 0.27];
+
+function EqBars() {
+  const reduce = useReducedMotion();
+  return (
+    <span className="flex h-4 items-end gap-0.5" aria-hidden>
+      {BAR_DELAYS.map((delay) => (
+        <motion.span
+          key={delay}
+          animate={reduce ? undefined : { scaleY: [0.4, 1, 0.55, 0.9, 0.4] }}
+          transition={{ duration: 1.1, repeat: Infinity, ease: "easeInOut", delay }}
+          className="h-full w-0.5 origin-bottom rounded-full bg-(--color-success)"
+          style={{ scaleY: 0.6 }}
+        />
+      ))}
+    </span>
+  );
+}
+
+function formatClock(totalSeconds: number) {
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export function DynamicIslandPreview() {
+  const [view, setView] = useState<IslandView>(null);
+  const [seconds, setSeconds] = useState(154);
+
+  useEffect(() => {
+    if (view !== "timer") return;
+    const id = window.setInterval(() => {
+      setSeconds((s) => (s > 0 ? s - 1 : 0));
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [view]);
+
+  return (
+    <div className="flex w-full flex-col items-center gap-8">
+      <DynamicIsland
+        view={view}
+        compact={
+          <>
+            <span className="h-1.5 w-1.5 rounded-full bg-(--color-success)" />
+            <span>9:41</span>
+          </>
+        }
+      >
+        <DynamicIslandView id="call" className="gap-4">
+          <div className="flex flex-col">
+            <span className="text-[10px] uppercase tracking-wider opacity-60">
+              Incoming call
+            </span>
+            <span className="text-sm font-semibold">Emil Kowalski</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              aria-label="Decline"
+              onClick={() => setView(null)}
+              className="flex h-8 w-8 items-center justify-center rounded-full bg-(--color-danger) text-white"
+            >
+              <PhoneOff className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              aria-label="Accept"
+              onClick={() => setView(null)}
+              className="flex h-8 w-8 items-center justify-center rounded-full bg-(--color-success) text-white"
+            >
+              <Phone className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </DynamicIslandView>
+
+        <DynamicIslandView id="timer" className="gap-3">
+          <Timer className="h-4 w-4 text-(--color-warning)" />
+          <span className="text-[10px] uppercase tracking-wider opacity-60">Timer</span>
+          <NumberTicker
+            value={seconds}
+            format={formatClock}
+            startOnView={false}
+            duration={0.5}
+            className="text-sm font-semibold"
+          />
+        </DynamicIslandView>
+
+        <DynamicIslandView id="music" className="gap-3">
+          <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-background/15">
+            <Music className="h-3.5 w-3.5" />
+          </span>
+          <div className="flex flex-col text-left">
+            <span className="text-xs font-semibold leading-tight">Midnight City</span>
+            <span className="text-[10px] opacity-60">M83</span>
+          </div>
+          <EqBars />
+        </DynamicIslandView>
+      </DynamicIsland>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <Button size="sm" variant="secondary" onClick={() => setView("call")}>
+          Call
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => {
+            setSeconds(154);
+            setView("timer");
+          }}
+        >
+          Timer
+        </Button>
+        <Button size="sm" variant="secondary" onClick={() => setView("music")}>
+          Music
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => setView(null)}>
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/previews/motion/dynamic-island.preview.tsx
+++ b/components/previews/motion/dynamic-island.preview.tsx
@@ -47,8 +47,11 @@ export function DynamicIslandPreview() {
   }, [view]);
 
   return (
-    <div className="flex w-full flex-col items-center gap-8">
-      <DynamicIsland
+    <div className="flex w-full flex-col items-center gap-4">
+      {/* Fixed-height, top-aligned zone: the island stays pinned at the top
+          like under a notch and unfurls downward into reserved space. */}
+      <div className="flex h-32 w-full items-start justify-center pt-2">
+        <DynamicIsland
         view={view}
         compact={
           <>
@@ -106,7 +109,8 @@ export function DynamicIslandPreview() {
           </div>
           <EqBars />
         </DynamicIslandView>
-      </DynamicIsland>
+        </DynamicIsland>
+      </div>
 
       <div className="flex flex-wrap items-center justify-center gap-2">
         <Button size="sm" variant="secondary" onClick={() => setView("call")}>

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -137,6 +137,12 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/tooltip.tsx",
       },
       {
+        slug: "dynamic-island",
+        name: "Dynamic Island",
+        description: "iOS-style island pill that morphs between live activity views with bouncy shell resize and blur crossfades.",
+        file: "components/motion/dynamic-island.tsx",
+      },
+      {
         slug: "morphing-modal",
         name: "Morphing Modal",
         description: "Family-app-style modal. A single panel that morphs its height as you navigate between inner views, with blur cross-fade on content.",


### PR DESCRIPTION
## What

New motion component: iOS-style Dynamic Island. Pill morphs between live activity views (call, timer, music in the preview) with Apple-style physics.

### How it works
- Shell springs real width/height/borderRadius toward the measured natural size of the active content (ResizeObserver + w-max sizer). No transform scaling, so slots are never distorted while the shell resizes; this was the fix for collapse flicker after two layout-prop attempts
- Compact pill uses real iPhone proportions (126 x 37). Everything blooms out of that capsule and gets sucked back into it: content anchored top center with scale and y drift from the pill line, shell pinned items-start so expansion unfurls downward
- Direction-split springs with matching bounce character: expand 550/25, collapse 520/24 mass 0.45, so the squeeze has the same life as the bloom instead of snapping shut
- Corner radius tweens between honest values (18.5 compact, 24 expanded) decoupled from the size spring; springing to a fake 999 radius glitched corners mid-resize
- Exits are 100ms, blur-free, scaled into the pill core before the shrinking shell can clip them
- role=status with aria-live announces view changes; reduced motion collapses everything to opacity crossfades and instant resize

### API
Controlled, mirrors morphing-modal: `view` id plus `compact` slot, `DynamicIslandView` children. Registry bundle verified: ships with lib/ease.ts and lib/utils.ts only.

Also adds a gitignored /docs/ folder for local working notes.

## Verification
- bun run check green (typecheck, biome, 19 registry components validated)
- Motion tuned over several rounds of hand testing in the browser: collapse flicker, corner glitch, press stall and heavy squeeze each diagnosed and fixed