### PR TITLE
Mobile nav via bottom sheet

### DIFF
--- a/components/app/mobile-nav.tsx
+++ b/components/app/mobile-nav.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { ChevronsUpDown, Compass } from "lucide-react";
+import { Menu } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { BottomSheet } from "@/components/motion/bottom-sheet";
 import { Button } from "@/components/motion/button";
 import { SidebarNav } from "@/components/app/site-sidebar";
 
-/** Mobile replacement for the sidebar: a trigger that opens the nav in beUI's own bottom sheet. */
+/** Mobile nav: a header hamburger that opens the sidebar list in beUI's own bottom sheet. */
 export function MobileNav() {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
@@ -19,20 +19,16 @@ export function MobileNav() {
   }, [pathname]);
 
   return (
-    <div className="mb-6 md:hidden">
+    <div className="md:hidden">
       <Button
-        variant="outline"
-        size="md"
+        variant="ghost"
+        size="icon"
         onClick={() => setOpen(true)}
+        aria-label="Open navigation"
         aria-haspopup="dialog"
         aria-expanded={open}
-        className="w-full justify-between rounded-xl"
       >
-        <span className="flex items-center gap-2">
-          <Compass className="h-4 w-4 text-(--color-fg-muted)" />
-          Browse components
-        </span>
-        <ChevronsUpDown className="h-4 w-4 text-(--color-fg-muted)" />
+        <Menu className="h-5 w-5" />
       </Button>
       <BottomSheet
         open={open}

--- a/components/app/mobile-nav.tsx
+++ b/components/app/mobile-nav.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { ChevronsUpDown, Compass } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { BottomSheet } from "@/components/motion/bottom-sheet";
+import { Button } from "@/components/motion/button";
+import { SidebarNav } from "@/components/app/site-sidebar";
+
+/** Mobile replacement for the sidebar: a trigger that opens the nav in beUI's own bottom sheet. */
+export function MobileNav() {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Covers navigation that doesn't go through a sheet link (back/forward).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the trigger — close the sheet on any route change.
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  return (
+    <div className="mb-6 md:hidden">
+      <Button
+        variant="outline"
+        size="md"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="w-full justify-between rounded-xl"
+      >
+        <span className="flex items-center gap-2">
+          <Compass className="h-4 w-4 text-(--color-fg-muted)" />
+          Browse components
+        </span>
+        <ChevronsUpDown className="h-4 w-4 text-(--color-fg-muted)" />
+      </Button>
+      <BottomSheet
+        open={open}
+        onOpenChange={setOpen}
+        title="Browse"
+        snapPoints={[0.85]}
+      >
+        <div className="pt-2">
+          <SidebarNav onNavigate={() => setOpen(false)} />
+        </div>
+      </BottomSheet>
+    </div>
+  );
+}

--- a/components/app/site-frame.tsx
+++ b/components/app/site-frame.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
+import { MobileNav } from "@/components/app/mobile-nav";
 import { SiteSidebar } from "@/components/app/site-sidebar";
 import { PageTransition } from "@/components/app/page-transition";
 
@@ -19,6 +20,7 @@ export function SiteFrame({ children }: { children: ReactNode }) {
     <div className="mx-auto max-w-7xl px-4">
       <SiteSidebar />
       <div className="min-w-0 py-8 md:pl-64">
+        <MobileNav />
         <PageTransition>{children}</PageTransition>
       </div>
     </div>

--- a/components/app/site-frame.tsx
+++ b/components/app/site-frame.tsx
@@ -2,7 +2,6 @@
 
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
-import { MobileNav } from "@/components/app/mobile-nav";
 import { SiteSidebar } from "@/components/app/site-sidebar";
 import { PageTransition } from "@/components/app/page-transition";
 
@@ -20,7 +19,6 @@ export function SiteFrame({ children }: { children: ReactNode }) {
     <div className="mx-auto max-w-7xl px-4">
       <SiteSidebar />
       <div className="min-w-0 py-8 md:pl-64">
-        <MobileNav />
         <PageTransition>{children}</PageTransition>
       </div>
     </div>

--- a/components/app/site-header.tsx
+++ b/components/app/site-header.tsx
@@ -6,6 +6,7 @@ import { useMotionValueEvent, useScroll } from "motion/react";
 import { ArrowRight, Star } from "lucide-react";
 import { useState } from "react";
 import { GithubIcon } from "@/components/app/icons";
+import { MobileNav } from "@/components/app/mobile-nav";
 import { PressLink } from "@/components/app/press-link";
 import { cn } from "@/lib/utils";
 
@@ -42,23 +43,26 @@ export function SiteHeader({
       )}
     >
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between gap-4 px-4">
-        <Link
-          href="/"
-          className="group flex items-center gap-2.5 text-sm font-semibold tracking-tight text-(--color-fg)"
-        >
-          <Image
-            src="/beui-mark.png"
-            alt=""
-            aria-hidden="true"
-            width={24}
-            height={24}
-            className="h-6 w-6 rounded-lg"
-          />
-          <span>beUI</span>
-          <span className="hidden rounded-full border border-(--color-border) bg-(--color-bg-elev) px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-(--color-fg-muted) sm:inline-block">
-            v2
-          </span>
-        </Link>
+        <div className="flex items-center gap-1.5">
+          <MobileNav />
+          <Link
+            href="/"
+            className="group flex items-center gap-2.5 text-sm font-semibold tracking-tight text-(--color-fg)"
+          >
+            <Image
+              src="/beui-mark.png"
+              alt=""
+              aria-hidden="true"
+              width={24}
+              height={24}
+              className="h-6 w-6 rounded-lg"
+            />
+            <span>beUI</span>
+            <span className="hidden rounded-full border border-(--color-border) bg-(--color-bg-elev) px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-(--color-fg-muted) sm:inline-block">
+              v2
+            </span>
+          </Link>
+        </div>
 
         <nav className="flex items-center gap-2">
           <PressLink

--- a/components/app/site-sidebar.tsx
+++ b/components/app/site-sidebar.tsx
@@ -19,99 +19,88 @@ function moveFirstItemsToBottom<T>(items: T[], count: number) {
   return [...items.slice(count), ...items.slice(0, count)];
 }
 
-export function SiteSidebar() {
+/** Nav list shared by the desktop sidebar and the mobile bottom sheet. */
+export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   const pathname = usePathname();
+
+  const linkClass = (active: boolean) =>
+    cn(
+      "relative block rounded-lg px-3 py-1.5 text-sm transition-colors",
+      active
+        ? "text-(--color-fg) font-medium bg-(--color-fg)/[0.06]"
+        : "text-(--color-fg-muted) hover:text-(--color-fg)",
+    );
+
+  return (
+    <nav className="flex flex-col gap-8">
+      <div>
+        <p className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+          Intro
+        </p>
+        <SharedLayoutBg inset={0} pillClassName="rounded-lg bg-(--color-fg)/[0.05]">
+          {INTRO.map((item) => (
+            <Link
+              key={item.slug}
+              href={item.href}
+              onClick={onNavigate}
+              className={linkClass(pathname === item.href)}
+            >
+              {item.name}
+            </Link>
+          ))}
+        </SharedLayoutBg>
+      </div>
+      <div>
+        <p className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+          Guides
+        </p>
+        <SharedLayoutBg inset={0} pillClassName="rounded-lg bg-(--color-fg)/[0.05]">
+          {PATTERNS.map((item) => (
+            <Link
+              key={item.slug}
+              href={item.href}
+              onClick={onNavigate}
+              className={linkClass(pathname === item.href)}
+            >
+              {item.name}
+            </Link>
+          ))}
+        </SharedLayoutBg>
+      </div>
+      {registry.map((cat) => (
+        <div key={cat.slug}>
+          <Link
+            href={`/components/${cat.slug}`}
+            onClick={onNavigate}
+            className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-(--color-fg-muted)"
+          >
+            {cat.name}
+          </Link>
+          <SharedLayoutBg inset={0} pillClassName="rounded-lg bg-(--color-fg)/[0.05]">
+            {moveFirstItemsToBottom(cat.components, 3).map((comp) => {
+              const href = `/components/${cat.slug}/${comp.slug}`;
+              return (
+                <Link
+                  key={comp.slug}
+                  href={href}
+                  onClick={onNavigate}
+                  className={linkClass(pathname === href)}
+                >
+                  {comp.name}
+                </Link>
+              );
+            })}
+          </SharedLayoutBg>
+        </div>
+      ))}
+    </nav>
+  );
+}
+
+export function SiteSidebar() {
   return (
     <aside className="fixed top-14 hidden h-[calc(100vh-3.5rem)] w-60 overflow-x-visible overflow-y-auto scrollbar-hide py-6 pr-4 md:block">
-      <nav className="flex flex-col gap-8">
-        <div>
-          <p className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-(--color-fg-muted)">
-            Intro
-          </p>
-          <SharedLayoutBg
-            inset={0}
-            pillClassName="rounded-lg bg-(--color-fg)/[0.05]"
-          >
-            {INTRO.map((item) => {
-              const active = pathname === item.href;
-              return (
-                <Link
-                  key={item.slug}
-                  href={item.href}
-                  className={cn(
-                    "relative block rounded-lg px-3 py-1.5 text-sm transition-colors",
-                    active
-                      ? "text-(--color-fg) font-medium bg-(--color-fg)/[0.06]"
-                      : "text-(--color-fg-muted) hover:text-(--color-fg)",
-                  )}
-                >
-                  {item.name}
-                </Link>
-              );
-            })}
-          </SharedLayoutBg>
-        </div>
-        <div>
-          <p className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-(--color-fg-muted)">
-            Guides
-          </p>
-          <SharedLayoutBg
-            inset={0}
-            pillClassName="rounded-lg bg-(--color-fg)/[0.05]"
-          >
-            {PATTERNS.map((item) => {
-              const active = pathname === item.href;
-              return (
-                <Link
-                  key={item.slug}
-                  href={item.href}
-                  className={cn(
-                    "relative block rounded-lg px-3 py-1.5 text-sm transition-colors",
-                    active
-                      ? "text-(--color-fg) font-medium bg-(--color-fg)/[0.06]"
-                      : "text-(--color-fg-muted) hover:text-(--color-fg)",
-                  )}
-                >
-                  {item.name}
-                </Link>
-              );
-            })}
-          </SharedLayoutBg>
-        </div>
-        {registry.map((cat) => (
-          <div key={cat.slug}>
-            <Link
-              href={`/components/${cat.slug}`}
-              className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-(--color-fg-muted)"
-            >
-              {cat.name}
-            </Link>
-            <SharedLayoutBg
-              inset={0}
-              pillClassName="rounded-lg bg-(--color-fg)/[0.05]"
-            >
-              {moveFirstItemsToBottom(cat.components, 3).map((comp) => {
-                const href = `/components/${cat.slug}/${comp.slug}`;
-                const active = pathname === href;
-                return (
-                  <Link
-                    key={comp.slug}
-                    href={href}
-                    className={cn(
-                      "relative block rounded-lg px-3 py-1.5 text-sm transition-colors",
-                      active
-                        ? "text-(--color-fg) font-medium bg-(--color-fg)/[0.06]"
-                        : "text-(--color-fg-muted) hover:text-(--color-fg)",
-                    )}
-                  >
-                    {comp.name}
-                  </Link>
-                );
-              })}
-            </SharedLayoutBg>
-          </div>
-        ))}
-      </nav>
+      <SidebarNav />
     </aside>
   );
 }

--- a/components/motion/bottom-sheet.tsx
+++ b/components/motion/bottom-sheet.tsx
@@ -9,6 +9,7 @@ import {
   type PanInfo,
 } from "motion/react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { EASE_OUT, SPRING_PANEL } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 
@@ -38,11 +39,16 @@ export function BottomSheet({
   dismissThreshold = 120,
 }: BottomSheetProps) {
   const [snap, setSnap] = useState(defaultSnap);
+  const [mounted, setMounted] = useState(false);
   const dragY = useMotionValue(0);
   const dragControls = useDragControls();
   const sheetRef = useRef<HTMLDivElement>(null);
   const reduce = useReducedMotion();
   const heightRef = useRef(0);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (open) setSnap(defaultSnap);
@@ -113,7 +119,12 @@ export function BottomSheet({
       ? { maxHeight: "92vh" }
       : { height: `${snapValue * 100}vh` };
 
-  return (
+  // Portal to <body>: an ancestor with backdrop-filter or transform becomes
+  // the containing block for fixed descendants, which would position the
+  // sheet against that ancestor instead of the viewport.
+  if (!mounted) return null;
+
+  return createPortal(
     <AnimatePresence>
       {open ? (
         <div className="pointer-events-none fixed inset-0 z-50">
@@ -180,6 +191,7 @@ export function BottomSheet({
           </motion.div>
         </div>
       ) : null}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   );
 }

--- a/components/motion/bottom-sheet.tsx
+++ b/components/motion/bottom-sheet.tsx
@@ -48,13 +48,33 @@ export function BottomSheet({
     if (open) setSnap(defaultSnap);
   }, [open, defaultSnap]);
 
-  // Lock background scroll while open.
+  // Lock background scroll while open. overflow:hidden alone is ignored by
+  // iOS Safari — boundary scrolls inside the sheet chain to the page, which
+  // scrolls underneath and ends up somewhere else on close. position:fixed
+  // is the lock that actually holds; restore the scroll position after.
   useEffect(() => {
     if (!open) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
+    const body = document.body;
+    const scrollY = window.scrollY;
+    const prev = {
+      position: body.style.position,
+      top: body.style.top,
+      left: body.style.left,
+      right: body.style.right,
+      overflow: body.style.overflow,
+    };
+    body.style.position = "fixed";
+    body.style.top = `-${scrollY}px`;
+    body.style.left = "0";
+    body.style.right = "0";
+    body.style.overflow = "hidden";
     return () => {
-      document.body.style.overflow = prev;
+      body.style.position = prev.position;
+      body.style.top = prev.top;
+      body.style.left = prev.left;
+      body.style.right = prev.right;
+      body.style.overflow = prev.overflow;
+      window.scrollTo(0, scrollY);
     };
   }, [open]);
 
@@ -155,7 +175,8 @@ export function BottomSheet({
                 </div>
               ) : null}
             </div>
-            <div className="flex-1 overflow-y-auto px-4 pb-6">{children}</div>
+            {/* overscroll-contain stops boundary scrolls from chaining to the page. */}
+            <div className="flex-1 overflow-y-auto overscroll-contain px-4 pb-6">{children}</div>
           </motion.div>
         </div>
       ) : null}


### PR DESCRIPTION
## What

The sidebar is hidden below md with no mobile replacement. Mobile now gets a hamburger in the header (left of the logo, mobile only) that opens the full nav list inside beUI's own BottomSheet at an 0.85 snap. Links close the sheet on tap, route changes close it as a fallback, and the nav list is extracted into SidebarNav shared by the desktop aside and the sheet. Since the header is global, mobile users can reach the component list from the landing page too.

## Library fixes shipped with it

Two real BottomSheet bugs surfaced by dogfooding:

- Boundary scroll bleed: the overflow:hidden body lock is ignored by iOS Safari, so scrolling past the sheet content's end chained to the page underneath, which wandered and landed somewhere else on close. The lock is now position:fixed with the scroll offset preserved and restored, and the sheet's scroller gets overscroll-contain.
- Containing-block trap: the sheet rendered in place, so an ancestor with backdrop-filter or transform became the containing block for its fixed container. Mounted under the site header (which gains backdrop-blur on scroll), the sheet positioned against the 56px header strip and appeared to open from the top. It now portals to document.body with a mounted guard, same pattern as the toast stack.

Both fixes ship to registry consumers of bottom-sheet.

## Verification

bun run check green (typecheck, biome, 19 registry components). Hand tested on mobile: sheet opens from the bottom at any scroll position, boundary scrolls stay inside the sheet, page scroll position survives open/close, links navigate and dismiss.