### PR TITLE
feat: add expandable tabs block

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-use-measure": "^2.1.7",
         "shiki": "^4.2.0",
         "tailwind-merge": "^3.6.0",
       },
@@ -302,6 +303,8 @@
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
+
+    "react-use-measure": ["react-use-measure@2.1.7", "", { "peerDependencies": { "react": ">=16.13", "react-dom": ">=16.13" }, "optionalPeers": ["react-dom"] }, "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 

--- a/components/motion/expandable-tabs.tsx
+++ b/components/motion/expandable-tabs.tsx
@@ -7,19 +7,20 @@ import {
   type Variants,
 } from "motion/react";
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
 } from "react";
-import useMeasure from "react-use-measure";
-import { EASE_OUT, SPRING_LAYOUT, SPRING_PANEL } from "@/lib/ease";
+import { EASE_OUT } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 
 export type ExpandableTabsItem = {
   id: string;
-  label: ReactNode;
+  /** String label — shown inside the active tab and used as the button's accessible name. */
+  label: string;
   icon: ReactNode;
   /** Panel shown above the bar when this tab is active. */
   content: ReactNode;
@@ -46,12 +47,140 @@ export interface ExpandableTabsProps {
   classNames?: ExpandableTabsClassNames;
 }
 
-// Content slides in from the side it was opened toward; exits faster.
+type Size = { width: number; height: number };
+
+// DynamicIsland-style real width/height motion, tuned tighter here so the tab
+// bar feels controlled instead of elastic.
+const SHELL_SPRING = { type: "spring", duration: 0.58, bounce: 0.06 } as const;
+
+// Position-only tab layout motion keeps switching loose without stretching
+// icons or letting the label linger.
+const TAB_CHANGE_SPRING = {
+  type: "spring",
+  duration: 0.46,
+  bounce: 0.04,
+} as const;
+const LABEL_OPEN = { type: "spring", duration: 0.38, bounce: 0.03 } as const;
+const LABEL_CLOSE = { duration: 0.16, ease: EASE_OUT } as const;
+
+// Fixed bar height keeps the content panel's bottom reserve static so the open
+// height is right on the first frame. p-2 (16) + h-9 button (36).
+const BAR_H = 52;
+const TAB_W = 32;
+const BAR_X = 16;
+const BAR_GAP = 4;
+const ROOT_BORDER = 2;
+const ICON_W = 16;
+const ACTIVE_LEFT_PAD = 10;
+const ACTIVE_RIGHT_PAD = 16;
+const LABEL_GAP = 7;
+const PANEL_DOCK_GAP = 4;
+
+// Content is clipped above the dock so rows never pass through the icon bar.
+// It enters from slightly above instead of from the dock line.
 const CONTENT_VARIANTS: Variants = {
-  enter: (dir: number) => ({ x: dir * 20, opacity: 0, filter: "blur(4px)" }),
-  center: { x: 0, opacity: 1, filter: "blur(0px)" },
-  exit: (dir: number) => ({ x: dir * -20, opacity: 0, filter: "blur(4px)" }),
+  enter: { y: -8, scale: 0.98, opacity: 0, filter: "blur(4px)" },
+  center: { y: 0, scale: 1, opacity: 1, filter: "blur(0px)" },
+  exit: {
+    y: -6,
+    scale: 0.98,
+    opacity: 0,
+    transition: { duration: 0.08, ease: EASE_OUT },
+  },
 };
+
+const CONTENT_SPRING = { type: "spring", duration: 0.46, bounce: 0.08 } as const;
+
+function sameSize(a: Size | null | undefined, b: Size | null | undefined) {
+  return a?.width === b?.width && a?.height === b?.height;
+}
+
+function sameWidths(a: Record<string, number>, b: Record<string, number>) {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+
+  return aKeys.every((key) => a[key] === b[key]);
+}
+
+function useContentSize() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState<Size | null>(null);
+
+  const measure = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    const next = { width: el.offsetWidth, height: el.offsetHeight };
+    setSize((current) => (sameSize(current, next) ? current : next));
+  }, []);
+
+  useLayoutEffect(() => {
+    measure();
+  }, [measure]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [measure]);
+
+  return [ref, size] as const;
+}
+
+function useLabelWidths(items: ExpandableTabsItem[]) {
+  const refs = useRef<Record<string, HTMLSpanElement | null>>({});
+  const [widths, setWidths] = useState<Record<string, number>>({});
+
+  const setLabelMeasureRef = useCallback(
+    (id: string) => (node: HTMLSpanElement | null) => {
+      refs.current[id] = node;
+    },
+    [],
+  );
+
+  const measure = useCallback(() => {
+    const next: Record<string, number> = {};
+
+    for (const item of items) {
+      const node = refs.current[item.id];
+
+      if (node) {
+        next[item.id] = Math.ceil(node.offsetWidth);
+      }
+    }
+
+    setWidths((current) => (sameWidths(current, next) ? current : next));
+  }, [items]);
+
+  useLayoutEffect(() => {
+    measure();
+  }, [measure]);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(measure);
+
+    for (const item of items) {
+      const node = refs.current[item.id];
+
+      if (node) {
+        observer.observe(node);
+      }
+    }
+
+    return () => observer.disconnect();
+  }, [items, measure]);
+
+  return { setLabelMeasureRef, widths };
+}
 
 export function ExpandableTabs({
   items,
@@ -63,31 +192,26 @@ export function ExpandableTabs({
 }: ExpandableTabsProps) {
   const reduce = useReducedMotion();
   const rootRef = useRef<HTMLDivElement>(null);
+  const [sizerRef, size] = useContentSize();
+  const { setLabelMeasureRef, widths: labelWidths } = useLabelWidths(items);
 
   const controlled = value !== undefined;
   const [internal, setInternal] = useState<string | null>(defaultValue);
   const activeId = controlled ? value : internal;
   const active = items.find((item) => item.id === activeId) ?? null;
+  const visualActiveId = active?.id ?? null;
 
-  const setActive = (next: string | null) => {
-    if (!controlled) setInternal(next);
-    onValueChange?.(next);
-  };
-
-  // Direction the content slides — which way the index moved. Holds the last
-  // open index so reopening keeps a sensible direction.
-  const prevIndex = useRef(0);
-  const activeIndex = active
-    ? items.findIndex((item) => item.id === active.id)
-    : prevIndex.current;
-  const direction = activeIndex >= prevIndex.current ? 1 : -1;
-  useEffect(() => {
-    if (active) prevIndex.current = activeIndex;
-  }, [active, activeIndex]);
+  const setActive = useCallback(
+    (next: string | null) => {
+      if (!controlled) setInternal(next);
+      onValueChange?.(next);
+    },
+    [controlled, onValueChange],
+  );
 
   // Outside click / Escape closes — it behaves like an open menu.
   useEffect(() => {
-    if (!active) return;
+    if (!visualActiveId) return;
     const onPointer = (e: PointerEvent) => {
       if (!rootRef.current?.contains(e.target as Node)) setActive(null);
     };
@@ -100,143 +224,209 @@ export function ExpandableTabs({
       document.removeEventListener("pointerdown", onPointer);
       document.removeEventListener("keydown", onKey);
     };
-  });
+  }, [setActive, visualActiveId]);
 
-  // Measures the natural size of the content; the shell springs to it. A
-  // synchronous mount measure seeds an explicit size before the first paint, so
-  // a fast first click (before react-use-measure's async observer fires) still
-  // animates instead of snapping open.
-  const [measureRef, bounds] = useMeasure();
-  const seedRef = useRef<HTMLDivElement | null>(null);
-  const [seed, setSeed] = useState<{ width: number; height: number } | null>(null);
-  useLayoutEffect(() => {
-    if (seedRef.current) {
-      setSeed({ width: seedRef.current.offsetWidth, height: seedRef.current.offsetHeight });
-    }
-  }, []);
-  const setSizeRef = (el: HTMLDivElement | null) => {
-    measureRef(el);
-    seedRef.current = el;
+  const closedSize = {
+    width:
+      items.length * TAB_W +
+      Math.max(0, items.length - 1) * BAR_GAP +
+      BAR_X +
+      ROOT_BORDER,
+    height: BAR_H + ROOT_BORDER,
   };
-  const shellWidth = bounds.width || seed?.width || 0;
-  const shellHeight = bounds.height || seed?.height || 0;
+  const openSize = size
+    ? {
+        width: Math.max(size.width + ROOT_BORDER, closedSize.width),
+        height: Math.max(size.height + ROOT_BORDER, closedSize.height),
+      }
+    : closedSize;
+  const targetSize = active ? openSize : closedSize;
+
+  const getActiveTabWidth = useCallback(
+    (item: ExpandableTabsItem) =>
+      Math.max(
+        TAB_W,
+        ACTIVE_LEFT_PAD +
+          ICON_W +
+          LABEL_GAP +
+          (labelWidths[item.id] ?? 0) +
+          ACTIVE_RIGHT_PAD,
+      ),
+    [labelWidths],
+  );
 
   return (
     <>
-      {/* Bottom-anchored: place this in a bottom-aligned parent so the card
-          unfurls upward. The shell springs to the measured natural size of the
-          content, so it hugs the bar when closed and grows to the panel when
-          open — no dead space, no width snap. `justify-end` pins the content to
-          the bottom so the bar stays put while the shell grows up. */}
       <motion.div
         ref={rootRef}
         initial={false}
-        animate={shellWidth ? { width: shellWidth, height: shellHeight } : undefined}
-        transition={reduce ? { duration: 0 } : SPRING_PANEL}
+        animate={
+          targetSize
+            ? { width: targetSize.width, height: targetSize.height }
+            : undefined
+        }
+        transition={reduce ? { duration: 0 } : SHELL_SPRING}
+        style={{ transformOrigin: "bottom center" }}
         className={cn(
-          "relative flex flex-col justify-end overflow-hidden rounded-3xl border border-border bg-card",
+          "relative overflow-hidden rounded-[26px] border border-border bg-card",
           className,
           classNames?.root,
         )}
       >
-        <div ref={setSizeRef} className="flex w-max flex-col p-2">
-          <AnimatePresence custom={direction} mode="popLayout" initial={false}>
+        <div
+          ref={sizerRef}
+          aria-hidden
+          className={cn(
+            "pointer-events-none invisible absolute left-0 top-0 grid w-max px-2 pt-2",
+            classNames?.panel,
+          )}
+          style={{ paddingBottom: BAR_H + PANEL_DOCK_GAP }}
+        >
+          {items.map((item) => (
+            <div key={item.id} className="col-start-1 row-start-1 w-max">
+              {item.content}
+            </div>
+          ))}
+        </div>
+
+        <div
+          className={cn(
+            "absolute left-0 right-0 top-0 z-10 overflow-hidden px-2 pt-2",
+            classNames?.panel,
+          )}
+          style={{ bottom: BAR_H + PANEL_DOCK_GAP }}
+        >
+          <AnimatePresence mode="popLayout" initial={false}>
             {active ? (
               <motion.div
                 key={active.id}
-                custom={direction}
                 variants={reduce ? undefined : CONTENT_VARIANTS}
                 initial={reduce ? { opacity: 0 } : "enter"}
                 animate={reduce ? { opacity: 1 } : "center"}
                 exit={reduce ? { opacity: 0 } : "exit"}
-                transition={reduce ? { duration: 0 } : { duration: 0.26, ease: EASE_OUT }}
-                className={cn("px-1 pb-2", classNames?.panel)}
+                transition={
+                  reduce ? { duration: 0.15, ease: EASE_OUT } : CONTENT_SPRING
+                }
+                className="w-max"
+                style={{
+                  transformOrigin: "top center",
+                  willChange: "transform, opacity, filter",
+                }}
               >
                 {active.content}
               </motion.div>
             ) : null}
           </AnimatePresence>
+        </div>
 
-          {/* Tab bar — active tab expands to a labelled pill, the rest stay icons. */}
-          <div
-            role="tablist"
-            aria-orientation="horizontal"
-            className={cn("flex items-center gap-1", classNames?.bar)}
-          >
-            {items.map((item) => {
-              const isActive = item.id === activeId;
-              return (
-                <button
-                  key={item.id}
-                  type="button"
-                  role="tab"
-                  aria-selected={isActive}
-                  onClick={() => setActive(isActive ? null : item.id)}
+        <div
+          role="tablist"
+          aria-label="Navigation tabs"
+          aria-orientation="horizontal"
+          className={cn(
+            "absolute bottom-0 left-0 z-20 flex w-full items-center justify-between gap-1 p-2",
+            classNames?.bar,
+          )}
+          style={{ height: BAR_H }}
+        >
+          {items.map((item) => {
+            const isActive = item.id === visualActiveId;
+            const activeTabWidth = getActiveTabWidth(item);
+            const labelWidth = labelWidths[item.id] ?? 0;
+
+            return (
+              <motion.button
+                key={item.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                aria-label={item.label}
+                onClick={() => setActive(isActive ? null : item.id)}
+                layout={reduce ? false : "position"}
+                animate={{
+                  width: active && isActive ? activeTabWidth : TAB_W,
+                }}
+                transition={reduce ? { duration: 0 } : TAB_CHANGE_SPRING}
+                className={cn(
+                  "relative isolate flex h-9 min-w-8 shrink-0 items-center justify-center overflow-hidden rounded-[18px] px-2 text-sm font-medium outline-none",
+                  "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                  active && isActive && "min-w-0 justify-start pl-2.5 pr-4",
+                  isActive
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                  classNames?.tab,
+                  isActive && classNames?.activeTab,
+                )}
+              >
+                {isActive ? (
+                  <span
+                    className={cn(
+                      "absolute inset-0 -z-10 rounded-[18px] bg-foreground/10",
+                      classNames?.pill,
+                    )}
+                  />
+                ) : null}
+                <span
                   className={cn(
-                    "relative isolate flex h-10 shrink-0 items-center rounded-2xl px-3 text-sm font-medium outline-none",
-                    "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                    isActive ? "text-foreground" : "text-muted-foreground hover:text-foreground",
-                    classNames?.tab,
-                    isActive && classNames?.activeTab,
+                    "grid shrink-0 place-items-center",
+                    classNames?.icon,
                   )}
                 >
-                  {/* No layoutId — the pill appears at the clicked tab and grows
-                      in place with the button (no glide from the previous tab). */}
-                  <AnimatePresence initial={false}>
-                    {isActive ? (
-                      <motion.span
-                        key="pill"
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                        transition={reduce ? { duration: 0 } : { duration: 0.15, ease: EASE_OUT }}
-                        className={cn(
-                          "absolute inset-0 -z-10 rounded-2xl bg-foreground/10",
-                          classNames?.pill,
-                        )}
-                      />
-                    ) : null}
-                  </AnimatePresence>
-                  <span className={cn("grid shrink-0 place-items-center", classNames?.icon)}>
-                    {item.icon}
-                  </span>
-                  {/* Width animates so the button — and the pill filling it — grow
-                      smoothly as the label appears, instead of snapping. */}
-                  <motion.span
-                    aria-hidden={!isActive}
-                    initial={false}
-                    animate={
-                      reduce
-                        ? { width: isActive ? "auto" : 0, opacity: isActive ? 1 : 0, marginLeft: isActive ? 8 : 0 }
-                        : {
-                            width: isActive ? "auto" : 0,
-                            opacity: isActive ? 1 : 0,
-                            marginLeft: isActive ? 8 : 0,
-                            filter: isActive ? "blur(0px)" : "blur(3px)",
-                          }
-                    }
-                    // Expand on a spring; collapse fast so the previous tab
-                    // doesn't linger ("left behind") as a new one opens.
-                    transition={
-                      reduce
-                        ? { duration: 0 }
-                        : isActive
-                          ? SPRING_LAYOUT
-                          : { duration: 0.13, ease: EASE_OUT }
-                    }
-                    className={cn(
-                      "inline-block overflow-hidden whitespace-nowrap",
-                      classNames?.label,
-                    )}
-                  >
-                    {item.label}
-                  </motion.span>
-                </button>
-              );
-            })}
-          </div>
+                  {item.icon}
+                </span>
+                <motion.span
+                  aria-hidden
+                  initial={false}
+                  animate={
+                    reduce
+                      ? {
+                          width: isActive ? labelWidth : 0,
+                          opacity: isActive ? 1 : 0,
+                          marginLeft: isActive ? LABEL_GAP : 0,
+                        }
+                      : {
+                          width: isActive ? labelWidth : 0,
+                          opacity: isActive ? 1 : 0,
+                          marginLeft: isActive ? LABEL_GAP : 0,
+                          filter: isActive ? "blur(0px)" : "blur(3px)",
+                        }
+                  }
+                  transition={
+                    reduce
+                      ? { duration: 0 }
+                      : isActive
+                        ? LABEL_OPEN
+                        : LABEL_CLOSE
+                  }
+                  className={cn(
+                    "inline-block overflow-hidden whitespace-nowrap",
+                    classNames?.label,
+                  )}
+                >
+                  {item.label}
+                </motion.span>
+              </motion.button>
+            );
+          })}
         </div>
       </motion.div>
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed left-0 top-0 -z-10 flex opacity-0"
+      >
+        {items.map((item) => (
+          <span
+            className={cn(
+              "whitespace-nowrap text-sm font-medium leading-none",
+              classNames?.label,
+            )}
+            key={item.id}
+            ref={setLabelMeasureRef(item.id)}
+          >
+            {item.label}
+          </span>
+        ))}
+      </div>
     </>
   );
 }

--- a/components/motion/expandable-tabs.tsx
+++ b/components/motion/expandable-tabs.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import {
+  AnimatePresence,
+  motion,
+  useReducedMotion,
+  type Variants,
+} from "motion/react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import useMeasure from "react-use-measure";
+import { EASE_OUT, SPRING_LAYOUT, SPRING_PANEL } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+export type ExpandableTabsItem = {
+  id: string;
+  label: ReactNode;
+  icon: ReactNode;
+  /** Panel shown above the bar when this tab is active. */
+  content: ReactNode;
+};
+
+export type ExpandableTabsClassNames = {
+  root?: string;
+  panel?: string;
+  bar?: string;
+  tab?: string;
+  activeTab?: string;
+  icon?: string;
+  label?: string;
+  pill?: string;
+};
+
+export interface ExpandableTabsProps {
+  items: ExpandableTabsItem[];
+  /** Active tab id, or null/undefined for the closed (bar-only) state. */
+  value?: string | null;
+  defaultValue?: string | null;
+  onValueChange?: (id: string | null) => void;
+  className?: string;
+  classNames?: ExpandableTabsClassNames;
+}
+
+// Content slides in from the side it was opened toward; exits faster.
+const CONTENT_VARIANTS: Variants = {
+  enter: (dir: number) => ({ x: dir * 20, opacity: 0, filter: "blur(4px)" }),
+  center: { x: 0, opacity: 1, filter: "blur(0px)" },
+  exit: (dir: number) => ({ x: dir * -20, opacity: 0, filter: "blur(4px)" }),
+};
+
+export function ExpandableTabs({
+  items,
+  value,
+  defaultValue = null,
+  onValueChange,
+  className,
+  classNames,
+}: ExpandableTabsProps) {
+  const reduce = useReducedMotion();
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const controlled = value !== undefined;
+  const [internal, setInternal] = useState<string | null>(defaultValue);
+  const activeId = controlled ? value : internal;
+  const active = items.find((item) => item.id === activeId) ?? null;
+
+  const setActive = (next: string | null) => {
+    if (!controlled) setInternal(next);
+    onValueChange?.(next);
+  };
+
+  // Direction the content slides — which way the index moved. Holds the last
+  // open index so reopening keeps a sensible direction.
+  const prevIndex = useRef(0);
+  const activeIndex = active
+    ? items.findIndex((item) => item.id === active.id)
+    : prevIndex.current;
+  const direction = activeIndex >= prevIndex.current ? 1 : -1;
+  useEffect(() => {
+    if (active) prevIndex.current = activeIndex;
+  }, [active, activeIndex]);
+
+  // Outside click / Escape closes — it behaves like an open menu.
+  useEffect(() => {
+    if (!active) return;
+    const onPointer = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setActive(null);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setActive(null);
+    };
+    document.addEventListener("pointerdown", onPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  });
+
+  // Measures the natural size of the content; the shell springs to it. A
+  // synchronous mount measure seeds an explicit size before the first paint, so
+  // a fast first click (before react-use-measure's async observer fires) still
+  // animates instead of snapping open.
+  const [measureRef, bounds] = useMeasure();
+  const seedRef = useRef<HTMLDivElement | null>(null);
+  const [seed, setSeed] = useState<{ width: number; height: number } | null>(null);
+  useLayoutEffect(() => {
+    if (seedRef.current) {
+      setSeed({ width: seedRef.current.offsetWidth, height: seedRef.current.offsetHeight });
+    }
+  }, []);
+  const setSizeRef = (el: HTMLDivElement | null) => {
+    measureRef(el);
+    seedRef.current = el;
+  };
+  const shellWidth = bounds.width || seed?.width || 0;
+  const shellHeight = bounds.height || seed?.height || 0;
+
+  return (
+    <>
+      {/* Bottom-anchored: place this in a bottom-aligned parent so the card
+          unfurls upward. The shell springs to the measured natural size of the
+          content, so it hugs the bar when closed and grows to the panel when
+          open — no dead space, no width snap. `justify-end` pins the content to
+          the bottom so the bar stays put while the shell grows up. */}
+      <motion.div
+        ref={rootRef}
+        initial={false}
+        animate={shellWidth ? { width: shellWidth, height: shellHeight } : undefined}
+        transition={reduce ? { duration: 0 } : SPRING_PANEL}
+        className={cn(
+          "relative flex flex-col justify-end overflow-hidden rounded-3xl border border-border bg-card",
+          className,
+          classNames?.root,
+        )}
+      >
+        <div ref={setSizeRef} className="flex w-max flex-col p-2">
+          <AnimatePresence custom={direction} mode="popLayout" initial={false}>
+            {active ? (
+              <motion.div
+                key={active.id}
+                custom={direction}
+                variants={reduce ? undefined : CONTENT_VARIANTS}
+                initial={reduce ? { opacity: 0 } : "enter"}
+                animate={reduce ? { opacity: 1 } : "center"}
+                exit={reduce ? { opacity: 0 } : "exit"}
+                transition={reduce ? { duration: 0 } : { duration: 0.26, ease: EASE_OUT }}
+                className={cn("px-1 pb-2", classNames?.panel)}
+              >
+                {active.content}
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+
+          {/* Tab bar — active tab expands to a labelled pill, the rest stay icons. */}
+          <div
+            role="tablist"
+            aria-orientation="horizontal"
+            className={cn("flex items-center gap-1", classNames?.bar)}
+          >
+            {items.map((item) => {
+              const isActive = item.id === activeId;
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setActive(isActive ? null : item.id)}
+                  className={cn(
+                    "relative isolate flex h-10 shrink-0 items-center rounded-2xl px-3 text-sm font-medium outline-none",
+                    "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                    isActive ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+                    classNames?.tab,
+                    isActive && classNames?.activeTab,
+                  )}
+                >
+                  {/* No layoutId — the pill appears at the clicked tab and grows
+                      in place with the button (no glide from the previous tab). */}
+                  <AnimatePresence initial={false}>
+                    {isActive ? (
+                      <motion.span
+                        key="pill"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={reduce ? { duration: 0 } : { duration: 0.15, ease: EASE_OUT }}
+                        className={cn(
+                          "absolute inset-0 -z-10 rounded-2xl bg-foreground/10",
+                          classNames?.pill,
+                        )}
+                      />
+                    ) : null}
+                  </AnimatePresence>
+                  <span className={cn("grid shrink-0 place-items-center", classNames?.icon)}>
+                    {item.icon}
+                  </span>
+                  {/* Width animates so the button — and the pill filling it — grow
+                      smoothly as the label appears, instead of snapping. */}
+                  <motion.span
+                    aria-hidden={!isActive}
+                    initial={false}
+                    animate={
+                      reduce
+                        ? { width: isActive ? "auto" : 0, opacity: isActive ? 1 : 0, marginLeft: isActive ? 8 : 0 }
+                        : {
+                            width: isActive ? "auto" : 0,
+                            opacity: isActive ? 1 : 0,
+                            marginLeft: isActive ? 8 : 0,
+                            filter: isActive ? "blur(0px)" : "blur(3px)",
+                          }
+                    }
+                    // Expand on a spring; collapse fast so the previous tab
+                    // doesn't linger ("left behind") as a new one opens.
+                    transition={
+                      reduce
+                        ? { duration: 0 }
+                        : isActive
+                          ? SPRING_LAYOUT
+                          : { duration: 0.13, ease: EASE_OUT }
+                    }
+                    className={cn(
+                      "inline-block overflow-hidden whitespace-nowrap",
+                      classNames?.label,
+                    )}
+                  >
+                    {item.label}
+                  </motion.span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </motion.div>
+    </>
+  );
+}

--- a/components/previews/blocks/expandable-tabs.preview.tsx
+++ b/components/previews/blocks/expandable-tabs.preview.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import {
+  ArrowUpCircle,
+  Bell,
+  BookOpen,
+  ChevronRight,
+  FolderKanban,
+  Home,
+  LogOut,
+  Settings2,
+  Shield,
+  User,
+  type LucideIcon,
+} from "lucide-react";
+import { ExpandableTabs } from "@/components/motion/expandable-tabs";
+
+function Row({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted"
+    >
+      <Icon className="h-4 w-4 text-muted-foreground" />
+      <span className="flex-1">{label}</span>
+      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+    </button>
+  );
+}
+
+function Menu({ rows }: { rows: { icon: LucideIcon; label: string }[] }) {
+  return (
+    <div className="flex w-56 flex-col gap-0.5">
+      {rows.map((r) => (
+        <Row key={r.label} icon={r.icon} label={r.label} />
+      ))}
+    </div>
+  );
+}
+
+export function ExpandableTabsPreview() {
+  return (
+    <div className="flex min-h-88 w-full items-end justify-center">
+      <ExpandableTabs
+        items={[
+        {
+          id: "dashboard",
+          label: "Dashboard",
+          icon: <Home className="h-4 w-4" />,
+          content: (
+            <Menu
+              rows={[
+                { icon: User, label: "profile" },
+                { icon: ArrowUpCircle, label: "upgrade" },
+                { icon: FolderKanban, label: "projects" },
+                { icon: BookOpen, label: "documentation" },
+                { icon: LogOut, label: "logout" },
+              ]}
+            />
+          ),
+        },
+        {
+          id: "alerts",
+          label: "Alerts",
+          icon: <Bell className="h-4 w-4" />,
+          content: (
+            <Menu
+              rows={[
+                { icon: Bell, label: "mentions" },
+                { icon: Bell, label: "comments" },
+              ]}
+            />
+          ),
+        },
+        {
+          id: "settings",
+          label: "Settings",
+          icon: <Settings2 className="h-4 w-4" />,
+          content: (
+            <Menu
+              rows={[
+                { icon: Settings2, label: "general" },
+                { icon: User, label: "account" },
+                { icon: Shield, label: "privacy" },
+              ]}
+            />
+          ),
+        },
+        {
+          id: "docs",
+          label: "Docs",
+          icon: <BookOpen className="h-4 w-4" />,
+          content: (
+            <Menu
+              rows={[
+                { icon: BookOpen, label: "getting started" },
+                { icon: BookOpen, label: "api reference" },
+                { icon: FolderKanban, label: "examples" },
+                { icon: ArrowUpCircle, label: "changelog" },
+              ]}
+            />
+          ),
+        },
+        {
+          id: "security",
+          label: "Security",
+          icon: <Shield className="h-4 w-4" />,
+          content: (
+            <Menu
+              rows={[
+                { icon: Shield, label: "two-factor auth" },
+                { icon: User, label: "sessions" },
+              ]}
+            />
+          ),
+        },
+        ]}
+      />
+    </div>
+  );
+}

--- a/components/previews/blocks/expandable-tabs.preview.tsx
+++ b/components/previews/blocks/expandable-tabs.preview.tsx
@@ -30,7 +30,7 @@ function Row({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
 
 function Menu({ rows }: { rows: { icon: LucideIcon; label: string }[] }) {
   return (
-    <div className="flex w-56 flex-col gap-0.5">
+    <div className="flex w-[17.125rem] flex-col gap-0.5">
       {rows.map((r) => (
         <Row key={r.label} icon={r.icon} label={r.label} />
       ))}

--- a/components/previews/blocks/expandable-tabs.preview.tsx
+++ b/components/previews/blocks/expandable-tabs.preview.tsx
@@ -1,16 +1,29 @@
 "use client";
 
 import {
-  ArrowUpCircle,
-  Bell,
-  BookOpen,
+  BadgeCheck,
+  Brush,
+  CalendarClock,
+  ChartSpline,
   ChevronRight,
-  FolderKanban,
-  Home,
-  LogOut,
-  Settings2,
-  Shield,
-  User,
+  ClipboardCheck,
+  CloudUpload,
+  FileText,
+  Gauge,
+  GitBranch,
+  Images,
+  Inbox,
+  MessageCircle,
+  Megaphone,
+  PackageOpen,
+  RefreshCw,
+  Rocket,
+  Siren,
+  SwatchBook,
+  UploadCloud,
+  Users,
+  Webhook,
+  Workflow,
   type LucideIcon,
 } from "lucide-react";
 import { ExpandableTabs } from "@/components/motion/expandable-tabs";
@@ -43,77 +56,79 @@ export function ExpandableTabsPreview() {
     <div className="flex min-h-88 w-full items-end justify-center">
       <ExpandableTabs
         items={[
-        {
-          id: "dashboard",
-          label: "Dashboard",
-          icon: <Home className="h-4 w-4" />,
-          content: (
-            <Menu
-              rows={[
-                { icon: User, label: "profile" },
-                { icon: ArrowUpCircle, label: "upgrade" },
-                { icon: FolderKanban, label: "projects" },
-                { icon: BookOpen, label: "documentation" },
-                { icon: LogOut, label: "logout" },
-              ]}
-            />
-          ),
-        },
-        {
-          id: "alerts",
-          label: "Alerts",
-          icon: <Bell className="h-4 w-4" />,
-          content: (
-            <Menu
-              rows={[
-                { icon: Bell, label: "mentions" },
-                { icon: Bell, label: "comments" },
-              ]}
-            />
-          ),
-        },
-        {
-          id: "settings",
-          label: "Settings",
-          icon: <Settings2 className="h-4 w-4" />,
-          content: (
-            <Menu
-              rows={[
-                { icon: Settings2, label: "general" },
-                { icon: User, label: "account" },
-                { icon: Shield, label: "privacy" },
-              ]}
-            />
-          ),
-        },
-        {
-          id: "docs",
-          label: "Docs",
-          icon: <BookOpen className="h-4 w-4" />,
-          content: (
-            <Menu
-              rows={[
-                { icon: BookOpen, label: "getting started" },
-                { icon: BookOpen, label: "api reference" },
-                { icon: FolderKanban, label: "examples" },
-                { icon: ArrowUpCircle, label: "changelog" },
-              ]}
-            />
-          ),
-        },
-        {
-          id: "security",
-          label: "Security",
-          icon: <Shield className="h-4 w-4" />,
-          content: (
-            <Menu
-              rows={[
-                { icon: Shield, label: "two-factor auth" },
-                { icon: User, label: "sessions" },
-              ]}
-            />
-          ),
-        },
+          {
+            id: "launch",
+            label: "Launch",
+            icon: <Rocket className="h-4 w-4" />,
+            content: (
+              <Menu
+                rows={[
+                  { icon: FileText, label: "Release Brief" },
+                  { icon: ClipboardCheck, label: "Launch Checklist" },
+                  { icon: Megaphone, label: "Campaign Notes" },
+                  { icon: CalendarClock, label: "Rollout Calendar" },
+                  { icon: CloudUpload, label: "Ship Build" },
+                ]}
+              />
+            ),
+          },
+          {
+            id: "inbox",
+            label: "Inbox",
+            icon: <Inbox className="h-4 w-4" />,
+            content: (
+              <Menu
+                rows={[
+                  { icon: MessageCircle, label: "Client Feedback" },
+                  { icon: Users, label: "Team Requests" },
+                  { icon: BadgeCheck, label: "Approval Notes" },
+                ]}
+              />
+            ),
+          },
+          {
+            id: "flows",
+            label: "Flows",
+            icon: <Workflow className="h-4 w-4" />,
+            content: (
+              <Menu
+                rows={[
+                  { icon: GitBranch, label: "Trigger Map" },
+                  { icon: Webhook, label: "Webhook Runs" },
+                  { icon: RefreshCw, label: "Retry Queue" },
+                ]}
+              />
+            ),
+          },
+          {
+            id: "assets",
+            label: "Assets",
+            icon: <PackageOpen className="h-4 w-4" />,
+            content: (
+              <Menu
+                rows={[
+                  { icon: SwatchBook, label: "Brand Kit" },
+                  { icon: Images, label: "Mockup Library" },
+                  { icon: Brush, label: "Design Tokens" },
+                  { icon: UploadCloud, label: "Export Queue" },
+                ]}
+              />
+            ),
+          },
+          {
+            id: "status",
+            label: "Status",
+            icon: <ChartSpline className="h-4 w-4" />,
+            content: (
+              <Menu
+                rows={[
+                  { icon: Gauge, label: "Activation" },
+                  { icon: ChartSpline, label: "Conversion" },
+                  { icon: Siren, label: "Incidents" },
+                ]}
+              />
+            ),
+          },
         ]}
       />
     </div>

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -16,6 +16,9 @@ export const previews: Record<string, ComponentType> = {
   "blocks/expandable-action-bar": dynamic(() =>
     import("./blocks/expandable-action-bar.preview").then((m) => m.ExpandableActionBarPreview),
   ),
+  "blocks/expandable-tabs": dynamic(() =>
+    import("./blocks/expandable-tabs.preview").then((m) => m.ExpandableTabsPreview),
+  ),
   "motion/tilt-card": dynamic(() =>
     import("./motion/tilt-card.preview").then((m) => m.TiltCardPreview),
   ),

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -275,6 +275,12 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/expandable-action-bar.tsx",
       },
       {
+        slug: "expandable-tabs",
+        name: "Expandable Tabs",
+        description: "Icon tab bar where the active tab expands to a labelled pill, with a panel above that morphs height and slides content direction-aware on switch.",
+        file: "components/motion/expandable-tabs.tsx",
+      },
+      {
         slug: "otp-input",
         name: "OTP Input",
         description: "One-time-code input with a gliding focus ring, digits that roll in per slot, error shake and a success check draw.",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-use-measure": "^2.1.7",
     "shiki": "^4.2.0",
     "tailwind-merge": "^3.6.0"
   },


### PR DESCRIPTION
## Summary
- add the expandable tabs block and registry preview
- polish the expanded dock, active pill, close behavior, and panel clipping animations
- refresh the preview with a distinct launch/workflow scenario

## Verification
- /Users/starc/.bun/bin/bun run typecheck
- /Users/starc/.bun/bin/bun run lint
- /Users/starc/.bun/bin/bun run check:registry
- browser smoke checks for tab labels, dock anchoring, and panel clipping