### PR TITLE
feat: add prediction market block

### DIFF
--- a/components/motion/button/stateful.tsx
+++ b/components/motion/button/stateful.tsx
@@ -1,9 +1,20 @@
 "use client";
 
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  AnimatePresence,
+  motion,
+  useReducedMotion,
+  type Variants,
+} from "motion/react";
 import { Check, Loader2, X } from "lucide-react";
-import { forwardRef, type ReactNode } from "react";
-import { SPRING_SWAP } from "@/lib/ease";
+import {
+  forwardRef,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { EASE_OUT, EASE_OUT_CSS, SPRING_SWAP } from "@/lib/ease";
 import { Button, type ButtonProps } from "./base";
 
 export type ButtonState = "idle" | "loading" | "success" | "error";
@@ -17,19 +28,136 @@ export interface StatefulButtonProps extends Omit<ButtonProps, "children"> {
   icon?: ReactNode;
 }
 
-function Slot({ keyId, children }: { keyId: string; children: ReactNode }) {
+const CASCADE_STAGGER = 0.025;
+const ROLL_BLUR = "blur(6px)";
+
+const CASCADE_LETTER_VARIANTS: Variants = {
+  initial: { opacity: 0, y: "105%", filter: ROLL_BLUR },
+  animate: (delay: number = 0) => ({
+    opacity: 1,
+    y: "0%",
+    filter: "blur(0px)",
+    transition: { ...SPRING_SWAP, delay },
+  }),
+  exit: (delay: number = 0) => ({
+    opacity: 0,
+    y: "-105%",
+    filter: ROLL_BLUR,
+    transition: { duration: 0.16, ease: EASE_OUT, delay: delay * 0.5 },
+  }),
+};
+
+const ICON_VARIANTS: Variants = {
+  initial: { opacity: 0, y: 14, filter: ROLL_BLUR },
+  animate: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: SPRING_SWAP,
+  },
+  exit: {
+    opacity: 0,
+    y: -14,
+    filter: ROLL_BLUR,
+    transition: { duration: 0.16, ease: EASE_OUT },
+  },
+};
+
+function IconSlot({ keyId, children }: { keyId: string; children: ReactNode }) {
   const reduce = useReducedMotion();
   return (
     <motion.span
       key={keyId}
-      initial={reduce ? { opacity: 0 } : { y: 14, opacity: 0, filter: "blur(6px)" }}
-      animate={reduce ? { opacity: 1 } : { y: 0, opacity: 1, filter: "blur(0px)" }}
-      exit={reduce ? { opacity: 0 } : { y: -14, opacity: 0, filter: "blur(6px)" }}
-      transition={reduce ? { duration: 0.15 } : SPRING_SWAP}
-      className="inline-flex items-center gap-2 whitespace-nowrap"
+      variants={ICON_VARIANTS}
+      initial={reduce ? { opacity: 0 } : "initial"}
+      animate={reduce ? { opacity: 1 } : "animate"}
+      exit={reduce ? { opacity: 0 } : "exit"}
+      transition={reduce ? { duration: 0.15 } : undefined}
+      className="inline-grid shrink-0 place-items-center will-change-[opacity,filter,transform]"
     >
       {children}
     </motion.span>
+  );
+}
+
+function TextSlot({
+  value,
+  children,
+}: {
+  value: string;
+  children: ReactNode;
+}) {
+  const reduce = useReducedMotion();
+  const measureRef = useRef<HTMLSpanElement>(null);
+  const [width, setWidth] = useState<number>();
+  const label = typeof children === "string" ? children : null;
+  const cascade = label !== null && !reduce;
+
+  useLayoutEffect(() => {
+    const nextWidth = measureRef.current?.offsetWidth;
+    if (!nextWidth) return;
+    setWidth((currentWidth) =>
+      currentWidth === nextWidth ? currentWidth : nextWidth,
+    );
+  });
+
+  return (
+    <span
+      className="relative inline-block overflow-hidden whitespace-nowrap align-bottom"
+      style={{
+        width,
+        transition: reduce ? undefined : `width 220ms ${EASE_OUT_CSS}`,
+      }}
+    >
+      <span
+        ref={measureRef}
+        aria-hidden
+        className="invisible inline-block whitespace-nowrap"
+      >
+        {children}
+      </span>
+
+      {cascade ? (
+        <>
+          <span className="sr-only">{label}</span>
+          <AnimatePresence initial={false}>
+            <motion.span
+              key={`cascade-${value}`}
+              aria-hidden
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              className="absolute left-0 top-0 inline-block whitespace-pre"
+            >
+              {label.split("").map((char, index) => (
+                <motion.span
+                  // biome-ignore lint/suspicious/noArrayIndexKey: position is the slot identity.
+                  key={index}
+                  custom={index * CASCADE_STAGGER}
+                  variants={CASCADE_LETTER_VARIANTS}
+                  className="inline-block whitespace-pre will-change-[opacity,filter,transform]"
+                >
+                  {char}
+                </motion.span>
+              ))}
+            </motion.span>
+          </AnimatePresence>
+        </>
+      ) : (
+        <AnimatePresence initial={false}>
+          <motion.span
+            key={`text-${value}`}
+            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 14, filter: ROLL_BLUR }}
+            animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0, filter: "blur(0px)" }}
+            exit={reduce ? { opacity: 0 } : { opacity: 0, y: -14, filter: ROLL_BLUR }}
+            transition={reduce ? { duration: 0.15 } : SPRING_SWAP}
+            className="absolute left-0 top-0 inline-block will-change-[opacity,filter,transform]"
+          >
+            {children}
+          </motion.span>
+        </AnimatePresence>
+      )}
+    </span>
   );
 }
 
