### PR TITLE
feat: refresh catalog cards and new component sections

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -15,6 +15,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/motion/tabs";
+import { NewBadge } from "@/components/app/new-badge";
 import { getPreview, previews } from "@/components/previews";
 import { readSourceFile } from "@/lib/source-files";
 
@@ -143,9 +144,12 @@ export default async function ComponentPage({
         <ChevronRight className="h-3.5 w-3.5 text-(--color-fg-muted)" />
         <span className="font-medium text-(--color-fg)">{comp.name}</span>
       </nav>
-      <h1 className="mt-4 text-3xl font-semibold tracking-tight text-(--color-fg)">
-        {comp.name}
-      </h1>
+      <div className="mt-4 flex items-center gap-3">
+        <h1 className="text-3xl font-semibold tracking-tight text-(--color-fg)">
+          {comp.name}
+        </h1>
+        {comp.badge === "new" ? <NewBadge className="mt-1" /> : null}
+      </div>
       <p className="mt-2 max-w-2xl text-(--color-fg-muted)">
         {comp.description}
       </p>

--- a/app/components/[category]/page.tsx
+++ b/app/components/[category]/page.tsx
@@ -134,7 +134,7 @@ function CategoryComponentCard({
   return (
     <Link
       href={`/components/${categorySlug}/${component.slug}`}
-      className="group/card relative flex h-48 flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
+      className="group/card relative flex h-40 flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
     >
       <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
         <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
@@ -143,8 +143,8 @@ function CategoryComponentCard({
         {component.badge === "new" ? <NewBadge /> : null}
       </div>
 
-      <div className="mx-2 mb-2 flex min-h-0 flex-1 items-end overflow-hidden rounded-3xl bg-(--color-bg) px-4 py-4 transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-(--color-bg)/80 group-focus-visible/card:bg-(--color-bg)/80">
-        <p className="line-clamp-4 text-sm leading-relaxed text-(--color-fg-muted)">
+      <div className="mx-2 mb-2 flex min-h-0 flex-1 items-start overflow-hidden rounded-3xl bg-(--color-bg) px-4 py-4 transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-(--color-bg)/80 group-focus-visible/card:bg-(--color-bg)/80">
+        <p className="line-clamp-3 text-sm leading-relaxed text-(--color-fg-muted)">
           {component.description}
         </p>
       </div>

--- a/app/components/[category]/page.tsx
+++ b/app/components/[category]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { findCategory, registry } from "@/lib/registry";
+import { NewBadge } from "@/components/app/new-badge";
 
 export function generateStaticParams() {
   return registry.map((c) => ({ category: c.slug }));
@@ -85,7 +86,12 @@ export default async function CategoryPage({ params }: { params: Promise<{ categ
             className="group flex items-start justify-between gap-3 rounded-2xl border border-(--color-border) bg-(--color-bg-elev) px-4 py-3.5 transition-colors hover:border-(--color-border-strong)"
           >
             <div className="min-w-0">
-              <h3 className="text-sm font-semibold text-(--color-fg)">{comp.name}</h3>
+              <div className="flex items-center gap-2">
+                <h3 className="truncate text-sm font-semibold text-(--color-fg)">
+                  {comp.name}
+                </h3>
+                {comp.badge === "new" ? <NewBadge /> : null}
+              </div>
               <p className="mt-1 line-clamp-2 text-xs text-(--color-fg-muted)">{comp.description}</p>
             </div>
             <ArrowUpRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-(--color-fg-muted) transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />

--- a/app/components/[category]/page.tsx
+++ b/app/components/[category]/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { ArrowUpRight } from "lucide-react";
-import { findCategory, registry } from "@/lib/registry";
+import { findCategory, registry, type ComponentEntry } from "@/lib/registry";
 import { NewBadge } from "@/components/app/new-badge";
 
 export function generateStaticParams() {
@@ -65,39 +64,90 @@ export async function generateMetadata({
   };
 }
 
-export default async function CategoryPage({ params }: { params: Promise<{ category: string }> }) {
+export default async function CategoryPage({
+  params,
+}: {
+  params: Promise<{ category: string }>;
+}) {
   const { category } = await params;
   const cat = findCategory(category);
   if (!cat) notFound();
+  const newComponents = cat.components.filter((comp) => comp.badge === "new");
 
   return (
     <div>
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
+      <nav
+        aria-label="Breadcrumb"
+        className="flex items-center gap-1.5 text-sm"
+      >
         <span className="font-medium text-(--color-fg)">{cat.name}</span>
       </nav>
-      <h1 className="mt-4 text-3xl font-semibold tracking-tight text-(--color-fg)">{cat.name}</h1>
-      <p className="mt-2 max-w-2xl text-(--color-fg-muted)">{cat.description}</p>
+      <h1 className="mt-4 text-3xl font-semibold tracking-tight text-(--color-fg)">
+        {cat.name}
+      </h1>
+      <p className="mt-2 max-w-2xl text-(--color-fg-muted)">
+        {cat.description}
+      </p>
 
-      <div className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-        {cat.components.map((comp) => (
-          <Link
-            key={comp.slug}
-            href={`/components/${cat.slug}/${comp.slug}`}
-            className="group flex items-start justify-between gap-3 rounded-2xl border border-(--color-border) bg-(--color-bg-elev) px-4 py-3.5 transition-colors hover:border-(--color-border-strong)"
-          >
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <h3 className="truncate text-sm font-semibold text-(--color-fg)">
-                  {comp.name}
-                </h3>
-                {comp.badge === "new" ? <NewBadge /> : null}
-              </div>
-              <p className="mt-1 line-clamp-2 text-xs text-(--color-fg-muted)">{comp.description}</p>
-            </div>
-            <ArrowUpRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-(--color-fg-muted) transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
-          </Link>
-        ))}
-      </div>
+      {newComponents.length ? (
+        <section className="mt-10">
+          <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
+            New
+          </p>
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {newComponents.map((comp) => (
+              <CategoryComponentCard
+                key={comp.slug}
+                categorySlug={cat.slug}
+                component={comp}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="mt-10">
+        <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
+          All {cat.name}
+        </p>
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {cat.components.map((comp) => (
+            <CategoryComponentCard
+              key={comp.slug}
+              categorySlug={cat.slug}
+              component={comp}
+            />
+          ))}
+        </div>
+      </section>
     </div>
+  );
+}
+
+function CategoryComponentCard({
+  categorySlug,
+  component,
+}: {
+  categorySlug: string;
+  component: ComponentEntry;
+}) {
+  return (
+    <Link
+      href={`/components/${categorySlug}/${component.slug}`}
+      className="group/card relative flex h-48 flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
+    >
+      <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
+        <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
+          {component.name}
+        </h3>
+        {component.badge === "new" ? <NewBadge /> : null}
+      </div>
+
+      <div className="mx-2 mb-2 flex min-h-0 flex-1 items-end overflow-hidden rounded-3xl bg-(--color-bg) px-4 py-4 transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-(--color-bg)/80 group-focus-visible/card:bg-(--color-bg)/80">
+        <p className="line-clamp-4 text-sm leading-relaxed text-(--color-fg-muted)">
+          {component.description}
+        </p>
+      </div>
+    </Link>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,12 +7,41 @@ import { LandingComponentCard } from "@/components/app/landing-component-card";
 export default function Home() {
   const motionCategory = registry[0];
   const blocksCategory = registry[1];
+  const newComponents = registry.flatMap((category) =>
+    category.components
+      .filter((component) => component.badge === "new")
+      .map((component) => ({ category: category.slug, component })),
+  );
 
   return (
     <div className="relative">
       <section className="relative isolate overflow-hidden px-4 pb-16 pt-20 md:pt-28">
         <Hero />
       </section>
+
+      {newComponents.length ? (
+        <section className="mx-auto max-w-7xl px-4 pb-16">
+          <div className="mb-8 flex flex-col gap-4 border-t border-(--color-border) pt-12 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
+                New
+              </p>
+              <h2 className="mt-2 max-w-2xl font-pixel text-3xl font-medium leading-tight text-(--color-fg) md:text-4xl">
+                Recently launched.
+              </h2>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+            {newComponents.map(({ category, component }) => (
+              <LandingComponentCard
+                key={`${category}-${component.slug}`}
+                component={component}
+                category={category}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       <section className="mx-auto max-w-7xl px-4 pb-16">
         <div className="mb-8 flex flex-col gap-4 border-t border-(--color-border) pt-12 md:flex-row md:items-center md:justify-between">

--- a/components/app/landing-component-card.tsx
+++ b/components/app/landing-component-card.tsx
@@ -13,26 +13,26 @@ export function LandingComponentCard({
   const Preview = getPreview(category, component.slug);
 
   return (
-    <article className="group/card relative min-h-64">
+    <article className="group/card relative h-64">
       <Link
         href={`/components/${category}/${component.slug}`}
         aria-label={`View ${component.name}`}
         className="absolute inset-0 z-20 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
       />
-      <div className="relative flex min-h-64 flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint]">
-        <div className="flex items-center justify-between gap-3 px-4 py-3">
+      <div className="relative flex h-full flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint]">
+        <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
           <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
             {component.name}
           </h3>
           {component.badge === "new" ? <NewBadge /> : null}
         </div>
 
-        <div className="relative mx-4 mb-4 flex flex-1 items-center justify-center overflow-hidden rounded-2xl bg-(--color-bg) px-5 py-5 contain-[paint]">
+        <div className="relative mx-2 mb-2 flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-3xl bg-(--color-bg) px-5 py-5 contain-[paint]">
           <div className="pointer-events-none flex w-full max-w-full origin-center scale-80 items-center justify-center overflow-hidden transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] group-hover/card:scale-[0.84] group-focus-within/card:scale-[0.84] [&_*]:!cursor-default">
             {Preview ? <Preview /> : null}
           </div>
 
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-2 bg-(--color-bg-elev)/82 px-4 py-3 opacity-0 backdrop-blur-md transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-hover/card:opacity-100 group-focus-within/card:translate-y-0 group-focus-within/card:opacity-100">
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-2 bg-(--color-bg-elev)/60 px-4 py-3 opacity-0 backdrop-blur-md transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-hover/card:opacity-100 group-focus-within/card:translate-y-0 group-focus-within/card:opacity-100">
             <p className="line-clamp-2 text-xs leading-relaxed text-(--color-fg-muted)">
               {component.description}
             </p>

--- a/components/app/landing-component-card.tsx
+++ b/components/app/landing-component-card.tsx
@@ -32,10 +32,12 @@ export function LandingComponentCard({
             {Preview ? <Preview /> : null}
           </div>
 
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-2 rounded-b-3xl bg-(--color-bg-elev)/60 px-4 py-3 opacity-0 backdrop-blur-md transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-hover/card:opacity-100 group-focus-within/card:translate-y-0 group-focus-within/card:opacity-100">
-            <p className="line-clamp-2 text-xs leading-relaxed text-(--color-fg-muted)">
-              {component.description}
-            </p>
+          <div className="pointer-events-none absolute inset-0 rounded-3xl bg-transparent backdrop-blur-0 transition-[background-color,backdrop-filter] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-(--color-bg-elev)/55 group-hover/card:backdrop-blur-md group-focus-within/card:bg-(--color-bg-elev)/55 group-focus-within/card:backdrop-blur-md">
+            <div className="absolute inset-x-0 bottom-0 overflow-hidden rounded-b-3xl px-4 py-3">
+              <p className="line-clamp-2 translate-y-full text-xs leading-relaxed text-(--color-fg-muted) transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-focus-within/card:translate-y-0">
+                {component.description}
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/components/app/landing-component-card.tsx
+++ b/components/app/landing-component-card.tsx
@@ -32,7 +32,7 @@ export function LandingComponentCard({
             {Preview ? <Preview /> : null}
           </div>
 
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-2 bg-(--color-bg-elev)/60 px-4 py-3 opacity-0 backdrop-blur-md transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-hover/card:opacity-100 group-focus-within/card:translate-y-0 group-focus-within/card:opacity-100">
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-2 rounded-b-3xl bg-(--color-bg-elev)/60 px-4 py-3 opacity-0 backdrop-blur-md transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-hover/card:opacity-100 group-focus-within/card:translate-y-0 group-focus-within/card:opacity-100">
             <p className="line-clamp-2 text-xs leading-relaxed text-(--color-fg-muted)">
               {component.description}
             </p>

--- a/components/app/landing-component-card.tsx
+++ b/components/app/landing-component-card.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { ArrowUpRight } from "lucide-react";
 import type { ComponentEntry } from "@/lib/registry";
 import { NewBadge } from "@/components/app/new-badge";
 import { getPreview } from "@/components/previews";
@@ -14,33 +13,32 @@ export function LandingComponentCard({
   const Preview = getPreview(category, component.slug);
 
   return (
-    <article className="group/card relative min-h-55">
+    <article className="group/card relative min-h-64">
       <Link
         href={`/components/${category}/${component.slug}`}
         aria-label={`View ${component.name}`}
         className="absolute inset-0 z-20 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
       />
       <div
-        className="flex min-h-55 flex-col overflow-hidden rounded-lg border border-(--color-border) bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] group-hover/card:border-(--color-border-strong) group-focus-within/card:border-(--color-border-strong)"
+        className="relative flex min-h-64 flex-col overflow-hidden rounded-lg border border-(--color-border) bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] group-hover/card:border-(--color-border-strong) group-focus-within/card:border-(--color-border-strong)"
       >
-        <div className="relative flex h-36 items-center justify-center overflow-hidden bg-(--color-bg) px-5 py-4 contain-[paint] mask-b-fade">
-          <div className="pointer-events-none flex w-full max-w-full origin-center scale-75 items-center justify-center overflow-hidden transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] group-hover/card:scale-[0.78] group-focus-within/card:scale-[0.78] [&_*]:!cursor-default">
+        <div className="flex items-center justify-between gap-3 border-b border-(--color-border) px-4 py-3">
+          <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
+            {component.name}
+          </h3>
+          {component.badge === "new" ? <NewBadge /> : null}
+        </div>
+
+        <div className="relative flex flex-1 items-center justify-center overflow-hidden bg-(--color-bg) px-5 py-5 contain-[paint]">
+          <div className="pointer-events-none flex w-full max-w-full origin-center scale-80 items-center justify-center overflow-hidden transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] group-hover/card:scale-[0.84] group-focus-within/card:scale-[0.84] [&_*]:!cursor-default">
             {Preview ? <Preview /> : null}
           </div>
         </div>
-        <div className="flex flex-1 items-start justify-between gap-3 border-t border-(--color-border) p-4">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
-                {component.name}
-              </h3>
-              {component.badge === "new" ? <NewBadge /> : null}
-            </div>
-            <p className="mt-1 line-clamp-2 text-xs text-(--color-fg-muted)">
-              {component.description}
-            </p>
-          </div>
-          <ArrowUpRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-(--color-fg-muted) transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-x-0.5 group-hover/card:-translate-y-0.5 group-focus-within/card:translate-x-0.5 group-focus-within/card:-translate-y-0.5" />
+
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-2 border-t border-(--color-border) bg-(--color-bg-elev)/82 px-4 py-3 opacity-0 backdrop-blur-md transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-hover/card:opacity-100 group-focus-within/card:translate-y-0 group-focus-within/card:opacity-100">
+          <p className="line-clamp-2 text-xs leading-relaxed text-(--color-fg-muted)">
+            {component.description}
+          </p>
         </div>
       </div>
     </article>

--- a/components/app/landing-component-card.tsx
+++ b/components/app/landing-component-card.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import type { ComponentEntry } from "@/lib/registry";
+import { NewBadge } from "@/components/app/new-badge";
 import { getPreview } from "@/components/previews";
 
 export function LandingComponentCard({
@@ -29,9 +30,12 @@ export function LandingComponentCard({
         </div>
         <div className="flex flex-1 items-start justify-between gap-3 border-t border-(--color-border) p-4">
           <div className="min-w-0">
-            <h3 className="font-pixel text-base font-medium text-(--color-fg)">
-              {component.name}
-            </h3>
+            <div className="flex items-center gap-2">
+              <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
+                {component.name}
+              </h3>
+              {component.badge === "new" ? <NewBadge /> : null}
+            </div>
             <p className="mt-1 line-clamp-2 text-xs text-(--color-fg-muted)">
               {component.description}
             </p>

--- a/components/app/landing-component-card.tsx
+++ b/components/app/landing-component-card.tsx
@@ -17,28 +17,26 @@ export function LandingComponentCard({
       <Link
         href={`/components/${category}/${component.slug}`}
         aria-label={`View ${component.name}`}
-        className="absolute inset-0 z-20 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
+        className="absolute inset-0 z-20 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
       />
-      <div
-        className="relative flex min-h-64 flex-col overflow-hidden rounded-lg border border-(--color-border) bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] group-hover/card:border-(--color-border-strong) group-focus-within/card:border-(--color-border-strong)"
-      >
-        <div className="flex items-center justify-between gap-3 border-b border-(--color-border) px-4 py-3">
+      <div className="relative flex min-h-64 flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint]">
+        <div className="flex items-center justify-between gap-3 px-4 py-3">
           <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
             {component.name}
           </h3>
           {component.badge === "new" ? <NewBadge /> : null}
         </div>
 
-        <div className="relative flex flex-1 items-center justify-center overflow-hidden bg-(--color-bg) px-5 py-5 contain-[paint]">
+        <div className="relative mx-4 mb-4 flex flex-1 items-center justify-center overflow-hidden rounded-2xl bg-(--color-bg) px-5 py-5 contain-[paint]">
           <div className="pointer-events-none flex w-full max-w-full origin-center scale-80 items-center justify-center overflow-hidden transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] group-hover/card:scale-[0.84] group-focus-within/card:scale-[0.84] [&_*]:!cursor-default">
             {Preview ? <Preview /> : null}
           </div>
-        </div>
 
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-2 border-t border-(--color-border) bg-(--color-bg-elev)/82 px-4 py-3 opacity-0 backdrop-blur-md transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-hover/card:opacity-100 group-focus-within/card:translate-y-0 group-focus-within/card:opacity-100">
-          <p className="line-clamp-2 text-xs leading-relaxed text-(--color-fg-muted)">
-            {component.description}
-          </p>
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-2 bg-(--color-bg-elev)/82 px-4 py-3 opacity-0 backdrop-blur-md transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-hover/card:opacity-100 group-focus-within/card:translate-y-0 group-focus-within/card:opacity-100">
+            <p className="line-clamp-2 text-xs leading-relaxed text-(--color-fg-muted)">
+              {component.description}
+            </p>
+          </div>
         </div>
       </div>
     </article>

--- a/components/app/new-badge.tsx
+++ b/components/app/new-badge.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/utils";
+
+export function NewBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-full border border-(--color-border-strong) bg-(--color-accent)/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-(--color-accent)",
+        className,
+      )}
+    >
+      New
+    </span>
+  );
+}

--- a/components/app/site-header.tsx
+++ b/components/app/site-header.tsx
@@ -9,6 +9,7 @@ import { usePathname } from "next/navigation";
 import { GithubIcon } from "@/components/app/icons";
 import { MobileNav } from "@/components/app/mobile-nav";
 import { PressLink } from "@/components/app/press-link";
+import { SiteSearch } from "@/components/app/site-search";
 import { cn } from "@/lib/utils";
 
 function formatStarCount(count: number) {
@@ -93,6 +94,7 @@ export function SiteHeader({
         </div>
 
         <nav className="flex items-center gap-2">
+          <SiteSearch className="w-9 justify-center px-0 sm:w-44 sm:justify-start sm:px-3 lg:w-56" />
           <PressLink
             href="https://github.com/starc007/ui-components"
             target="_blank"

--- a/components/app/site-search.tsx
+++ b/components/app/site-search.tsx
@@ -3,6 +3,7 @@
 import { Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
 import {
   CommandPalette,
   type CommandItem,
@@ -18,8 +19,8 @@ const PAGES = [
   },
 ];
 
-/** Sidebar search trigger backed by the library's own command palette. */
-export function SiteSearch() {
+/** Site search trigger backed by the library's own command palette. */
+export function SiteSearch({ className }: { className?: string }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
 
@@ -49,12 +50,16 @@ export function SiteSearch() {
     <>
       <button
         type="button"
+        aria-label="Search components"
         onClick={() => setOpen(true)}
-        className="flex w-full items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-3 py-1.5 text-sm text-(--color-fg-muted) transition-colors hover:border-(--color-border-strong) hover:text-(--color-fg)"
+        className={cn(
+          "flex h-9 w-full items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-3 text-sm text-(--color-fg-muted) transition-colors hover:border-(--color-border-strong) hover:text-(--color-fg)",
+          className,
+        )}
       >
-        <Search className="h-3.5 w-3.5" />
-        <span className="flex-1 text-left">Search</span>
-        <kbd className="rounded border border-(--color-border) bg-(--color-bg) px-1.5 py-0.5 text-[10px] text-(--color-fg-muted)">
+        <Search className="h-3.5 w-3.5 shrink-0" />
+        <span className="hidden flex-1 text-left sm:block">Search</span>
+        <kbd className="hidden rounded border border-(--color-border) bg-(--color-bg) px-1.5 py-0.5 text-[10px] text-(--color-fg-muted) md:inline-block">
           ⌘K
         </kbd>
       </button>

--- a/components/app/site-sidebar.tsx
+++ b/components/app/site-sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { registry } from "@/lib/registry";
-import { SiteSearch } from "@/components/app/site-search";
+import { NewBadge } from "@/components/app/new-badge";
 import { SharedLayoutBg } from "@/components/motion/shared-layout-bg";
 import { cn } from "@/lib/utils";
 
@@ -87,7 +87,10 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
                   onClick={onNavigate}
                   className={linkClass(pathname === href)}
                 >
-                  {comp.name}
+                  <span className="flex items-center justify-between gap-2">
+                    <span className="truncate">{comp.name}</span>
+                    {comp.badge === "new" ? <NewBadge /> : null}
+                  </span>
                 </Link>
               );
             })}
@@ -101,9 +104,6 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
 export function SiteSidebar() {
   return (
     <aside className="fixed top-14 hidden h-[calc(100vh-3.5rem)] w-60 overflow-x-visible overflow-y-auto scrollbar-hide py-6 pr-4 md:block">
-      <div className="mb-6">
-        <SiteSearch />
-      </div>
       <SidebarNav />
     </aside>
   );

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -17,6 +17,7 @@ export type ComponentEntry = {
   name: string;
   description: string;
   file: string;
+  badge?: "new";
   /** Extra source files bundled under this slug (e.g. multi-file components). */
   extraFiles?: string[];
   /** Per-variant breakdown rendered as separate Preview / Usage / Source on the page. */
@@ -248,6 +249,7 @@ export const registry: CategoryEntry[] = [
         name: "Theme Toggle",
         description: "Theme toggle button with a full-page rectangle clip-path reveal via the View Transition API.",
         file: "components/motion/theme-toggle.tsx",
+        badge: "new",
       },
     ],
   },
@@ -291,18 +293,21 @@ export const registry: CategoryEntry[] = [
         name: "Swipeable List",
         description: "Mobile-style list rows that swipe left or right to reveal contextual action buttons.",
         file: "components/motion/swipeable-list.tsx",
+        badge: "new",
       },
       {
         slug: "bouncy-accordion",
         name: "Bouncy Accordion",
         description: "Single-open accordion with weighted spring layout, icon rows and reduced-motion-safe content reveals.",
         file: "components/motion/bouncy-accordion.tsx",
+        badge: "new",
       },
       {
         slug: "otp-input",
         name: "OTP Input",
         description: "One-time-code input with a gliding focus ring, digits that roll in per slot, error shake and a success check draw.",
         file: "components/motion/otp-input.tsx",
+        badge: "new",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- move site search into the header so Cmd/Ctrl+K works from the landing page
- add registry-driven New badges and New sections on the landing, motion, and blocks routes
- restyle landing and category cards with the new rounded shell and hover preview blur/description behavior

## Checks
- bun run typecheck
- bun run lint
- bun run check:registry
- git diff --check