### PR TITLE
perf: lazy-load previews and make category cards static

### DIFF
--- a/app/components/[category]/page.tsx
+++ b/app/components/[category]/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
 import { findCategory, registry } from "@/lib/registry";
-import { getPreview } from "@/components/previews";
 
 export function generateStaticParams() {
   return registry.map((c) => ({ category: c.slug }));
@@ -78,26 +78,19 @@ export default async function CategoryPage({ params }: { params: Promise<{ categ
       <p className="mt-2 max-w-2xl text-(--color-fg-muted)">{cat.description}</p>
 
       <div className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-        {cat.components.map((comp) => {
-          const Preview = getPreview(cat.slug, comp.slug);
-          return (
-            <Link
-              key={comp.slug}
-              href={`/components/${cat.slug}/${comp.slug}`}
-              className="group flex flex-col overflow-hidden rounded-2xl border border-(--color-border) bg-(--color-bg-elev) transition-colors hover:border-(--color-border-strong)"
-            >
-              <div className="relative flex h-36 items-center justify-center overflow-hidden border-b border-(--color-border) bg-(--color-bg) p-4 mask-b-fade">
-                <div className="pointer-events-none scale-[0.62] [&_*]:!cursor-default">
-                  {Preview ? <Preview /> : null}
-                </div>
-              </div>
-              <div className="px-3.5 py-3">
-                <h3 className="text-sm font-semibold text-(--color-fg)">{comp.name}</h3>
-                <p className="mt-0.5 line-clamp-1 text-xs text-(--color-fg-muted)">{comp.description}</p>
-              </div>
-            </Link>
-          );
-        })}
+        {cat.components.map((comp) => (
+          <Link
+            key={comp.slug}
+            href={`/components/${cat.slug}/${comp.slug}`}
+            className="group flex items-start justify-between gap-3 rounded-2xl border border-(--color-border) bg-(--color-bg-elev) px-4 py-3.5 transition-colors hover:border-(--color-border-strong)"
+          >
+            <div className="min-w-0">
+              <h3 className="text-sm font-semibold text-(--color-fg)">{comp.name}</h3>
+              <p className="mt-1 line-clamp-2 text-xs text-(--color-fg-muted)">{comp.description}</p>
+            </div>
+            <ArrowUpRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-(--color-fg-muted) transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+          </Link>
+        ))}
       </div>
     </div>
   );

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -1,65 +1,99 @@
-import type { ReactNode } from "react";
-import { TiltCardPreview } from "./motion/tilt-card.preview";
-import { MarqueePreview } from "./motion/marquee.preview";
-import { TextAnimationPreview } from "./motion/text-animation.preview";
-import { TextShimmerPreview } from "./motion/text-shimmer.preview";
-import { NumberPreview } from "./motion/number.preview";
-import { AnimatedNumberPreview } from "./motion/animated-number.preview";
-import { NumberTickerPreview } from "./motion/number-ticker.preview";
-import { BottomSheetPreview } from "./motion/bottom-sheet.preview";
-import { TabsPreview } from "./motion/tabs.preview";
-import { SwitchPreview } from "./motion/switch.preview";
-import { CommandPalettePreview } from "./blocks/command-palette.preview";
-import { SharedLayoutBgPreview } from "./motion/shared-layout-bg.preview";
-import { DockPreview } from "./motion/dock.preview";
-import { TooltipPreview } from "./motion/tooltip.preview";
-import { MorphingModalPreview } from "./motion/morphing-modal.preview";
-import { TextRevealPreview } from "./motion/text-reveal.preview";
-import { ButtonBasePreview } from "./motion/button-base.preview";
-import { SwapPreview } from "./blocks/swap.preview";
-import { ButtonStatefulPreview } from "./motion/button-stateful.preview";
-import { ButtonMagneticPreview } from "./motion/button-magnetic.preview";
-import { AnimatedBadgePreview } from "./motion/animated-badge.preview";
-import { AnimatedToastStackPreview } from "./motion/animated-toast-stack.preview";
-import { ExpandableActionBarPreview } from "./blocks/expandable-action-bar.preview";
-import { ActionSwapPreview } from "./motion/action-swap.preview";
-import { ActionSwapBlurPreview } from "./motion/action-swap-blur.preview";
-import { ActionSwapRollPreview } from "./motion/action-swap-roll.preview";
-import { DynamicIslandPreview } from "./blocks/dynamic-island.preview";
-import { ActionSwapCascadePreview } from "./motion/action-swap-cascade.preview";
-import { TextCascadePreview } from "./motion/text-cascade.preview";
+import dynamic from "next/dynamic";
+import type { ComponentType } from "react";
 
-export const previews: Record<string, () => ReactNode> = {
-  "blocks/dynamic-island": DynamicIslandPreview,
-  "blocks/swap": SwapPreview,
-  "blocks/command-palette": CommandPalettePreview,
-  "blocks/expandable-action-bar": ExpandableActionBarPreview,
-  "motion/tilt-card": TiltCardPreview,
-  "motion/marquee": MarqueePreview,
-  "motion/text-animation": TextAnimationPreview,
-  "motion/text-shimmer": TextShimmerPreview,
-  "motion/number": NumberPreview,
-  "motion/animated-number": AnimatedNumberPreview,
-  "motion/number-ticker": NumberTickerPreview,
-  "motion/animated-badge": AnimatedBadgePreview,
-  "motion/animated-toast-stack": AnimatedToastStackPreview,
-  "motion/action-swap": ActionSwapPreview,
-  "motion/action-swap-blur": ActionSwapBlurPreview,
-  "motion/action-swap-roll": ActionSwapRollPreview,
-  "motion/action-swap-cascade": ActionSwapCascadePreview,
-  "motion/bottom-sheet": BottomSheetPreview,
-  "motion/tabs": TabsPreview,
-  "motion/switch": SwitchPreview,
-  "motion/shared-layout-bg": SharedLayoutBgPreview,
-  "motion/dock": DockPreview,
-  "motion/tooltip": TooltipPreview,
-  "motion/morphing-modal": MorphingModalPreview,
-  "motion/text-reveal": TextRevealPreview,
-  "motion/text-cascade": TextCascadePreview,
-  "motion/button": ButtonBasePreview,
-  "motion/button-base": ButtonBasePreview,
-  "motion/button-stateful": ButtonStatefulPreview,
-  "motion/button-magnetic": ButtonMagneticPreview,
+// Every preview is a client component dragging the library + motion with it.
+// Lazy chunks keep a page's JS limited to the previews it actually renders.
+export const previews: Record<string, ComponentType> = {
+  "blocks/dynamic-island": dynamic(() =>
+    import("./blocks/dynamic-island.preview").then((m) => m.DynamicIslandPreview),
+  ),
+  "blocks/swap": dynamic(() =>
+    import("./blocks/swap.preview").then((m) => m.SwapPreview),
+  ),
+  "blocks/command-palette": dynamic(() =>
+    import("./blocks/command-palette.preview").then((m) => m.CommandPalettePreview),
+  ),
+  "blocks/expandable-action-bar": dynamic(() =>
+    import("./blocks/expandable-action-bar.preview").then((m) => m.ExpandableActionBarPreview),
+  ),
+  "motion/tilt-card": dynamic(() =>
+    import("./motion/tilt-card.preview").then((m) => m.TiltCardPreview),
+  ),
+  "motion/marquee": dynamic(() =>
+    import("./motion/marquee.preview").then((m) => m.MarqueePreview),
+  ),
+  "motion/text-animation": dynamic(() =>
+    import("./motion/text-animation.preview").then((m) => m.TextAnimationPreview),
+  ),
+  "motion/text-shimmer": dynamic(() =>
+    import("./motion/text-shimmer.preview").then((m) => m.TextShimmerPreview),
+  ),
+  "motion/number": dynamic(() =>
+    import("./motion/number.preview").then((m) => m.NumberPreview),
+  ),
+  "motion/animated-number": dynamic(() =>
+    import("./motion/animated-number.preview").then((m) => m.AnimatedNumberPreview),
+  ),
+  "motion/number-ticker": dynamic(() =>
+    import("./motion/number-ticker.preview").then((m) => m.NumberTickerPreview),
+  ),
+  "motion/animated-badge": dynamic(() =>
+    import("./motion/animated-badge.preview").then((m) => m.AnimatedBadgePreview),
+  ),
+  "motion/animated-toast-stack": dynamic(() =>
+    import("./motion/animated-toast-stack.preview").then((m) => m.AnimatedToastStackPreview),
+  ),
+  "motion/action-swap": dynamic(() =>
+    import("./motion/action-swap.preview").then((m) => m.ActionSwapPreview),
+  ),
+  "motion/action-swap-blur": dynamic(() =>
+    import("./motion/action-swap-blur.preview").then((m) => m.ActionSwapBlurPreview),
+  ),
+  "motion/action-swap-roll": dynamic(() =>
+    import("./motion/action-swap-roll.preview").then((m) => m.ActionSwapRollPreview),
+  ),
+  "motion/action-swap-cascade": dynamic(() =>
+    import("./motion/action-swap-cascade.preview").then((m) => m.ActionSwapCascadePreview),
+  ),
+  "motion/bottom-sheet": dynamic(() =>
+    import("./motion/bottom-sheet.preview").then((m) => m.BottomSheetPreview),
+  ),
+  "motion/tabs": dynamic(() =>
+    import("./motion/tabs.preview").then((m) => m.TabsPreview),
+  ),
+  "motion/switch": dynamic(() =>
+    import("./motion/switch.preview").then((m) => m.SwitchPreview),
+  ),
+  "motion/shared-layout-bg": dynamic(() =>
+    import("./motion/shared-layout-bg.preview").then((m) => m.SharedLayoutBgPreview),
+  ),
+  "motion/dock": dynamic(() =>
+    import("./motion/dock.preview").then((m) => m.DockPreview),
+  ),
+  "motion/tooltip": dynamic(() =>
+    import("./motion/tooltip.preview").then((m) => m.TooltipPreview),
+  ),
+  "motion/morphing-modal": dynamic(() =>
+    import("./motion/morphing-modal.preview").then((m) => m.MorphingModalPreview),
+  ),
+  "motion/text-reveal": dynamic(() =>
+    import("./motion/text-reveal.preview").then((m) => m.TextRevealPreview),
+  ),
+  "motion/text-cascade": dynamic(() =>
+    import("./motion/text-cascade.preview").then((m) => m.TextCascadePreview),
+  ),
+  "motion/button": dynamic(() =>
+    import("./motion/button-base.preview").then((m) => m.ButtonBasePreview),
+  ),
+  "motion/button-base": dynamic(() =>
+    import("./motion/button-base.preview").then((m) => m.ButtonBasePreview),
+  ),
+  "motion/button-stateful": dynamic(() =>
+    import("./motion/button-stateful.preview").then((m) => m.ButtonStatefulPreview),
+  ),
+  "motion/button-magnetic": dynamic(() =>
+    import("./motion/button-magnetic.preview").then((m) => m.ButtonMagneticPreview),
+  ),
 };
 
 export function getPreview(category: string, slug: string) {


### PR DESCRIPTION
## What

Two cuts to client JS and runtime animation cost.

### Lazy preview chunks
`components/previews/index.tsx` now maps every preview to a `next/dynamic` import instead of static barrel imports. Each demo becomes its own chunk, so a page only ships the previews it actually renders. Previously any page touching the barrel pulled all 30 client previews (and the whole motion library with them). Previews are still SSR'd, so no hydration flash.

### Static category list cards
`/components/{category}` cards no longer mount live previews. Compact text cards instead: name, two-line description, hover arrow (same visual language as landing cards). List pages previously ran ~19 simultaneous animations (marquee loops, ticker intervals, toast timers) even offscreen; now they ship almost no library JS at all.

## Verification
`bun run check` green (typecheck, lint, 19 registry components validated). `check:registry` reads the filesystem, not the barrel, so registry publishing is unaffected.