### PR TITLE
feat: add bouncy accordion block

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -2,9 +2,19 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
-import { findCategory, findComponent, registry, type ComponentExample } from "@/lib/registry";
+import {
+  findCategory,
+  findComponent,
+  registry,
+  type ComponentExample,
+} from "@/lib/registry";
 import { CodeBlock } from "@/components/app/code-block";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/motion/tabs";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/motion/tabs";
 import { getPreview, previews } from "@/components/previews";
 import { readSourceFile } from "@/lib/source-files";
 
@@ -26,9 +36,16 @@ export async function generateMetadata({
   const cat = findCategory(category);
   const comp = findComponent(category, slug);
   if (!cat || !comp) return {};
-  const installSlugs = comp.examples?.flatMap((example) => example.installSlug ? [example.installSlug] : []) ?? [];
-  const registryItem = installSlugs[0] ? `/r/${installSlugs[0]}.json` : `/r/${comp.slug}.json`;
-  const directoryItem = installSlugs[0] ? `/${installSlugs[0]}.json` : `/${comp.slug}.json`;
+  const installSlugs =
+    comp.examples?.flatMap((example) =>
+      example.installSlug ? [example.installSlug] : [],
+    ) ?? [];
+  const registryItem = installSlugs[0]
+    ? `/r/${installSlugs[0]}.json`
+    : `/r/${comp.slug}.json`;
+  const directoryItem = installSlugs[0]
+    ? `/${installSlugs[0]}.json`
+    : `/${comp.slug}.json`;
 
   const title = `${comp.name} · ${cat.name} component · beUI v2`;
   const pageUrl = `/components/${cat.slug}/${comp.slug}`;
@@ -73,7 +90,8 @@ export async function generateMetadata({
     alternates: {
       canonical: pageUrl,
       types: {
-        "application/json": installSlugs.length > 0 ? `/r/${comp.slug}` : `/r/${comp.slug}.json`,
+        "application/json":
+          installSlugs.length > 0 ? `/r/${comp.slug}` : `/r/${comp.slug}.json`,
         "text/plain": `/r/${comp.slug}/raw`,
       },
     },
@@ -83,7 +101,11 @@ export async function generateMetadata({
       "beui:registry-item": registryItem,
       "beui:directory-item": directoryItem,
       ...(installSlugs.length > 0
-        ? { "beui:variant-registry-items": installSlugs.map((installSlug) => `/r/${installSlug}.json`) }
+        ? {
+            "beui:variant-registry-items": installSlugs.map(
+              (installSlug) => `/r/${installSlug}.json`,
+            ),
+          }
         : {}),
     },
   };
@@ -103,19 +125,30 @@ export default async function ComponentPage({
   const comp = findComponent(category, slug);
   if (!cat || !comp) notFound();
   const installCommand = `npx shadcn@latest add @beui/${comp.slug}`;
-  const hasVariantInstallCommands = comp.examples?.some((example) => example.installSlug) ?? false;
+  const hasVariantInstallCommands =
+    comp.examples?.some((example) => example.installSlug) ?? false;
 
   return (
     <div>
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
-        <Link href={`/components/${cat.slug}`} className="text-(--color-fg-muted) transition-colors hover:text-(--color-fg)">
+      <nav
+        aria-label="Breadcrumb"
+        className="flex items-center gap-1.5 text-sm"
+      >
+        <Link
+          href={`/components/${cat.slug}`}
+          className="text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+        >
           {cat.name}
         </Link>
         <ChevronRight className="h-3.5 w-3.5 text-(--color-fg-muted)" />
         <span className="font-medium text-(--color-fg)">{comp.name}</span>
       </nav>
-      <h1 className="mt-4 text-3xl font-semibold tracking-tight text-(--color-fg)">{comp.name}</h1>
-      <p className="mt-2 max-w-2xl text-(--color-fg-muted)">{comp.description}</p>
+      <h1 className="mt-4 text-3xl font-semibold tracking-tight text-(--color-fg)">
+        {comp.name}
+      </h1>
+      <p className="mt-2 max-w-2xl text-(--color-fg-muted)">
+        {comp.description}
+      </p>
 
       {comp.examples?.length ? (
         <div className="mt-10 flex flex-col gap-12">
@@ -135,7 +168,7 @@ export default async function ComponentPage({
               Add this component with the shadcn CLI.
             </p>
             <div className="mt-3">
-              <CodeBlock code={installCommand} lang="bash" filename="terminal" />
+              <CodeBlock code={installCommand} lang="bash" />
             </div>
           </div>
         </section>
@@ -155,13 +188,17 @@ async function ExampleBlock({ example }: { example: ComponentExample }) {
   return (
     <section>
       <div className="mb-4 flex items-baseline justify-between gap-3">
-        <h2 className="text-xl font-semibold tracking-tight text-(--color-fg)">{example.name}</h2>
+        <h2 className="text-xl font-semibold tracking-tight text-(--color-fg)">
+          {example.name}
+        </h2>
         <code className="rounded-md bg-(--color-fg)/5 px-2 py-0.5 font-mono text-[11px] text-(--color-fg-muted)">
           {example.file.split("/").pop()}
         </code>
       </div>
       {example.description ? (
-        <p className="mb-4 text-sm text-(--color-fg-muted)">{example.description}</p>
+        <p className="mb-4 text-sm text-(--color-fg-muted)">
+          {example.description}
+        </p>
       ) : null}
       <Tabs defaultValue="preview" variant="pill">
         <TabsList>
@@ -193,7 +230,15 @@ async function ExampleBlock({ example }: { example: ComponentExample }) {
   );
 }
 
-async function DefaultTabs({ category, slug, file }: { category: string; slug: string; file: string }) {
+async function DefaultTabs({
+  category,
+  slug,
+  file,
+}: {
+  category: string;
+  slug: string;
+  file: string;
+}) {
   const Preview = getPreview(category, slug);
   const previewFile = `components/previews/${category}/${slug}.preview.tsx`;
   const source = await loadSource(file);

--- a/components/app/copy-button.tsx
+++ b/components/app/copy-button.tsx
@@ -6,7 +6,13 @@ import { useState } from "react";
 import { Button } from "@/components/motion/button";
 import { cn } from "@/lib/utils";
 
-export function CopyButton({ text, className }: { text: string; className?: string }) {
+export function CopyButton({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
   const [copied, setCopied] = useState(false);
 
   return (
@@ -20,7 +26,10 @@ export function CopyButton({ text, className }: { text: string; className?: stri
         setTimeout(() => setCopied(false), 1500);
       }}
       aria-label={copied ? "Copied" : "Copy code"}
-      className={cn("text-(--color-fg-muted) hover:text-(--color-fg)", className)}
+      className={cn(
+        "text-(--color-fg-muted) hover:text-(--color-fg)",
+        className,
+      )}
     >
       <AnimatePresence mode="wait" initial={false}>
         {copied ? (
@@ -29,7 +38,12 @@ export function CopyButton({ text, className }: { text: string; className?: stri
             initial={{ scale: 0.4, opacity: 0, filter: "blur(4px)" }}
             animate={{ scale: 1, opacity: 1, filter: "blur(0px)" }}
             exit={{ scale: 0.4, opacity: 0, filter: "blur(4px)" }}
-            transition={{ type: "spring", stiffness: 500, damping: 28, mass: 0.5 }}
+            transition={{
+              type: "spring",
+              stiffness: 500,
+              damping: 28,
+              mass: 0.5,
+            }}
             className="inline-flex"
           >
             <Check className="h-3.5 w-3.5 text-(--color-success)" />
@@ -40,7 +54,12 @@ export function CopyButton({ text, className }: { text: string; className?: stri
             initial={{ scale: 0.4, opacity: 0, filter: "blur(4px)" }}
             animate={{ scale: 1, opacity: 1, filter: "blur(0px)" }}
             exit={{ scale: 0.4, opacity: 0, filter: "blur(4px)" }}
-            transition={{ type: "spring", stiffness: 500, damping: 28, mass: 0.5 }}
+            transition={{
+              type: "spring",
+              stiffness: 500,
+              damping: 28,
+              mass: 0.5,
+            }}
             className="inline-flex"
           >
             <Copy className="h-3.5 w-3.5" />

--- a/components/motion/bouncy-accordion.tsx
+++ b/components/motion/bouncy-accordion.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import {
+  motion,
+  useReducedMotion,
+  type Transition,
+} from "motion/react";
+import { ChevronDown } from "lucide-react";
+import {
+  useCallback,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { EASE_OUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+export type BouncyAccordionItem = {
+  id: string;
+  title: ReactNode;
+  description?: ReactNode;
+  icon?: ReactNode;
+  disabled?: boolean;
+};
+
+export type BouncyAccordionClassNames = {
+  root?: string;
+  item?: string;
+  trigger?: string;
+  icon?: string;
+  title?: string;
+  chevron?: string;
+  content?: string;
+  description?: string;
+};
+
+export interface BouncyAccordionProps {
+  items: BouncyAccordionItem[];
+  value?: string | null;
+  defaultValue?: string | null;
+  onValueChange?: (value: string | null) => void;
+  collapsible?: boolean;
+  className?: string;
+  classNames?: BouncyAccordionClassNames;
+}
+
+// Local springs keep the accordion's connected groups moving together while
+// avoiding scale projection on text-heavy row contents.
+// Gap spring: must not overshoot y — positive y overshoot drifts items below
+// their mt-3 resting point and briefly overlaps the next item.
+const ROW_TRANSITION: Transition = {
+  type: "spring",
+  duration: 0.55,
+  bounce: 0.38,
+};
+
+const CONTENT_OPEN_TRANSITION: Transition = {
+  type: "spring",
+  duration: 0.58,
+  bounce: 0.32,
+};
+
+const CONTENT_CLOSE_TRANSITION: Transition = {
+  type: "spring",
+  duration: 0.46,
+  bounce: 0.26,
+};
+
+const DESCRIPTION_TRANSITION: Transition = {
+  duration: 0.18,
+  ease: EASE_OUT,
+};
+
+const CHEVRON_TRANSITION: Transition = {
+  type: "spring",
+  duration: 0.42,
+  bounce: 0.28,
+};
+
+
+function useControllableAccordionValue({
+  value,
+  defaultValue,
+  onValueChange,
+}: {
+  value?: string | null;
+  defaultValue?: string | null;
+  onValueChange?: (value: string | null) => void;
+}) {
+  const [internalValue, setInternalValue] = useState(defaultValue ?? null);
+  const isControlled = value !== undefined;
+  const currentValue = value ?? internalValue;
+
+  const setValue = useCallback(
+    (next: string | null) => {
+      if (!isControlled) {
+        setInternalValue(next);
+      }
+
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange],
+  );
+
+  return [currentValue, setValue] as const;
+}
+
+function BouncyAccordionRow({
+  item,
+  open,
+  startsGroup,
+  endsGroup,
+  separatedFromPrevious,
+  contentId,
+  triggerId,
+  reduce,
+  classNames,
+  onToggle,
+}: {
+  item: BouncyAccordionItem;
+  open: boolean;
+  startsGroup: boolean;
+  endsGroup: boolean;
+  separatedFromPrevious: boolean;
+  contentId: string;
+  triggerId: string;
+  reduce: boolean | null;
+  classNames?: BouncyAccordionClassNames;
+  onToggle: () => void;
+}) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    const node = contentRef.current;
+    if (!node) return;
+
+    const updateHeight = () => {
+      setContentHeight(node.offsetHeight);
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <motion.div
+      initial={false}
+      animate={{ marginTop: separatedFromPrevious ? 12 : 0 }}
+      transition={reduce ? { duration: 0 } : ROW_TRANSITION}
+    >
+      <motion.div
+        data-state={open ? "open" : "closed"}
+        initial={false}
+        animate={{
+          borderTopLeftRadius: startsGroup ? 28 : 0,
+          borderTopRightRadius: startsGroup ? 28 : 0,
+          borderBottomLeftRadius: endsGroup ? 28 : 0,
+          borderBottomRightRadius: endsGroup ? 28 : 0,
+        }}
+        transition={reduce ? { duration: 0 } : ROW_TRANSITION}
+        className={cn(
+          "overflow-hidden bg-card text-card-foreground",
+          item.disabled && "opacity-50",
+          classNames?.item,
+        )}
+      >
+        <button
+          id={triggerId}
+          type="button"
+          disabled={item.disabled}
+          aria-expanded={open}
+          aria-controls={contentId}
+          onClick={onToggle}
+          className={cn(
+            "flex min-h-[54px] w-full items-center gap-4 px-5 text-left outline-none transition-colors",
+            "focus-visible:bg-muted/25",
+            "disabled:pointer-events-none",
+            classNames?.trigger,
+          )}
+        >
+          {item.icon ? (
+            <span
+              className={cn(
+                "grid h-7 w-7 shrink-0 place-items-center text-muted-foreground",
+                classNames?.icon,
+              )}
+            >
+              {item.icon}
+            </span>
+          ) : null}
+          <span
+            className={cn(
+              "min-w-0 flex-1 truncate text-[15px] font-medium text-foreground",
+              classNames?.title,
+            )}
+          >
+            {item.title}
+          </span>
+          <motion.span
+            aria-hidden
+            animate={{ rotate: open ? 180 : 0 }}
+            transition={reduce ? { duration: 0 } : CHEVRON_TRANSITION}
+            className={cn(
+              "grid h-6 w-6 shrink-0 place-items-center text-muted-foreground",
+              classNames?.chevron,
+            )}
+          >
+            <ChevronDown className="h-4 w-4" />
+          </motion.span>
+        </button>
+
+        <motion.div
+          id={contentId}
+          role="region"
+          aria-labelledby={triggerId}
+          aria-hidden={!open}
+          initial={false}
+          animate={{
+            height: open && item.description ? contentHeight : 0,
+          }}
+          transition={
+            reduce
+              ? { duration: 0 }
+              : open
+                ? CONTENT_OPEN_TRANSITION
+                : CONTENT_CLOSE_TRANSITION
+          }
+          className={cn("overflow-hidden", classNames?.content)}
+        >
+          <motion.div
+            ref={contentRef}
+            animate={{
+              opacity: open ? 1 : 0,
+            }}
+            transition={reduce ? { duration: 0 } : DESCRIPTION_TRANSITION}
+            className="px-5 pb-5"
+          >
+            <div
+              className={cn(
+                "text-[15px] leading-6 text-muted-foreground",
+                classNames?.description,
+              )}
+            >
+              {item.description}
+            </div>
+          </motion.div>
+        </motion.div>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+export function BouncyAccordion({
+  items,
+  value,
+  defaultValue = null,
+  onValueChange,
+  collapsible = true,
+  className,
+  classNames,
+}: BouncyAccordionProps) {
+  const reduce = useReducedMotion();
+  const baseId = useId();
+  const [activeValue, setActiveValue] = useControllableAccordionValue({
+    value,
+    defaultValue,
+    onValueChange,
+  });
+  const activeIndex = items.findIndex((item) => item.id === activeValue);
+
+  const toggleItem = useCallback(
+    (id: string) => {
+      if (activeValue === id) {
+        if (collapsible) {
+          setActiveValue(null);
+        }
+        return;
+      }
+
+      setActiveValue(id);
+    },
+    [activeValue, collapsible, setActiveValue],
+  );
+
+  return (
+    <div className={cn("w-full", className, classNames?.root)}>
+      {items.map((item, index) => {
+        const open = activeValue === item.id;
+        const previousIsOpen = activeIndex === index - 1;
+        const nextIsOpen = activeIndex === index + 1;
+        const startsGroup = open || index === 0 || previousIsOpen;
+        const endsGroup = open || index === items.length - 1 || nextIsOpen;
+        const separatedFromPrevious = index > 0 && (open || previousIsOpen);
+        const contentId = `${baseId}-${item.id}-content`;
+        const triggerId = `${baseId}-${item.id}-trigger`;
+
+        return (
+          <BouncyAccordionRow
+            key={item.id}
+            item={item}
+            open={open}
+            startsGroup={startsGroup}
+            endsGroup={endsGroup}
+            separatedFromPrevious={separatedFromPrevious}
+            contentId={contentId}
+            triggerId={triggerId}
+            reduce={reduce}
+            classNames={classNames}
+            onToggle={() => toggleItem(item.id)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/components/previews/blocks/bouncy-accordion.preview.tsx
+++ b/components/previews/blocks/bouncy-accordion.preview.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import {
+  CalendarClock,
+  FileText,
+  FolderKanban,
+  PackageCheck,
+  RadioTower,
+  ShieldCheck,
+} from "lucide-react";
+import { BouncyAccordion } from "@/components/motion/bouncy-accordion";
+
+const items = [
+  {
+    id: "brief",
+    title: "Release Brief",
+    description:
+      "Collect launch notes, owners, and risks in one compact handoff before the release window opens.",
+    icon: <FileText className="h-4 w-4" />,
+  },
+  {
+    id: "launch",
+    title: "Launch Checklist",
+    description:
+      "Verify copy, links, analytics, rollback steps, and final approvals without leaving the queue.",
+    icon: <ShieldCheck className="h-4 w-4" />,
+  },
+  {
+    id: "campaign",
+    title: "Campaign Notes",
+    description:
+      "Keep channel-specific notes close to the task while preserving a calm collapsed list.",
+    icon: <RadioTower className="h-4 w-4" />,
+  },
+  {
+    id: "calendar",
+    title: "Rollout Calendar",
+    description:
+      "Plan announcements, staging checks, reminders, and quiet periods around the same timeline.",
+    icon: <CalendarClock className="h-4 w-4" />,
+  },
+  {
+    id: "ship",
+    title: "Ship Build",
+    description:
+      "Track the current artifact, deploy status, and final sign-off before marking the release complete.",
+    icon: <PackageCheck className="h-4 w-4" />,
+  },
+  {
+    id: "archive",
+    title: "Archive Assets",
+    description:
+      "Move final copy, images, and source files into the campaign folder once the rollout is done.",
+    icon: <FolderKanban className="h-4 w-4" />,
+  },
+];
+
+export function BouncyAccordionPreview() {
+  return (
+    <div className="flex min-h-96 w-full items-center justify-center">
+      <div className="w-full max-w-sm h-[480px]">
+        <BouncyAccordion items={items} defaultValue="calendar" />
+      </div>
+    </div>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -22,6 +22,11 @@ export const previews: Record<string, ComponentType> = {
   "blocks/swipeable-list": dynamic(() =>
     import("./blocks/swipeable-list.preview").then((m) => m.SwipeableListPreview),
   ),
+  "blocks/bouncy-accordion": dynamic(() =>
+    import("./blocks/bouncy-accordion.preview").then(
+      (m) => m.BouncyAccordionPreview,
+    ),
+  ),
   "motion/tilt-card": dynamic(() =>
     import("./motion/tilt-card.preview").then((m) => m.TiltCardPreview),
   ),

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -293,6 +293,12 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/swipeable-list.tsx",
       },
       {
+        slug: "bouncy-accordion",
+        name: "Bouncy Accordion",
+        description: "Single-open accordion with weighted spring layout, icon rows and reduced-motion-safe content reveals.",
+        file: "components/motion/bouncy-accordion.tsx",
+      },
+      {
         slug: "otp-input",
         name: "OTP Input",
         description: "One-time-code input with a gliding focus ring, digits that roll in per slot, error shake and a success check draw.",


### PR DESCRIPTION
## Summary

- New `BouncyAccordion` block component with connected spring motion
- Each corner's border-radius is individually spring-animated — items smoothly attach and detach as the open group shape changes (no instant snap from rounded to flat)
- Gap between items uses `animate={{ marginTop }}` so all items in the flow move together (no cascade gap artifacts)
- Content height uses an underdamped spring on both open and close — panel bounces in both directions
- Full controlled/uncontrolled API (`value`, `defaultValue`, `onValueChange`, `collapsible`)
- `classNames` prop for per-slot customisation
- `useReducedMotion()` gates all springs; opacity/color transitions are preserved

## Test plan

- [ ] Open and close each item — border-radius transitions smoothly between rounded and flat corners
- [ ] Open item 4 of 6 — no stray gap between items 5 and 6
- [ ] Switch between items — connected group bounces and reattaches cleanly
- [ ] Verify reduced-motion: no transform animations, content still fades
- [ ] Verify `disabled` prop disables interaction and dims item
- [ ] Check registry: `bun run check:registry` passes