@@ -48,38 +176,48 @@ export const StatefulButton = forwardRef<HTMLButtonElement, StatefulButtonProps>
 ) {
   const reduce = useReducedMotion();
   const isBusy = state === "loading";
+  const stateText =
+    state === "loading"
+      ? loadingText
+      : state === "success"
+        ? successText
+        : state === "error"
+        ? errorText
+        : children;
+  const textKey =
+    typeof stateText === "string" ? `${state}-${stateText}` : state;
+
   return (
     <Button ref={ref} disabled={disabled || isBusy} aria-busy={isBusy} {...rest}>
       <motion.span
         layout={!reduce}
         transition={SPRING_SWAP}
         aria-live="polite"
-        className="relative inline-flex items-center justify-center overflow-hidden"
+        className="relative inline-flex items-center justify-center gap-2 overflow-hidden"
       >
         <AnimatePresence mode="popLayout" initial={false}>
-          {state === "idle" ? (
-            <Slot keyId="idle">
-              {children}
-              {icon}
-            </Slot>
-          ) : null}
           {state === "loading" ? (
-            <Slot keyId="loading">
+            <IconSlot keyId="loading-icon">
               <Loader2 className="h-4 w-4 animate-spin" />
-              {loadingText}
-            </Slot>
+            </IconSlot>
           ) : null}
           {state === "success" ? (
-            <Slot keyId="success">
+            <IconSlot keyId="success-icon">
               <Check className="h-4 w-4" />
-              {successText}
-            </Slot>
+            </IconSlot>
           ) : null}
           {state === "error" ? (
-            <Slot keyId="error">
+            <IconSlot keyId="error-icon">
               <X className="h-4 w-4" />
-              {errorText}
-            </Slot>
+            </IconSlot>
+          ) : null}
+        </AnimatePresence>
+
+        <TextSlot value={textKey}>{stateText}</TextSlot>
+
+        <AnimatePresence mode="popLayout" initial={false}>
+          {state === "idle" && icon ? (
+            <IconSlot keyId="idle-icon">{icon}</IconSlot>
           ) : null}
         </AnimatePresence>
       </motion.span>

--- a/components/motion/number-ticker.tsx
+++ b/components/motion/number-ticker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView, useReducedMotion } from "motion/react";
+import { animate, motion, useInView, useReducedMotion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { EASE_OUT } from "@/lib/ease";
 import { cn } from "@/lib/utils";
@@ -17,6 +17,8 @@ export interface NumberTickerProps {
   startOnView?: boolean;
   prefix?: string;
   suffix?: string;
+  /** Add a small blur during digit rolls. */
+  blur?: boolean;
   className?: string;
   digitClassName?: string;
   /** Insert locale group separators (commas). Server-component safe. */
@@ -36,6 +38,7 @@ export function NumberTicker({
   startOnView = true,
   prefix,
   suffix,
+  blur = false,
   className,
   digitClassName,
   locale,
@@ -103,6 +106,7 @@ export function NumberTicker({
               digit={armed ? digit : 0}
               delay={entered ? 0 : i * stagger}
               duration={duration}
+              blur={blur}
               className={digitClassName}
             />
           );
@@ -117,27 +121,61 @@ function Digit({
   digit,
   delay,
   duration,
+  blur,
   className,
 }: {
   digit: number;
   delay: number;
   duration: number;
+  blur: boolean;
   className?: string;
 }) {
   const reduce = useReducedMotion();
+  const columnRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (reduce || !blur || !columnRef.current || !Number.isFinite(digit)) {
+      return;
+    }
+
+    const node = columnRef.current;
+    const controls = animate(
+      node,
+      { filter: ["blur(10px)", "blur(0px)"] },
+      {
+        duration: Math.min(duration * 0.75, 0.32),
+        delay,
+        ease: EASE_OUT,
+      },
+    );
+
+    return () => {
+      controls.stop();
+      node.style.filter = "blur(0px)";
+    };
+  }, [blur, delay, digit, duration, reduce]);
+
   return (
     <span
       className={cn("relative inline-block overflow-hidden", className)}
       style={{ height: `${DIGIT_HEIGHT_EM}em`, width: "1ch" }}
     >
       <motion.span
+        ref={columnRef}
         initial={{ y: 0 }}
         animate={{ y: `-${digit * DIGIT_HEIGHT_EM}em` }}
-        transition={reduce ? { duration: 0 } : { duration, delay, ease: EASE_OUT }}
-        className="absolute inset-x-0 top-0 flex flex-col items-center"
+        transition={
+          reduce
+            ? { duration: 0 }
+            : { duration, delay, ease: EASE_OUT }
+        }
+        className="absolute inset-x-0 top-0 flex flex-col items-center will-change-[transform,filter]"
       >
         {DIGITS.map((n) => (
-          <span key={n} className="flex h-[1.1em] items-center justify-center leading-none">
+          <span
+            key={n}
+            className="flex h-[1.1em] items-center justify-center leading-none"
+          >
             {n}
           </span>
         ))}

--- a/components/motion/prediction-market.tsx
+++ b/components/motion/prediction-market.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Banknote, CheckCircle2, ChevronDown, Loader2 } from "lucide-react";
+import { Banknote, ChevronDown } from "lucide-react";
 import {
   AnimatePresence,
   animate,
@@ -18,6 +18,7 @@ import {
 } from "react";
 import { EASE_OUT } from "@/lib/ease";
 import { cn } from "@/lib/utils";
+import { StatefulButton, type ButtonState } from "./button";
 import { NumberTicker } from "./number-ticker";
 import { Tabs, TabsList, TabsTrigger } from "./tabs";
 
@@ -86,7 +87,6 @@ const MODES: { id: PredictionMarketMode; label: string }[] = [
 ];
 
 const DEFAULT_QUICK_AMOUNTS = [10, 50, 100, 500];
-const FAST_TRANSITION = { duration: 0.16, ease: EASE_OUT } as const;
 const DIGIT_TRANSITION = { duration: 0.18, ease: EASE_OUT } as const;
 type AmountInputStyle = CSSProperties & { "--amount-chars": string };
 
@@ -456,15 +456,14 @@ export function PredictionMarket({
 
   const inputSize = amountInputSize(order.amount);
   const payoutSize = payoutTickerSize(quote.payout);
-  const actionLabel = !authenticated
-    ? "Sign In"
-    : status === "placing"
-      ? "Trading"
+  const actionState: ButtonState =
+    status === "placing"
+      ? "loading"
       : status === "filled"
-        ? "Trade filled"
+        ? "success"
         : quote.valid
-          ? "Trade"
-          : quote.error;
+          ? "idle"
+          : "error";
   const showFooter = authenticated;
 
   return (
@@ -563,10 +562,10 @@ export function PredictionMarket({
           ref={amountRef}
           className={cn("rounded-3xl bg-card p-4", classNames?.amount)}
         >
-          <div className="flex min-h-24 flex-col items-center justify-center gap-4 text-center">
+          <div className="flex min-h-24 flex-col items-center justify-center gap-5 text-center">
             <label
               htmlFor={inputId}
-              className="text-xl font-medium text-foreground"
+              className="text-xl font-medium text-foreground mr-6"
             >
               {order.mode === "buy" ? "Amount" : "Shares"}
             </label>
@@ -596,7 +595,7 @@ export function PredictionMarket({
                 type="button"
                 disabled={status === "placing"}
                 onClick={() => addAmount(amount)}
-                className="h-9 rounded-xl bg-background px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-95 disabled:pointer-events-none disabled:opacity-50"
+                className="h-9 rounded-xl bg-background px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 active:scale-95 disabled:pointer-events-none disabled:opacity-50"
               >
                 +{order.mode === "buy" ? formatCompactCurrency(amount) : amount}
               </button>
@@ -605,7 +604,7 @@ export function PredictionMarket({
               type="button"
               disabled={status === "placing"}
               onClick={setMax}
-              className="h-9 rounded-xl bg-background px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-95 disabled:pointer-events-none disabled:opacity-50"
+              className="h-9 rounded-xl bg-background px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 active:scale-95 disabled:pointer-events-none disabled:opacity-50"
             >
               Max
             </button>
@@ -644,56 +643,38 @@ export function PredictionMarket({
             />
           </div>
 
-          <button
-            type="button"
-            disabled={status === "placing"}
+          <StatefulButton
+            state={actionState}
+            variant="primary"
+            size="lg"
+            pressScale={0.98}
             onClick={submit}
+            loadingText="Trading"
+            successText="Trade filled"
+            errorText={quote.error ?? "Enter an amount"}
             className={cn(
-              "flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-primary text-base font-semibold text-primary-foreground transition-[background-color,transform,opacity] duration-150 hover:bg-primary/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground",
+              "h-12 w-full rounded-2xl text-base font-semibold",
               classNames?.action,
             )}
           >
-            <AnimatePresence mode="wait" initial={false}>
-              <motion.span
-                key={actionLabel}
-                initial={
-                  reduce
-                    ? { opacity: 0 }
-                    : { opacity: 0, transform: "translateY(4px)" }
-                }
-                animate={{ opacity: 1, transform: "translateY(0px)" }}
-                exit={
-                  reduce
-                    ? { opacity: 0 }
-                    : { opacity: 0, transform: "translateY(-4px)" }
-                }
-                transition={FAST_TRANSITION}
-                className="inline-flex items-center gap-2"
-              >
-                {status === "placing" ? (
-                  <Loader2
-                    className={cn("h-4 w-4", !reduce && "animate-spin")}
-                  />
-                ) : status === "filled" ? (
-                  <CheckCircle2 className="h-4 w-4" />
-                ) : null}
-                {actionLabel}
-              </motion.span>
-            </AnimatePresence>
-          </button>
+            Trade
+          </StatefulButton>
         </div>
       ) : (
         <div className="px-4 pb-5">
-          <button
-            type="button"
+          <StatefulButton
+            state="idle"
+            variant="primary"
+            size="lg"
+            pressScale={0.98}
             onClick={submit}
             className={cn(
-              "flex h-14 w-full items-center justify-center rounded-2xl bg-foreground text-base font-semibold text-background transition-transform duration-150 active:scale-[0.98]",
+              "h-14 w-full rounded-2xl text-base font-semibold",
               classNames?.action,
             )}
           >
-            {actionLabel}
-          </button>
+            Sign In
+          </StatefulButton>
         </div>
       )}
     </div>

--- a/components/motion/prediction-market.tsx
+++ b/components/motion/prediction-market.tsx
@@ -14,9 +14,11 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
 } from "react";
 import { EASE_OUT } from "@/lib/ease";
 import { cn } from "@/lib/utils";
+import { NumberTicker } from "./number-ticker";
 import { Tabs, TabsList, TabsTrigger } from "./tabs";
 
 export type PredictionMarketMode = "buy" | "sell";
@@ -86,6 +88,7 @@ const MODES: { id: PredictionMarketMode; label: string }[] = [
 const DEFAULT_QUICK_AMOUNTS = [10, 50, 100, 500];
 const FAST_TRANSITION = { duration: 0.16, ease: EASE_OUT } as const;
 const DIGIT_TRANSITION = { duration: 0.18, ease: EASE_OUT } as const;
+type AmountInputStyle = CSSProperties & { "--amount-chars": string };
 
 function useControllableOrder({
   value,
@@ -225,55 +228,125 @@ function buildQuote({
   };
 }
 
-function RollingValue({
+function keyedAmountChars(value: string) {
+  const seen = new Map<string, number>();
+  return value.split("").map((char) => {
+    const count = seen.get(char) ?? 0;
+    seen.set(char, count + 1);
+    return { id: `${char}-${count}`, char };
+  });
+}
+
+function amountInputSize(value: string) {
+  const length = value.replace(/\D/g, "").length;
+  if (length >= 10) return "text-3xl sm:text-4xl";
+  if (length >= 8) return "text-4xl sm:text-5xl";
+  if (length >= 6) return "text-[44px] sm:text-[56px]";
+  return "text-5xl sm:text-6xl";
+}
+
+function payoutTickerSize(value: number) {
+  const length = formatCurrency(value).length;
+  if (length >= 16) return "text-xl sm:text-2xl";
+  if (length >= 13) return "text-2xl";
+  if (length >= 10) return "text-3xl";
+  return "text-4xl";
+}
+
+function AnimatedAmountInput({
+  id,
   value,
+  mode,
+  inputSize,
+  disabled,
   reduce,
-  muted,
+  onChange,
 }: {
+  id: string;
   value: string;
+  mode: PredictionMarketMode;
+  inputSize: string;
+  disabled: boolean;
   reduce: boolean;
-  muted?: boolean;
+  onChange: (value: string) => void;
 }) {
-  const chars = value.split("");
+  const displayValue = value || "0";
+  const chars = keyedAmountChars(displayValue);
+  const inputStyle = {
+    "--amount-chars": String(chars.length),
+  } as AmountInputStyle;
+  const label = mode === "buy" ? "Amount" : "Shares";
 
   return (
-    <span
-      aria-hidden
-      className={cn(
-        "flex justify-center overflow-hidden text-5xl font-semibold leading-none tracking-tight tabular-nums sm:text-6xl",
-        muted ? "text-muted-foreground/55" : "text-foreground",
-      )}
-    >
-      {chars.map((char, index) => (
+    <div className="flex min-w-0 items-center justify-center overflow-hidden">
+      {mode === "buy" ? (
         <span
-          // biome-ignore lint/suspicious/noArrayIndexKey: fixed character slots for rolling display.
-          key={`${index}-${char}`}
-          className="relative inline-block min-w-[0.55em] overflow-hidden"
+          aria-hidden
+          className={cn(
+            "shrink-0 font-semibold leading-none tracking-normal text-muted-foreground/65 tabular-nums transition-[font-size] duration-200",
+            inputSize,
+          )}
         >
-          <AnimatePresence mode="popLayout" initial={false}>
-            <motion.span
-              // biome-ignore lint/suspicious/noArrayIndexKey: fixed visual character slots, animated by position.
-              key={`${index}-${char}`}
-              initial={
-                reduce
-                  ? { opacity: 0 }
-                  : { opacity: 0, transform: "translateY(70%)" }
-              }
-              animate={{ opacity: 1, transform: "translateY(0%)" }}
-              exit={
-                reduce
-                  ? { opacity: 0 }
-                  : { opacity: 0, transform: "translateY(-70%)" }
-              }
-              transition={DIGIT_TRANSITION}
-              className="inline-block"
-            >
-              {char}
-            </motion.span>
-          </AnimatePresence>
+          $
         </span>
-      ))}
-    </span>
+      ) : null}
+
+      <div className="relative min-w-0 shrink">
+        <input
+          id={id}
+          value={value}
+          disabled={disabled}
+          onChange={(event) => onChange(sanitizeAmount(event.target.value))}
+          placeholder="0"
+          inputMode="decimal"
+          aria-label={label}
+          autoComplete="off"
+          className={cn(
+            "w-[calc((var(--amount-chars)+1)*0.62em)] min-w-[0.8em] max-w-[260px] bg-transparent text-left font-semibold leading-none tracking-normal text-transparent outline-none tabular-nums",
+            "caret-foreground transition-[font-size] duration-200 placeholder:text-transparent selection:bg-foreground/10 disabled:cursor-not-allowed",
+            inputSize,
+          )}
+          style={inputStyle}
+        />
+        <div
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-0 flex min-w-0 items-center justify-start overflow-hidden font-semibold leading-none tracking-normal text-foreground tabular-nums transition-[font-size] duration-200",
+            !value && "text-muted-foreground/55",
+            inputSize,
+          )}
+          style={inputStyle}
+        >
+          <AnimatePresence initial={false} mode="popLayout">
+            {chars.map(({ id: charId, char }) => (
+              <motion.span
+                key={charId}
+                layout={reduce ? false : "position"}
+                initial={
+                  reduce
+                    ? { opacity: 0 }
+                    : { opacity: 0, y: 18, filter: "blur(10px)" }
+                }
+                animate={
+                  reduce
+                    ? { opacity: 1 }
+                    : { opacity: 1, y: 0, filter: "blur(0px)" }
+                }
+                exit={
+                  reduce
+                    ? { opacity: 0 }
+                    : { opacity: 0, y: -14, filter: "blur(10px)" }
+                }
+                transition={DIGIT_TRANSITION}
+                className="inline-block min-w-[0.55em] text-center will-change-[transform,opacity,filter]"
+              >
+                {char}
+              </motion.span>
+            ))}
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -381,8 +454,8 @@ export function PredictionMarket({
     }, 650);
   };
 
-  const amountDisplay =
-    order.mode === "buy" ? `$${order.amount || "0"}` : `${order.amount || "0"}`;
+  const inputSize = amountInputSize(order.amount);
+  const payoutSize = payoutTickerSize(quote.payout);
   const actionLabel = !authenticated
     ? "Sign In"
     : status === "placing"
@@ -397,7 +470,7 @@ export function PredictionMarket({
   return (
     <div
       className={cn(
-        "w-full max-w-[400px] overflow-hidden rounded-3xl border border-border bg-card",
+        "w-full max-w-[400px] overflow-hidden rounded-3xl border border-border bg-background",
         className,
         classNames?.root,
       )}
@@ -452,7 +525,7 @@ export function PredictionMarket({
           variant="pill"
           className={classNames?.outcomes}
         >
-          <TabsList className="grid w-full grid-cols-2 gap-2 rounded-[1.75rem] bg-muted p-1.5">
+          <TabsList className="grid w-full grid-cols-2 gap-2 p-1.5">
             {outcomes.map((outcome) => {
               const selected = outcome.id === selectedOutcome.id;
               const isNo =
@@ -488,7 +561,7 @@ export function PredictionMarket({
 
         <div
           ref={amountRef}
-          className={cn("rounded-3xl bg-background p-4", classNames?.amount)}
+          className={cn("rounded-3xl bg-card p-4", classNames?.amount)}
         >
           <div className="flex min-h-24 flex-col items-center justify-center gap-4 text-center">
             <label
@@ -498,22 +571,15 @@ export function PredictionMarket({
               {order.mode === "buy" ? "Amount" : "Shares"}
             </label>
 
-            <div className="relative w-full min-w-0 text-center">
-              <RollingValue
-                value={amountDisplay}
-                reduce={reduce}
-                muted={order.amount === ""}
-              />
-              <input
+            <div className="w-full min-w-0">
+              <AnimatedAmountInput
                 id={inputId}
+                mode={order.mode}
                 value={order.amount}
                 disabled={status === "placing"}
-                onChange={(event) =>
-                  setOrderValue({ amount: sanitizeAmount(event.target.value) })
-                }
-                inputMode="decimal"
-                aria-label={order.mode === "buy" ? "Amount" : "Shares"}
-                className="absolute inset-0 z-10 h-full w-full cursor-text bg-transparent text-center text-5xl text-transparent caret-transparent outline-none disabled:cursor-not-allowed"
+                inputSize={inputSize}
+                reduce={reduce}
+                onChange={(amount) => setOrderValue({ amount })}
               />
             </div>
           </div>
@@ -530,7 +596,7 @@ export function PredictionMarket({
                 type="button"
                 disabled={status === "placing"}
                 onClick={() => addAmount(amount)}
-                className="h-9 rounded-xl border border-border/50 bg-card px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-95 disabled:pointer-events-none disabled:opacity-50"
+                className="h-9 rounded-xl bg-background px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-95 disabled:pointer-events-none disabled:opacity-50"
               >
                 +{order.mode === "buy" ? formatCompactCurrency(amount) : amount}
               </button>
@@ -539,7 +605,7 @@ export function PredictionMarket({
               type="button"
               disabled={status === "placing"}
               onClick={setMax}
-              className="h-9 rounded-xl border border-border/50 bg-card px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-95 disabled:pointer-events-none disabled:opacity-50"
+              className="h-9 rounded-xl bg-background px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-95 disabled:pointer-events-none disabled:opacity-50"
             >
               Max
             </button>
@@ -554,8 +620,8 @@ export function PredictionMarket({
             classNames?.footer,
           )}
         >
-          <div className="mb-4 flex items-end justify-between gap-4">
-            <div>
+          <div className="mb-4 flex items-end justify-between gap-3">
+            <div className="min-w-0 shrink">
               <div className="flex items-center gap-2 text-xl font-semibold text-foreground">
                 {order.mode === "buy" ? "To win" : "To receive"}
                 <Banknote className="h-5 w-5 text-emerald-500" />
@@ -564,9 +630,18 @@ export function PredictionMarket({
                 Avg. Price {formatCents(quote.price)}
               </p>
             </div>
-            <div className="text-right text-4xl font-semibold leading-none tracking-tight text-emerald-500 tabular-nums">
-              {formatCurrency(quote.payout)}
-            </div>
+            <NumberTicker
+              value={quote.payout * 100}
+              startOnView={false}
+              duration={0.45}
+              stagger={0}
+              blur
+              className={cn(
+                "ml-auto min-w-0 shrink-0 justify-end whitespace-nowrap text-right font-semibold leading-none tracking-tight text-emerald-500 tabular-nums transition-[font-size] duration-200",
+                payoutSize,
+              )}
+              format={(cents) => formatCurrency(cents / 100)}
+            />
           </div>
 
           <button
@@ -574,7 +649,7 @@ export function PredictionMarket({
             disabled={status === "placing"}
             onClick={submit}
             className={cn(
-              "flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-blue-500 text-base font-semibold text-white transition-[background-color,transform,opacity] duration-150 hover:bg-blue-500/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-70",
+              "flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-primary text-base font-semibold text-primary-foreground transition-[background-color,transform,opacity] duration-150 hover:bg-primary/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground",
               classNames?.action,
             )}
           >

--- a/components/motion/prediction-market.tsx
+++ b/components/motion/prediction-market.tsx
@@ -1,0 +1,626 @@
+"use client";
+
+import { Banknote, CheckCircle2, ChevronDown, Loader2 } from "lucide-react";
+import {
+  AnimatePresence,
+  animate,
+  motion,
+  useReducedMotion,
+} from "motion/react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { EASE_OUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+import { Tabs, TabsList, TabsTrigger } from "./tabs";
+
+export type PredictionMarketMode = "buy" | "sell";
+
+export type PredictionMarketOutcome = {
+  id: string;
+  label: string;
+  price: number;
+};
+
+export type PredictionMarketOrderValue = {
+  mode: PredictionMarketMode;
+  outcomeId: string;
+  amount: string;
+};
+
+export type PredictionMarketQuote = {
+  valid: boolean;
+  amount: number;
+  price: number;
+  shares: number;
+  payout: number;
+  error?: string;
+};
+
+export type PredictionMarketClassNames = {
+  root?: string;
+  header?: string;
+  tabs?: string;
+  outcomes?: string;
+  amount?: string;
+  chips?: string;
+  footer?: string;
+  action?: string;
+};
+
+export interface PredictionMarketProps {
+  outcomes?: PredictionMarketOutcome[];
+  value?: PredictionMarketOrderValue;
+  defaultValue?: Partial<PredictionMarketOrderValue>;
+  onValueChange?: (value: PredictionMarketOrderValue) => void;
+  onTrade?: (
+    order: PredictionMarketOrderValue,
+    quote: PredictionMarketQuote,
+  ) => void;
+  onSignIn?: () => void;
+  authenticated?: boolean;
+  orderTypeLabel?: string;
+  balance?: number;
+  positions?: Record<string, number>;
+  quickAmounts?: number[];
+  minTrade?: number;
+  className?: string;
+  classNames?: PredictionMarketClassNames;
+}
+
+const DEFAULT_OUTCOMES: PredictionMarketOutcome[] = [
+  { id: "up", label: "Up", price: 0.09 },
+  { id: "down", label: "Down", price: 0.91 },
+];
+
+const MODES: { id: PredictionMarketMode; label: string }[] = [
+  { id: "buy", label: "Buy" },
+  { id: "sell", label: "Sell" },
+];
+
+const DEFAULT_QUICK_AMOUNTS = [10, 50, 100, 500];
+const FAST_TRANSITION = { duration: 0.16, ease: EASE_OUT } as const;
+const DIGIT_TRANSITION = { duration: 0.18, ease: EASE_OUT } as const;
+
+function useControllableOrder({
+  value,
+  defaultValue,
+  outcomes,
+  onValueChange,
+}: {
+  value?: PredictionMarketOrderValue;
+  defaultValue?: Partial<PredictionMarketOrderValue>;
+  outcomes: PredictionMarketOutcome[];
+  onValueChange?: (value: PredictionMarketOrderValue) => void;
+}) {
+  const initialValue: PredictionMarketOrderValue = {
+    mode: defaultValue?.mode ?? "buy",
+    outcomeId: defaultValue?.outcomeId ?? outcomes[0]?.id ?? "",
+    amount: defaultValue?.amount ?? "",
+  };
+
+  const [internalValue, setInternalValue] = useState(initialValue);
+  const controlled = value !== undefined;
+  const order = value ?? internalValue;
+
+  const setOrder = useCallback(
+    (next: PredictionMarketOrderValue) => {
+      if (!controlled) {
+        setInternalValue(next);
+      }
+
+      onValueChange?.(next);
+    },
+    [controlled, onValueChange],
+  );
+
+  return [order, setOrder] as const;
+}
+
+function sanitizeAmount(value: string) {
+  const normalized = value.replace(/[^\d.]/g, "");
+  const [whole, ...decimalParts] = normalized.split(".");
+  const decimal = decimalParts.join("");
+  if (decimalParts.length === 0) return whole;
+  return `${whole}.${decimal.slice(0, 2)}`;
+}
+
+function parseAmount(value: string) {
+  return Number(value) || 0;
+}
+
+function formatCurrency(value: number, maximumFractionDigits = 2) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits,
+  }).format(value);
+}
+
+function formatCompactCurrency(value: number) {
+  return value >= 100
+    ? formatCurrency(value, 0)
+    : formatCurrency(value, value % 1 === 0 ? 0 : 2);
+}
+
+function formatCents(value: number) {
+  const cents = value * 100;
+  const precision = Number.isInteger(cents) ? 0 : 1;
+  return `${cents.toFixed(precision)}¢`;
+}
+
+function buildQuote({
+  order,
+  outcome,
+  balance,
+  position,
+  minTrade,
+}: {
+  order: PredictionMarketOrderValue;
+  outcome: PredictionMarketOutcome;
+  balance: number;
+  position: number;
+  minTrade: number;
+}): PredictionMarketQuote {
+  const amount = parseAmount(order.amount);
+  const price = Math.max(0.01, Math.min(0.99, outcome.price));
+  const shares = order.mode === "buy" ? amount / price : amount;
+  const payout = order.mode === "buy" ? shares : amount * price;
+
+  if (amount <= 0) {
+    return {
+      valid: false,
+      amount,
+      price,
+      shares: 0,
+      payout: 0,
+      error: "Enter an amount",
+    };
+  }
+
+  if (order.mode === "buy" && amount < minTrade) {
+    return {
+      valid: false,
+      amount,
+      price,
+      shares,
+      payout,
+      error: `Minimum ${formatCompactCurrency(minTrade)}`,
+    };
+  }
+
+  if (order.mode === "buy" && amount > balance) {
+    return {
+      valid: false,
+      amount,
+      price,
+      shares,
+      payout,
+      error: "Insufficient balance",
+    };
+  }
+
+  if (order.mode === "sell" && amount > position) {
+    return {
+      valid: false,
+      amount,
+      price,
+      shares,
+      payout,
+      error: "Not enough shares",
+    };
+  }
+
+  return {
+    valid: true,
+    amount,
+    price,
+    shares,
+    payout,
+  };
+}
+
+function RollingValue({
+  value,
+  reduce,
+  muted,
+}: {
+  value: string;
+  reduce: boolean;
+  muted?: boolean;
+}) {
+  const chars = value.split("");
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "flex justify-center overflow-hidden text-5xl font-semibold leading-none tracking-tight tabular-nums sm:text-6xl",
+        muted ? "text-muted-foreground/55" : "text-foreground",
+      )}
+    >
+      {chars.map((char, index) => (
+        <span
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed character slots for rolling display.
+          key={`${index}-${char}`}
+          className="relative inline-block min-w-[0.55em] overflow-hidden"
+        >
+          <AnimatePresence mode="popLayout" initial={false}>
+            <motion.span
+              // biome-ignore lint/suspicious/noArrayIndexKey: fixed visual character slots, animated by position.
+              key={`${index}-${char}`}
+              initial={
+                reduce
+                  ? { opacity: 0 }
+                  : { opacity: 0, transform: "translateY(70%)" }
+              }
+              animate={{ opacity: 1, transform: "translateY(0%)" }}
+              exit={
+                reduce
+                  ? { opacity: 0 }
+                  : { opacity: 0, transform: "translateY(-70%)" }
+              }
+              transition={DIGIT_TRANSITION}
+              className="inline-block"
+            >
+              {char}
+            </motion.span>
+          </AnimatePresence>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function PredictionMarket({
+  outcomes = DEFAULT_OUTCOMES,
+  value,
+  defaultValue,
+  onValueChange,
+  onTrade,
+  onSignIn,
+  authenticated = true,
+  orderTypeLabel = "Market",
+  balance = 500,
+  positions = { up: 24, down: 16 },
+  quickAmounts = DEFAULT_QUICK_AMOUNTS,
+  minTrade = 1,
+  className,
+  classNames,
+}: PredictionMarketProps) {
+  const inputId = useId();
+  const reduce = useReducedMotion() ?? false;
+  const amountRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [status, setStatus] = useState<"idle" | "placing" | "filled">("idle");
+  const [shakeKey, setShakeKey] = useState(0);
+  const [order, setOrder] = useControllableOrder({
+    value,
+    defaultValue,
+    outcomes,
+    onValueChange,
+  });
+
+  const selectedOutcome =
+    outcomes.find((outcome) => outcome.id === order.outcomeId) ?? outcomes[0];
+  const position = positions[selectedOutcome.id] ?? 0;
+  const quote = useMemo(
+    () =>
+      buildQuote({
+        order,
+        outcome: selectedOutcome,
+        balance,
+        position,
+        minTrade,
+      }),
+    [balance, minTrade, order, position, selectedOutcome],
+  );
+
+  const setOrderValue = useCallback(
+    (next: Partial<PredictionMarketOrderValue>) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+
+      setStatus("idle");
+      setOrder({ ...order, ...next });
+    },
+    [order, setOrder],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (shakeKey === 0 || reduce || !amountRef.current) return;
+    animate(
+      amountRef.current,
+      { x: [0, -5, 5, -3, 3, -1, 0] },
+      { duration: 0.38, ease: EASE_OUT },
+    );
+  }, [reduce, shakeKey]);
+
+  const addAmount = (increment: number) => {
+    const next = parseAmount(order.amount) + increment;
+    setOrderValue({ amount: String(next) });
+  };
+
+  const setMax = () => {
+    if (order.mode === "buy") {
+      setOrderValue({ amount: String(Math.floor(balance)) });
+      return;
+    }
+
+    setOrderValue({ amount: position.toFixed(position % 1 === 0 ? 0 : 2) });
+  };
+
+  const submit = () => {
+    if (!authenticated) {
+      onSignIn?.();
+      return;
+    }
+
+    if (!quote.valid) {
+      setShakeKey((key) => key + 1);
+      return;
+    }
+
+    setStatus("placing");
+    timeoutRef.current = setTimeout(() => {
+      setStatus("filled");
+      onTrade?.(order, quote);
+    }, 650);
+  };
+
+  const amountDisplay =
+    order.mode === "buy" ? `$${order.amount || "0"}` : `${order.amount || "0"}`;
+  const actionLabel = !authenticated
+    ? "Sign In"
+    : status === "placing"
+      ? "Trading"
+      : status === "filled"
+        ? "Trade filled"
+        : quote.valid
+          ? "Trade"
+          : quote.error;
+  const showFooter = authenticated;
+
+  return (
+    <div
+      className={cn(
+        "w-full max-w-[400px] overflow-hidden rounded-3xl border border-border bg-card",
+        className,
+        classNames?.root,
+      )}
+    >
+      <div
+        className={cn(
+          "border-b border-border/80 px-4 pt-4",
+          classNames?.header,
+        )}
+      >
+        <div className="flex items-end justify-between gap-4">
+          <Tabs
+            value={order.mode}
+            onValueChange={(mode) =>
+              setOrderValue({
+                mode: mode as PredictionMarketMode,
+                amount: "",
+              })
+            }
+            variant="underline"
+            className={cn("shrink-0", classNames?.tabs)}
+          >
+            <TabsList className="gap-5 border-b-0 bg-transparent p-0">
+              {MODES.map((mode) => (
+                <TabsTrigger
+                  key={mode.id}
+                  value={mode.id}
+                  className="px-0 pb-3 pt-0 text-2xl font-semibold"
+                  indicatorClassName="h-0.5 bg-foreground"
+                >
+                  {mode.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+
+          <button
+            type="button"
+            disabled={status === "placing"}
+            className="mb-3 inline-flex items-center gap-2 text-xl font-semibold text-foreground transition-opacity disabled:opacity-50"
+          >
+            {orderTypeLabel}
+            <ChevronDown className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-4 p-3">
+        <Tabs
+          value={selectedOutcome.id}
+          onValueChange={(outcomeId) => setOrderValue({ outcomeId })}
+          variant="pill"
+          className={classNames?.outcomes}
+        >
+          <TabsList className="grid w-full grid-cols-2 gap-2 rounded-[1.75rem] bg-muted p-1.5">
+            {outcomes.map((outcome) => {
+              const selected = outcome.id === selectedOutcome.id;
+              const isNo =
+                outcome.label.toLowerCase() === "no" ||
+                outcome.label.toLowerCase() === "down";
+
+              return (
+                <TabsTrigger
+                  key={outcome.id}
+                  value={outcome.id}
+                  indicatorClassName={
+                    isNo
+                      ? "bg-red-500/10 dark:bg-red-500/15"
+                      : "bg-emerald-500/20"
+                  }
+                  className={cn(
+                    "h-14 w-full rounded-[1.35rem] px-0 py-0 text-base font-semibold active:scale-[0.99]",
+                    isNo
+                      ? selected
+                        ? "text-red-300 dark:text-red-300"
+                        : "text-red-300/55 dark:text-red-300/50"
+                      : selected
+                        ? "text-emerald-400 dark:text-emerald-300"
+                        : "text-muted-foreground",
+                  )}
+                >
+                  {outcome.label} {formatCents(outcome.price)}
+                </TabsTrigger>
+              );
+            })}
+          </TabsList>
+        </Tabs>
+
+        <div
+          ref={amountRef}
+          className={cn("rounded-3xl bg-background p-4", classNames?.amount)}
+        >
+          <div className="flex min-h-24 flex-col items-center justify-center gap-4 text-center">
+            <label
+              htmlFor={inputId}
+              className="text-xl font-medium text-foreground"
+            >
+              {order.mode === "buy" ? "Amount" : "Shares"}
+            </label>
+
+            <div className="relative w-full min-w-0 text-center">
+              <RollingValue
+                value={amountDisplay}
+                reduce={reduce}
+                muted={order.amount === ""}
+              />
+              <input
+                id={inputId}
+                value={order.amount}
+                disabled={status === "placing"}
+                onChange={(event) =>
+                  setOrderValue({ amount: sanitizeAmount(event.target.value) })
+                }
+                inputMode="decimal"
+                aria-label={order.mode === "buy" ? "Amount" : "Shares"}
+                className="absolute inset-0 z-10 h-full w-full cursor-text bg-transparent text-center text-5xl text-transparent caret-transparent outline-none disabled:cursor-not-allowed"
+              />
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              "mt-8 flex flex-wrap justify-center gap-2",
+              classNames?.chips,
+            )}
+          >
+            {quickAmounts.map((amount) => (
+              <button
+                key={amount}
+                type="button"
+                disabled={status === "placing"}
+                onClick={() => addAmount(amount)}
+                className="h-9 rounded-xl border border-border/50 bg-card px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-95 disabled:pointer-events-none disabled:opacity-50"
+              >
+                +{order.mode === "buy" ? formatCompactCurrency(amount) : amount}
+              </button>
+            ))}
+            <button
+              type="button"
+              disabled={status === "placing"}
+              onClick={setMax}
+              className="h-9 rounded-xl border border-border/50 bg-card px-3.5 text-sm font-semibold text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-95 disabled:pointer-events-none disabled:opacity-50"
+            >
+              Max
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {showFooter ? (
+        <div
+          className={cn(
+            "border-t border-border/80 px-4 py-4",
+            classNames?.footer,
+          )}
+        >
+          <div className="mb-4 flex items-end justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2 text-xl font-semibold text-foreground">
+                {order.mode === "buy" ? "To win" : "To receive"}
+                <Banknote className="h-5 w-5 text-emerald-500" />
+              </div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Avg. Price {formatCents(quote.price)}
+              </p>
+            </div>
+            <div className="text-right text-4xl font-semibold leading-none tracking-tight text-emerald-500 tabular-nums">
+              {formatCurrency(quote.payout)}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            disabled={status === "placing"}
+            onClick={submit}
+            className={cn(
+              "flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-blue-500 text-base font-semibold text-white transition-[background-color,transform,opacity] duration-150 hover:bg-blue-500/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-70",
+              classNames?.action,
+            )}
+          >
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.span
+                key={actionLabel}
+                initial={
+                  reduce
+                    ? { opacity: 0 }
+                    : { opacity: 0, transform: "translateY(4px)" }
+                }
+                animate={{ opacity: 1, transform: "translateY(0px)" }}
+                exit={
+                  reduce
+                    ? { opacity: 0 }
+                    : { opacity: 0, transform: "translateY(-4px)" }
+                }
+                transition={FAST_TRANSITION}
+                className="inline-flex items-center gap-2"
+              >
+                {status === "placing" ? (
+                  <Loader2
+                    className={cn("h-4 w-4", !reduce && "animate-spin")}
+                  />
+                ) : status === "filled" ? (
+                  <CheckCircle2 className="h-4 w-4" />
+                ) : null}
+                {actionLabel}
+              </motion.span>
+            </AnimatePresence>
+          </button>
+        </div>
+      ) : (
+        <div className="px-4 pb-5">
+          <button
+            type="button"
+            onClick={submit}
+            className={cn(
+              "flex h-14 w-full items-center justify-center rounded-2xl bg-foreground text-base font-semibold text-background transition-transform duration-150 active:scale-[0.98]",
+              classNames?.action,
+            )}
+          >
+            {actionLabel}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/motion/tabs.tsx
+++ b/components/motion/tabs.tsx
@@ -84,7 +84,17 @@ export function TabsList({ children, className }: { children: ReactNode; classNa
   );
 }
 
-export function TabsTrigger({ value, children, className }: { value: string; children: ReactNode; className?: string }) {
+export function TabsTrigger({
+  value,
+  children,
+  className,
+  indicatorClassName,
+}: {
+  value: string;
+  children: ReactNode;
+  className?: string;
+  indicatorClassName?: string;
+}) {
   const { value: current, setValue, layoutId, variant } = useTabs();
   const active = current === value;
 
@@ -103,10 +113,13 @@ export function TabsTrigger({ value, children, className }: { value: string; chi
       >
         {children}
         {active ? (
-          <motion.span
-            layoutId={layoutId}
-            className="absolute -bottom-px left-0 right-0 h-px bg-primary"
-          />
+        <motion.span
+          layoutId={layoutId}
+          className={cn(
+            "absolute -bottom-px left-0 right-0 h-px bg-primary",
+            indicatorClassName,
+          )}
+        />
         ) : null}
       </button>
     );
@@ -123,8 +136,9 @@ export function TabsTrigger({ value, children, className }: { value: string; chi
           layoutId={layoutId}
           style={{ borderRadius: variant === "pill" ? 9999 : 8 }}
           className={cn(
-            "absolute inset-0 bg-primary shadow-sm",
+            "absolute inset-0 bg-primary",
             radius,
+            indicatorClassName,
           )}
         />
       ) : null}

--- a/components/previews/blocks/prediction-market.preview.tsx
+++ b/components/previews/blocks/prediction-market.preview.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import {
+  PredictionMarket,
+  type PredictionMarketOrderValue,
+} from "@/components/motion/prediction-market";
+
+const outcomes = [
+  {
+    id: "yes",
+    label: "Yes",
+    price: 0.167,
+  },
+  {
+    id: "no",
+    label: "No",
+    price: 0.834,
+  },
+];
+
+export function PredictionMarketPreview() {
+  const [order, setOrder] = useState<PredictionMarketOrderValue>({
+    mode: "buy",
+    outcomeId: "yes",
+    amount: "115",
+  });
+
+  return (
+    <div className="flex w-full items-center justify-center">
+      <PredictionMarket
+        outcomes={outcomes}
+        value={order}
+        onValueChange={setOrder}
+        balance={500}
+        positions={{ yes: 125, no: 48 }}
+        quickAmounts={[1, 5, 10, 100]}
+      />
+    </div>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -25,6 +25,11 @@ export const previews: Record<string, ComponentType> = {
   "blocks/file-upload": dynamic(() =>
     import("./blocks/file-upload.preview").then((m) => m.FileUploadPreview),
   ),
+  "blocks/prediction-market": dynamic(() =>
+    import("./blocks/prediction-market.preview").then(
+      (m) => m.PredictionMarketPreview,
+    ),
+  ),
   "motion/bouncy-accordion": dynamic(() =>
     import("./motion/bouncy-accordion.preview").then(
       (m) => m.BouncyAccordionPreview,

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -310,6 +310,13 @@ export const registry: CategoryEntry[] = [
         badge: "new",
       },
       {
+        slug: "prediction-market",
+        name: "Prediction Market",
+        description: "Prediction market trade ticket with buy/sell modes, outcome prices, rolling amount entry, quick add chips and trade states.",
+        file: "components/motion/prediction-market.tsx",
+        badge: "new",
+      },
+      {
         slug: "otp-input",
         name: "OTP Input",
         description: "One-time-code input with a gliding focus ring, digits that roll in per slot, error shake and a success check draw.",


### PR DESCRIPTION
## Summary
- add the prediction market block with pilled/underline tabs, amount controls, quote footer, and trade states
- reuse NumberTicker for payout motion and StatefulButton for the CTA
- refine amount and payout number animations with reduced-motion handling

## Checks
- bun run typecheck
- bun run lint
- bun run check:registry