### PR TITLE
feat: landing page redesign

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   type ComponentExample,
 } from "@/lib/registry";
 import { CodeBlock } from "@/components/app/code-block";
+import { InstallCommand } from "@/components/app/install-command";
 import {
   Tabs,
   TabsContent,
@@ -125,7 +126,6 @@ export default async function ComponentPage({
   const cat = findCategory(category);
   const comp = findComponent(category, slug);
   if (!cat || !comp) notFound();
-  const installCommand = `npx shadcn@latest add @beui/${comp.slug}`;
   const hasVariantInstallCommands =
     comp.examples?.some((example) => example.installSlug) ?? false;
 
@@ -165,14 +165,14 @@ export default async function ComponentPage({
       )}
 
       {!hasVariantInstallCommands ? (
-        <section className="mt-12 grid gap-6 border-t border-(--color-border) pt-8">
-          <div>
+        <section className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-6 border-t border-(--color-border) pt-8">
+          <div className="min-w-0">
             <h2 className="text-sm font-semibold text-(--color-fg)">Install</h2>
             <p className="mt-1 text-sm text-(--color-fg-muted)">
               Add this component with the shadcn CLI.
             </p>
             <div className="mt-3">
-              <CodeBlock code={installCommand} lang="bash" />
+              <InstallCommand slug={comp.slug} />
             </div>
           </div>
         </section>
@@ -185,9 +185,7 @@ async function ExampleBlock({ example }: { example: ComponentExample }) {
   const Preview = previews[example.previewKey];
   const source = await loadSource(example.file);
   const usage = await loadSource(example.previewFile);
-  const installCommand = example.installSlug
-    ? `npx shadcn@latest add @beui/${example.installSlug}`
-    : null;
+  const installSlug = example.installSlug ?? null;
 
   return (
     <section>
@@ -222,11 +220,11 @@ async function ExampleBlock({ example }: { example: ComponentExample }) {
           <CodeBlock code={source} filename={example.file} />
         </TabsContent>
       </Tabs>
-      {installCommand ? (
-        <div className="mt-5 border-t border-(--color-border) pt-5">
+      {installSlug ? (
+        <div className="mt-5 min-w-0 border-t border-(--color-border) pt-5">
           <h3 className="text-sm font-semibold text-(--color-fg)">Install</h3>
           <div className="mt-3">
-            <CodeBlock code={installCommand} lang="bash" filename="terminal" />
+            <InstallCommand slug={installSlug} />
           </div>
         </div>
       ) : null}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -73,8 +73,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             <SiteFrame>{children}</SiteFrame>
           </main>
           <SiteDock />
-          <Analytics />
-          <SpeedInsights />
+          {process.env.NODE_ENV === "production" && <Analytics />}
+          {process.env.NODE_ENV === "production" && <SpeedInsights />}
           <GoogleAnalytics measurementId={googleAnalyticsId} />
         </ThemeProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,17 +2,30 @@ import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { registry } from "@/lib/registry";
 import { Hero } from "@/components/app/hero";
+import { InstallCommand } from "@/components/app/install-command";
 import { LandingComponentCard } from "@/components/app/landing-component-card";
+import { SiteFooter } from "@/components/app/site-footer";
+
+const CURATED: { category: string; slug: string }[] = [
+  { category: "motion", slug: "button" },
+  { category: "motion", slug: "morphing-modal" },
+  { category: "motion", slug: "animated-toast-stack" },
+  { category: "motion", slug: "action-swap" },
+  { category: "motion", slug: "dock" },
+  { category: "motion", slug: "tabs" },
+  { category: "blocks", slug: "dynamic-island" },
+  { category: "blocks", slug: "command-palette" },
+  { category: "blocks", slug: "expandable-action-bar" },
+  { category: "blocks", slug: "expandable-tabs" },
+];
 
 export default function Home() {
-  const motionCategory = registry[0];
-  const blocksCategory = registry[1];
-  const motionComponents = motionCategory.components.filter(
-    (component) => component.badge !== "new",
-  );
-  const blockComponents = blocksCategory.components.filter(
-    (component) => component.badge !== "new",
-  );
+  const curatedComponents = CURATED.flatMap(({ category, slug }) => {
+    const cat = registry.find((c) => c.slug === category);
+    const comp = cat?.components.find((c) => c.slug === slug);
+    return comp ? [{ category, component: comp }] : [];
+  });
+
   const newComponents = registry.flatMap((category) =>
     category.components
       .filter((component) => component.badge === "new")
@@ -25,6 +38,13 @@ export default function Home() {
         <Hero />
       </section>
 
+      <section className="mx-auto max-w-2xl px-4 pb-24">
+        <p className="mb-5 text-center text-sm text-(--color-fg-muted)">
+          Built on Motion. Distributed via shadcn.
+        </p>
+        <InstallCommand />
+      </section>
+
       {newComponents.length ? (
         <section className="mx-auto max-w-7xl px-4 pb-16">
           <div className="mb-8 flex flex-col gap-4 border-t border-(--color-border) pt-12 md:flex-row md:items-center md:justify-between">
@@ -32,7 +52,7 @@ export default function Home() {
               <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
                 New
               </p>
-              <h2 className="mt-2 max-w-2xl font-pixel text-3xl font-medium leading-tight text-(--color-fg) md:text-4xl">
+              <h2 className="mt-2 font-pixel text-3xl font-medium leading-tight text-(--color-fg) md:text-4xl">
                 Recently launched.
               </h2>
             </div>
@@ -55,8 +75,8 @@ export default function Home() {
             <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
               Components
             </p>
-            <h2 className="mt-2 max-w-2xl font-pixel text-3xl font-medium leading-tight text-(--color-fg) md:text-4xl">
-              {motionComponents.length} components.
+            <h2 className="mt-2 font-pixel text-3xl font-medium leading-tight text-(--color-fg) md:text-4xl">
+              Motion primitives.
             </h2>
           </div>
           <Link
@@ -67,35 +87,17 @@ export default function Home() {
           </Link>
         </div>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-          {motionComponents.map((comp) => (
-            <LandingComponentCard key={comp.slug} component={comp} category="motion" />
+          {curatedComponents.map(({ category, component }) => (
+            <LandingComponentCard
+              key={`${category}-${component.slug}`}
+              component={component}
+              category={category}
+            />
           ))}
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-4 pb-28">
-        <div className="mb-8 flex flex-col gap-4 border-t border-(--color-border) pt-12 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
-              Blocks
-            </p>
-            <h2 className="mt-2 max-w-2xl font-pixel text-3xl font-medium leading-tight text-(--color-fg) md:text-4xl">
-              {blockComponents.length} blocks.
-            </h2>
-          </div>
-          <Link
-            href="/components/blocks"
-            className="inline-flex items-center self-start text-sm font-medium text-(--color-fg-muted) hover:text-(--color-fg) md:self-center"
-          >
-            Browse all <ArrowRight className="ml-1 h-3.5 w-3.5" />
-          </Link>
-        </div>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-          {blockComponents.map((comp) => (
-            <LandingComponentCard key={comp.slug} component={comp} category="blocks" />
-          ))}
-        </div>
-      </section>
+      <SiteFooter />
     </div>
   );
 }

--- a/components/app/code-block.tsx
+++ b/components/app/code-block.tsx
@@ -1,4 +1,3 @@
-// components/code-block.tsx
 import { codeToHtml } from "shiki";
 import {
   transformerNotationHighlight,
@@ -82,9 +81,7 @@ export async function CodeBlock({
 
             <FileIcon className="h-3.5 w-3.5 shrink-0 text-(--color-fg-muted)" />
             <span className="truncate font-mono text-(--color-fg-muted)">
-              {fileDir && (
-                <span className="opacity-60">{fileDir}/</span>
-              )}
+              {fileDir && <span className="opacity-60">{fileDir}/</span>}
               <span className="text-(--color-fg) font-medium">{fileName}</span>
             </span>
           </div>

--- a/components/app/hero.tsx
+++ b/components/app/hero.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { ArrowRight, ArrowUpRight } from "lucide-react";
 import { motion } from "motion/react";
+import { ArrowRight, ArrowUpRight } from "lucide-react";
 import { EASE_OUT } from "@/lib/ease";
 import { GithubIcon } from "@/components/app/icons";
 import { PressLink } from "@/components/app/press-link";
 import { TextReveal } from "@/components/motion/text-reveal";
-import { DynamicIslandPreview } from "@/components/previews/blocks/dynamic-island.preview";
-import { OverflowActionsPreview } from "@/components/previews/blocks/overflow-actions.preview";
-import { ExpandableTabsPreview } from "@/components/previews/blocks/expandable-tabs.preview";
 
 const HEADLINE = ["Motion", "components", "for React."];
 const HEADLINE_WORDS = HEADLINE.reduce((n, l) => n + l.split(" ").length, 0);
@@ -19,10 +16,9 @@ export function Hero() {
   const headlineEnd = START + HEADLINE_WORDS * STAGGER;
   const subDelay = headlineEnd + 0.05;
   const ctaDelay = subDelay + 0.25;
-  const demoDelay = ctaDelay + 0.1;
 
   return (
-    <div className="mx-auto max-w-5xl text-center">
+    <div className="mx-auto max-w-7xl text-center">
       <motion.div
         initial={{ opacity: 0, y: 6 }}
         animate={{ opacity: 1, y: 0 }}
@@ -66,7 +62,7 @@ export function Hero() {
       >
         <PressLink
           href="/components/motion"
-          className="group inline-flex h-11 items-center gap-2 rounded-full bg-(--color-fg) px-6 text-sm font-medium text-(--color-bg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
+          className="group inline-flex h-10 items-center gap-2 rounded-full bg-(--color-fg) px-4 text-sm font-medium text-(--color-bg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
         >
           Browse components
           <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
@@ -75,40 +71,11 @@ export function Hero() {
           href="https://github.com/starc007/ui-components"
           target="_blank"
           rel="noreferrer noopener"
-          className="inline-flex h-11 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-6 text-sm font-medium text-(--color-fg) hover:border-(--color-border-strong) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
+          className="inline-flex h-10 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-4 text-sm font-medium text-(--color-fg) hover:border-(--color-border-strong) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
         >
           <GithubIcon className="h-4 w-4" />
           GitHub
         </PressLink>
-      </motion.div>
-
-      {/* Demo */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.65, ease: EASE_OUT, delay: demoDelay }}
-        className="mt-14 overflow-hidden rounded-2xl border border-(--color-border)"
-        style={{
-          background:
-            "radial-gradient(ellipse 60% 80% at 10% 50%, color-mix(in srgb, #7c3aed 18%, transparent), transparent 70%), radial-gradient(ellipse 50% 70% at 90% 20%, color-mix(in srgb, #0ea5e9 14%, transparent), transparent 65%), radial-gradient(ellipse 40% 60% at 60% 90%, color-mix(in srgb, #f59e0b 10%, transparent), transparent 60%), var(--color-bg)",
-        }}
-      >
-        {/* Top row: Dynamic Island (wide) + Overflow Actions */}
-        <div className="grid h-[260px] grid-cols-[1fr_260px] border-b border-(--color-border)">
-          <div className="overflow-hidden border-r border-(--color-border) p-6">
-            <DynamicIslandPreview />
-          </div>
-          <div className="flex items-center justify-center overflow-hidden p-6">
-            <OverflowActionsPreview />
-          </div>
-        </div>
-
-        {/* Bottom row: Expandable Tabs full width */}
-        <div className="relative h-[200px] overflow-hidden">
-          <div className="absolute bottom-0 left-0 right-0">
-            <ExpandableTabsPreview />
-          </div>
-        </div>
       </motion.div>
     </div>
   );

--- a/components/app/hero.tsx
+++ b/components/app/hero.tsx
@@ -1,223 +1,113 @@
 "use client";
 
 import { ArrowRight, ArrowUpRight } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { motion } from "motion/react";
 import { EASE_OUT } from "@/lib/ease";
-import { useEffect, useState } from "react";
 import { GithubIcon } from "@/components/app/icons";
 import { PressLink } from "@/components/app/press-link";
-import { AnimatedBadge } from "@/components/motion/animated-badge";
-import { StatefulButton } from "@/components/motion/button";
-import { Switch } from "@/components/motion/switch";
 import { TextReveal } from "@/components/motion/text-reveal";
+import { DynamicIslandPreview } from "@/components/previews/blocks/dynamic-island.preview";
+import { OverflowActionsPreview } from "@/components/previews/blocks/overflow-actions.preview";
+import { ExpandableTabsPreview } from "@/components/previews/blocks/expandable-tabs.preview";
 
 const HEADLINE = ["Motion", "components", "for React."];
 const HEADLINE_WORDS = HEADLINE.reduce((n, l) => n + l.split(" ").length, 0);
 const STAGGER = 0.09;
 const START = 0.12;
-const SAMPLE_INTERVAL_MS = 2600;
 
 export function Hero() {
-  const [motionEnabled, setMotionEnabled] = useState(true);
-  const [activeSampleIndex, setActiveSampleIndex] = useState(0);
   const headlineEnd = START + HEADLINE_WORDS * STAGGER;
   const subDelay = headlineEnd + 0.05;
   const ctaDelay = subDelay + 0.25;
-  const samples = [
-    {
-      id: "button",
-      file: "motion/button.tsx",
-      code: `<StatefulButton state="success">
-  Save changes
-</StatefulButton>`,
-      label: "Stateful button",
-      detail: "Success state",
-      preview: (
-        <StatefulButton state="success" size="md" successText="Saved">
-          Save
-        </StatefulButton>
-      ),
-    },
-    {
-      id: "switch",
-      file: "motion/switch.tsx",
-      code: `<Switch
-  checked={enabled}
-  onCheckedChange={setEnabled}
-/>`,
-      label: "Switch",
-      detail: "Spring thumb",
-      preview: (
-        <Switch checked={motionEnabled} onCheckedChange={setMotionEnabled} />
-      ),
-    },
-    {
-      id: "badge",
-      file: "motion/badge.tsx",
-      code: `<AnimatedBadge status="success">
-  Ready
-</AnimatedBadge>`,
-      label: "Animated badge",
-      detail: "Registry install",
-      preview: (
-        <AnimatedBadge status="success" size="md" pulse={false}>
-          Ready
-        </AnimatedBadge>
-      ),
-    },
-  ];
-  const activeSample = samples[activeSampleIndex];
-
-  useEffect(() => {
-    const interval = window.setInterval(() => {
-      setActiveSampleIndex((index) => (index + 1) % samples.length);
-    }, SAMPLE_INTERVAL_MS);
-
-    return () => window.clearInterval(interval);
-  }, [samples.length]);
+  const demoDelay = ctaDelay + 0.1;
 
   return (
-    <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[minmax(0,1fr)_430px] lg:items-center">
-      <div>
-        <motion.div
-          initial={{ opacity: 0, y: 6 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, ease: EASE_OUT }}
+    <div className="mx-auto max-w-5xl text-center">
+      <motion.div
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.45, ease: EASE_OUT, delay: 0.05 }}
+        className="flex justify-center"
+      >
+        <PressLink
+          href="https://github.com/starc007/ui-components"
+          target="_blank"
+          rel="noreferrer noopener"
+          className="group mb-7 inline-flex min-h-9 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-3 text-xs font-medium text-(--color-fg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
         >
-          <PressLink
-            href="https://github.com/starc007/ui-components"
-            target="_blank"
-            rel="noreferrer noopener"
-            className="group mb-7 inline-flex min-h-10 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-3 text-xs font-medium text-(--color-fg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
-          >
-            <span className="h-1.5 w-1.5 rounded-full bg-(--color-accent)" />
-            Tailwind 4 + React 19
-            <ArrowUpRight className="h-3 w-3 text-(--color-fg-muted) transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
-          </PressLink>
-        </motion.div>
+          <span className="h-1.5 w-1.5 rounded-full bg-(--color-accent)" />
+          Tailwind 4 + React 19
+          <ArrowUpRight className="h-3 w-3 text-(--color-fg-muted) transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+        </PressLink>
+      </motion.div>
 
-        <TextReveal
-          as="h1"
-          text={HEADLINE}
-          delay={START}
-          stagger={STAGGER}
-          className="max-w-5xl font-pixel text-[3.2rem] font-medium leading-[0.86] text-(--color-fg) sm:text-7xl md:text-8xl lg:text-[8.5rem]"
-        />
+      <TextReveal
+        as="h1"
+        text={HEADLINE}
+        delay={START}
+        stagger={STAGGER}
+        className="mx-auto font-pixel text-5xl font-medium leading-[0.9] text-(--color-fg) sm:text-6xl md:text-7xl"
+      />
 
-        <motion.p
-          initial={{ opacity: 0, y: 10, filter: "blur(6px)" }}
-          animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-          transition={{ duration: 0.55, ease: EASE_OUT, delay: subDelay }}
-          className="mt-7 max-w-md text-pretty text-base leading-7 text-(--color-fg-muted)"
-        >
-          Copy-ready components with clean motion.
-        </motion.p>
-
-        <motion.div
-          initial={{ opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.55, ease: EASE_OUT, delay: ctaDelay }}
-          className="mt-8 flex flex-wrap items-center gap-3"
-        >
-          <PressLink
-            href="/components/motion"
-            className="group inline-flex h-11 items-center gap-2 rounded-full bg-(--color-fg) px-6 text-sm font-medium text-(--color-bg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
-          >
-            Browse components
-            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-          </PressLink>
-          <PressLink
-            href="https://github.com/starc007/ui-components"
-            target="_blank"
-            rel="noreferrer noopener"
-            className="inline-flex h-11 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-6 text-sm font-medium text-(--color-fg) hover:border-(--color-border-strong) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
-          >
-            <GithubIcon className="h-4 w-4" />
-            GitHub
-          </PressLink>
-        </motion.div>
-      </div>
+      <motion.p
+        initial={{ opacity: 0, y: 10, filter: "blur(6px)" }}
+        animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+        transition={{ duration: 0.5, ease: EASE_OUT, delay: subDelay }}
+        className="mx-auto mt-6 max-w-sm text-pretty text-base leading-7 text-(--color-fg-muted)"
+      >
+        Copy-ready components with clean motion.
+      </motion.p>
 
       <motion.div
-        initial={{ opacity: 0, y: 12 }}
+        initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.55, ease: EASE_OUT, delay: ctaDelay + 0.1 }}
-        className="hidden h-[400px] overflow-hidden rounded-lg border border-(--color-border) bg-(--color-bg-elev) lg:block"
+        transition={{ duration: 0.5, ease: EASE_OUT, delay: ctaDelay }}
+        className="mt-8 flex flex-wrap items-center justify-center gap-3"
       >
-        <div className="flex h-12 items-center justify-between border-b border-(--color-border) bg-(--color-bg) px-4">
-          <p className="font-pixel text-[11px] font-medium text-(--color-fg-muted)">
-            Component asset
-          </p>
-          <AnimatedBadge status="neutral" size="sm" pulse={false}>
-            {String(activeSampleIndex + 1).padStart(2, "0")} / {samples.length}
-          </AnimatedBadge>
+        <PressLink
+          href="/components/motion"
+          className="group inline-flex h-11 items-center gap-2 rounded-full bg-(--color-fg) px-6 text-sm font-medium text-(--color-bg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
+        >
+          Browse components
+          <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+        </PressLink>
+        <PressLink
+          href="https://github.com/starc007/ui-components"
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex h-11 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-6 text-sm font-medium text-(--color-fg) hover:border-(--color-border-strong) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
+        >
+          <GithubIcon className="h-4 w-4" />
+          GitHub
+        </PressLink>
+      </motion.div>
+
+      {/* Demo */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.65, ease: EASE_OUT, delay: demoDelay }}
+        className="mt-14 overflow-hidden rounded-2xl border border-(--color-border)"
+        style={{
+          background:
+            "radial-gradient(ellipse 60% 80% at 10% 50%, color-mix(in srgb, #7c3aed 18%, transparent), transparent 70%), radial-gradient(ellipse 50% 70% at 90% 20%, color-mix(in srgb, #0ea5e9 14%, transparent), transparent 65%), radial-gradient(ellipse 40% 60% at 60% 90%, color-mix(in srgb, #f59e0b 10%, transparent), transparent 60%), var(--color-bg)",
+        }}
+      >
+        {/* Top row: Dynamic Island (wide) + Overflow Actions */}
+        <div className="grid h-[260px] grid-cols-[1fr_260px] border-b border-(--color-border)">
+          <div className="overflow-hidden border-r border-(--color-border) p-6">
+            <DynamicIslandPreview />
+          </div>
+          <div className="flex items-center justify-center overflow-hidden p-6">
+            <OverflowActionsPreview />
+          </div>
         </div>
 
-        <div className="h-32 border-b border-(--color-border) bg-(--color-bg) p-4">
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.div
-              key={`${activeSample.id}-code`}
-              initial={{ opacity: 0, y: 8, filter: "blur(6px)" }}
-              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-              exit={{ opacity: 0, y: -8, filter: "blur(6px)" }}
-              transition={{ duration: 0.24, ease: EASE_OUT }}
-            >
-              <p className="mb-2 font-mono text-[11px] text-(--color-fg-muted)">
-                {activeSample.file}
-              </p>
-              <pre className="overflow-hidden font-mono text-[11px] leading-4 text-(--color-fg-muted)">
-                <code>{activeSample.code}</code>
-              </pre>
-            </motion.div>
-          </AnimatePresence>
-        </div>
-
-        <div className="h-40 p-3">
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.div
-              key={`${activeSample.id}-preview`}
-              initial={{ opacity: 0, y: 10, filter: "blur(6px)" }}
-              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-              exit={{ opacity: 0, y: -10, filter: "blur(6px)" }}
-              transition={{ duration: 0.26, ease: EASE_OUT }}
-              className="flex h-[136px] items-center justify-between rounded-md border border-(--color-border) bg-(--color-bg) p-4"
-            >
-              <div>
-                <p className="font-mono text-[11px] text-(--color-fg-muted)">
-                  {activeSample.id}.tsx
-                </p>
-                <p className="mt-1 font-pixel text-sm font-medium text-(--color-fg)">
-                  {activeSample.label}
-                </p>
-                <p className="mt-1 text-xs text-(--color-fg-muted)">
-                  {activeSample.detail}
-                </p>
-              </div>
-              <div className="flex shrink-0 items-center justify-end">
-                {activeSample.preview}
-              </div>
-            </motion.div>
-          </AnimatePresence>
-        </div>
-
-        <div className="grid h-16 grid-cols-3 gap-px border-t border-(--color-border) bg-(--color-border)">
-          {samples.map((sample, index) => (
-            <div
-              key={sample.id}
-              className={
-                index === activeSampleIndex
-                  ? "bg-(--color-bg) px-3 py-2"
-                  : "bg-(--color-bg-elev) px-3 py-2"
-              }
-            >
-              <p className="font-mono text-[10px] text-(--color-fg-muted)">
-                asset
-              </p>
-              <p className="mt-1 truncate text-xs font-medium text-(--color-fg)">
-                {sample.id}.tsx
-              </p>
-            </div>
-          ))}
+        {/* Bottom row: Expandable Tabs full width */}
+        <div className="relative h-[200px] overflow-hidden">
+          <div className="absolute bottom-0 left-0 right-0">
+            <ExpandableTabsPreview />
+          </div>
         </div>
       </motion.div>
     </div>

--- a/components/app/install-command.tsx
+++ b/components/app/install-command.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CopyButton } from "@/components/app/copy-button";
+import { ActionSwapCascadeText } from "@/components/motion/action-swap-cascade";
+import { registry } from "@/lib/registry";
+import { cn } from "@/lib/utils";
+
+const PM_COMMANDS = {
+  bun: "bunx --bun",
+  npm: "npx",
+  pnpm: "pnpm dlx",
+  yarn: "yarn dlx",
+} as const;
+
+type PM = keyof typeof PM_COMMANDS;
+const PMS = Object.keys(PM_COMMANDS) as PM[];
+
+const REGISTRY_URL = "https://beui.dev/r";
+const CYCLE_MS = 1800;
+
+const COMPONENT_SLUGS = registry.flatMap((cat) =>
+  cat.components.flatMap((comp) =>
+    comp.examples
+      ? comp.examples.filter((e) => e.installSlug).map((e) => e.installSlug!)
+      : [comp.slug],
+  ),
+);
+
+export function InstallCommand({ className }: { className?: string }) {
+  const [pm, setPm] = useState<PM>("bun");
+  const [nameIndex, setNameIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setNameIndex((i) => (i + 1) % COMPONENT_SLUGS.length);
+    }, CYCLE_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const currentSlug = COMPONENT_SLUGS[nameIndex];
+  const copyValue = `${PM_COMMANDS[pm]} shadcn add ${REGISTRY_URL}/${currentSlug}`;
+
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-xl border border-(--color-border) bg-(--color-bg-elev) text-sm",
+        className,
+      )}
+    >
+      <div className="flex items-center border-b border-(--color-border) px-3 py-1.5">
+        <div className="flex gap-0.5">
+          {PMS.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setPm(p)}
+              className={cn(
+                "h-7 rounded-md px-2.5 text-xs font-medium transition-colors",
+                pm === p
+                  ? "border border-(--color-border) bg-(--color-bg) text-(--color-fg)"
+                  : "text-(--color-fg-muted) hover:text-(--color-fg)",
+              )}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+        <div className="ml-auto">
+          <CopyButton text={copyValue} />
+        </div>
+      </div>
+
+      <pre className="px-5 py-4 font-mono text-[13px]">
+        <code className="text-(--color-fg-muted)">
+          <span className="select-none">{"$ "}</span>
+          {PM_COMMANDS[pm]}
+          {" shadcn add "}
+          {REGISTRY_URL}/
+          <ActionSwapCascadeText
+            value={currentSlug}
+            className="font-semibold text-(--color-fg)"
+          >
+            {currentSlug}
+          </ActionSwapCascadeText>
+        </code>
+      </pre>
+    </div>
+  );
+}

--- a/components/app/install-command.tsx
+++ b/components/app/install-command.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { CopyButton } from "@/components/app/copy-button";
 import { ActionSwapCascadeText } from "@/components/motion/action-swap-cascade";
+import { Tabs, TabsList, TabsTrigger } from "@/components/motion/tabs";
 import { registry } from "@/lib/registry";
 import { cn } from "@/lib/utils";
 
@@ -27,18 +28,25 @@ const COMPONENT_SLUGS = registry.flatMap((cat) =>
   ),
 );
 
-export function InstallCommand({ className }: { className?: string }) {
+export function InstallCommand({
+  className,
+  slug,
+}: {
+  className?: string;
+  slug?: string;
+}) {
   const [pm, setPm] = useState<PM>("bun");
   const [nameIndex, setNameIndex] = useState(0);
 
   useEffect(() => {
+    if (slug) return;
     const id = setInterval(() => {
       setNameIndex((i) => (i + 1) % COMPONENT_SLUGS.length);
     }, CYCLE_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [slug]);
 
-  const currentSlug = COMPONENT_SLUGS[nameIndex];
+  const currentSlug = slug ?? COMPONENT_SLUGS[nameIndex];
   const copyValue = `${PM_COMMANDS[pm]} shadcn add ${REGISTRY_URL}/${currentSlug}`;
 
   return (
@@ -48,43 +56,52 @@ export function InstallCommand({ className }: { className?: string }) {
         className,
       )}
     >
-      <div className="flex items-center border-b border-(--color-border) px-3 py-1.5">
-        <div className="flex gap-0.5">
-          {PMS.map((p) => (
-            <button
-              key={p}
-              type="button"
-              onClick={() => setPm(p)}
-              className={cn(
-                "h-7 rounded-md px-2.5 text-xs font-medium transition-colors",
-                pm === p
-                  ? "border border-(--color-border) bg-(--color-bg) text-(--color-fg)"
-                  : "text-(--color-fg-muted) hover:text-(--color-fg)",
-              )}
-            >
-              {p}
-            </button>
-          ))}
-        </div>
-        <div className="ml-auto">
+      <div className="flex items-center gap-2 border-b border-(--color-border) px-3 py-1.5">
+        <Tabs
+          value={pm}
+          onValueChange={(v) => setPm(v as PM)}
+          variant="segment"
+        >
+          <TabsList className="gap-0.5 rounded-none bg-transparent p-0">
+            {PMS.map((p) => (
+              <TabsTrigger
+                key={p}
+                value={p}
+                indicatorClassName="bg-(--color-bg) border border-(--color-border) shadow-none"
+                className="h-7 px-2.5 text-xs font-medium text-(--color-fg-muted) hover:text-(--color-fg) aria-[selected=true]:text-(--color-fg)"
+              >
+                {p}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+        <div className="ml-auto shrink-0">
           <CopyButton text={copyValue} />
         </div>
       </div>
 
-      <pre className="px-5 py-4 font-mono text-[13px]">
-        <code className="text-(--color-fg-muted)">
-          <span className="select-none">{"$ "}</span>
-          {PM_COMMANDS[pm]}
-          {" shadcn add "}
-          {REGISTRY_URL}/
+      <div className="overflow-x-auto">
+        <div className="min-w-max px-5 py-4 font-mono text-[13px] whitespace-nowrap">
+          <span className="select-none text-[#6e7781] dark:text-[#8b949e]">{"$ "}</span>
+          <span className="text-[#1f6feb] dark:text-[#ffa657]">
+            {PM_COMMANDS[pm].split(" ")[0]}
+          </span>
+          {PM_COMMANDS[pm].split(" ")[1] && (
+            <span className="text-[#6f42c1] dark:text-[#d2a8ff]">
+              {" "}{PM_COMMANDS[pm].split(" ")[1]}
+            </span>
+          )}
+          <span className="text-[#24292f] dark:text-[#e6edf3]">{" shadcn "}</span>
+          <span className="text-[#0550ae] dark:text-[#79c0ff]">add</span>
+          <span className="text-[#24292f]/50 dark:text-[#e6edf3]/40">{" "}{REGISTRY_URL}/</span>
           <ActionSwapCascadeText
             value={currentSlug}
-            className="font-semibold text-(--color-fg)"
+            className="font-medium text-[#0a3069] dark:text-[#a5d6ff]"
           >
             {currentSlug}
           </ActionSwapCascadeText>
-        </code>
-      </pre>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/app/site-footer.tsx
+++ b/components/app/site-footer.tsx
@@ -1,0 +1,146 @@
+import Link from "next/link";
+import { GithubIcon } from "@/components/app/icons";
+import { registry } from "@/lib/registry";
+
+const motionComponents = registry.find((c) => c.slug === "motion")?.components ?? [];
+const blockComponents = registry.find((c) => c.slug === "blocks")?.components ?? [];
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-(--color-border) px-4 pt-14 pb-10">
+      <div className="mx-auto max-w-7xl">
+        {/* Main grid */}
+        <div className="grid grid-cols-2 gap-10 md:grid-cols-[1.5fr_1fr_1fr_1fr]">
+          {/* Brand */}
+          <div className="col-span-2 md:col-span-1">
+            <p className="font-pixel text-lg font-medium text-(--color-fg)">beUI</p>
+            <p className="mt-2 max-w-[220px] text-sm leading-6 text-(--color-fg-muted)">
+              Motion components for React. Copy-paste via shadcn registry.
+            </p>
+            <p className="mt-5 text-xs text-(--color-fg-muted)">
+              Created by{" "}
+              <Link
+                href="https://x.com/saurra3h"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="font-medium text-(--color-fg) underline-offset-2 hover:underline"
+              >
+                Saurabh
+              </Link>
+            </p>
+            <div className="mt-5 flex items-center gap-3">
+              <Link
+                href="https://github.com/starc007/ui-components"
+                target="_blank"
+                rel="noreferrer noopener"
+                aria-label="GitHub"
+                className="text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+              >
+                <GithubIcon className="h-4 w-4" />
+              </Link>
+              <Link
+                href="https://x.com/saurra3h"
+                target="_blank"
+                rel="noreferrer noopener"
+                aria-label="X / Twitter"
+                className="text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+              >
+                <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor" aria-hidden="true">
+                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                </svg>
+              </Link>
+            </div>
+          </div>
+
+          {/* Components */}
+          <div>
+            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+              Components
+            </p>
+            <ul className="space-y-2.5">
+              {motionComponents.map((c) => (
+                <li key={c.slug}>
+                  <Link
+                    href={`/components/motion/${c.slug}`}
+                    className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                  >
+                    {c.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Blocks */}
+          <div>
+            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+              Blocks
+            </p>
+            <ul className="space-y-2.5">
+              {blockComponents.map((c) => (
+                <li key={c.slug}>
+                  <Link
+                    href={`/components/blocks/${c.slug}`}
+                    className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                  >
+                    {c.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Links */}
+          <div>
+            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+              Links
+            </p>
+            <ul className="space-y-2.5">
+              <li>
+                <Link
+                  href="/components/motion"
+                  className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                >
+                  Browse all
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="https://github.com/starc007/ui-components"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                >
+                  GitHub
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="https://x.com/saurra3h"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                >
+                  X / Twitter
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/llms.txt"
+                  className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                >
+                  llms.txt
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div className="mt-14 border-t border-(--color-border) pt-6">
+          <p className="text-xs text-(--color-fg-muted)">© 2026 beUI. MIT License.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

- Centered hero layout with badge pill, TextReveal headline, subtitle, CTAs
- Install command widget with PM switcher (bun/npm/pnpm/yarn) and cycling component name via `ActionSwapCascadeText`
- Curated 10-component grid replacing the full dump; recently launched shown above primitives
- Expanded footer with Components + Blocks columns, author credit (Saurabh / @saurra3h), social links
- Removed stats strip

## Test plan

- [ ] Hero renders correctly in dark and light mode
- [ ] Install command PM switcher works, component name cycles
- [ ] Copy button in install command copies correct command
- [ ] Footer component links resolve correctly
- [ ] Recently launched section appears above Motion primitives
- [ ] Shift+D theme toggle still works