### PR TITLE
feat: SEO improvements (structured data, metadata, indexable content)

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -17,8 +17,14 @@ import {
   TabsTrigger,
 } from "@/components/motion/tabs";
 import { NewBadge } from "@/components/app/new-badge";
+import { JsonLd } from "@/components/app/json-ld";
 import { getPreview, previews } from "@/components/previews";
 import { readSourceFile } from "@/lib/source-files";
+import {
+  breadcrumbJsonLd,
+  componentJsonLd,
+  relatedComponents,
+} from "@/lib/seo";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
@@ -49,7 +55,8 @@ export async function generateMetadata({
     ? `/${installSlugs[0]}.json`
     : `/${comp.slug}.json`;
 
-  const title = `${comp.name} · ${cat.name} component · beUI v2`;
+  const title = `${comp.name} · React motion component`;
+  const ogTitle = `${title} · beUI v2`;
   const pageUrl = `/components/${cat.slug}/${comp.slug}`;
   const imageUrl = `/api/og?component=${comp.slug}`;
   const keywords = [
@@ -69,7 +76,7 @@ export async function generateMetadata({
     description: comp.description,
     keywords,
     openGraph: {
-      title,
+      title: ogTitle,
       description: comp.description,
       url: pageUrl,
       type: "article",
@@ -85,7 +92,7 @@ export async function generateMetadata({
     },
     twitter: {
       card: "summary_large_image",
-      title,
+      title: ogTitle,
       description: comp.description,
       images: [imageUrl],
     },
@@ -128,9 +135,20 @@ export default async function ComponentPage({
   if (!cat || !comp) notFound();
   const hasVariantInstallCommands =
     comp.examples?.some((example) => example.installSlug) ?? false;
+  const related = relatedComponents(cat.slug, comp.slug);
 
   return (
     <div>
+      <JsonLd
+        data={[
+          breadcrumbJsonLd([
+            { name: "beUI v2", path: "/" },
+            { name: cat.name, path: `/components/${cat.slug}` },
+            { name: comp.name, path: `/components/${cat.slug}/${comp.slug}` },
+          ]),
+          componentJsonLd(cat, comp),
+        ]}
+      />
       <nav
         aria-label="Breadcrumb"
         className="flex items-center gap-1.5 text-sm"
@@ -175,6 +193,31 @@ export default async function ComponentPage({
               <InstallCommand slug={comp.slug} />
             </div>
           </div>
+        </section>
+      ) : null}
+
+      {related.length ? (
+        <section className="mt-12 border-t border-(--color-border) pt-8">
+          <h2 className="text-sm font-semibold text-(--color-fg)">
+            Related components
+          </h2>
+          <ul className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {related.map((rel) => (
+              <li key={`${rel.category}/${rel.slug}`}>
+                <Link
+                  href={`/components/${rel.category}/${rel.slug}`}
+                  className="group/rel flex h-full flex-col rounded-2xl border border-(--color-border) bg-(--color-bg-elev) p-4 transition-colors hover:bg-(--color-bg-elev)/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
+                >
+                  <span className="font-medium text-(--color-fg)">
+                    {rel.name}
+                  </span>
+                  <span className="mt-1 line-clamp-2 text-sm text-(--color-fg-muted)">
+                    {rel.description}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
         </section>
       ) : null}
     </div>

--- a/app/components/[category]/page.tsx
+++ b/app/components/[category]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { findCategory, registry, type ComponentEntry } from "@/lib/registry";
 import { NewBadge } from "@/components/app/new-badge";
+import { JsonLd } from "@/components/app/json-ld";
+import { breadcrumbJsonLd, categoryJsonLd } from "@/lib/seo";
 
 export function generateStaticParams() {
   return registry.map((c) => ({ category: c.slug }));
@@ -17,7 +19,8 @@ export async function generateMetadata({
   const cat = findCategory(category);
   if (!cat) return {};
 
-  const title = `${cat.name} components · beUI v2`;
+  const title = `${cat.name} · React motion components`;
+  const ogTitle = `${title} · beUI v2`;
   const pageUrl = `/components/${cat.slug}`;
   const imageUrl = `/api/og?category=${cat.slug}`;
   const componentNames = cat.components.map((comp) => comp.name);
@@ -35,7 +38,7 @@ export async function generateMetadata({
       ...componentNames,
     ],
     openGraph: {
-      title,
+      title: ogTitle,
       description: cat.description,
       url: pageUrl,
       type: "website",
@@ -51,7 +54,7 @@ export async function generateMetadata({
     },
     twitter: {
       card: "summary_large_image",
-      title,
+      title: ogTitle,
       description: cat.description,
       images: [imageUrl],
     },
@@ -77,6 +80,15 @@ export default async function CategoryPage({
 
   return (
     <div>
+      <JsonLd
+        data={[
+          breadcrumbJsonLd([
+            { name: "beUI v2", path: "/" },
+            { name: cat.name, path: `/components/${cat.slug}` },
+          ]),
+          categoryJsonLd(cat),
+        ]}
+      />
       <nav
         aria-label="Breadcrumb"
         className="flex items-center gap-1.5 text-sm"

--- a/app/docs/ai-agents/page.tsx
+++ b/app/docs/ai-agents/page.tsx
@@ -1,10 +1,27 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { CodeBlock } from "@/components/app/code-block";
 
-export const metadata = {
-  title: "AI Agents · beUI v2",
-  description: "Endpoints for coding agents to consume beUI components programmatically.",
+export const metadata: Metadata = {
+  title: "AI Agents",
+  description:
+    "Endpoints for coding agents to consume beUI components programmatically: llms.txt, JSON registry, and raw source.",
+  alternates: { canonical: "/docs/ai-agents" },
+  openGraph: {
+    title: "AI Agents · beUI v2",
+    description:
+      "Endpoints for coding agents to consume beUI components programmatically: llms.txt, JSON registry, and raw source.",
+    url: "/docs/ai-agents",
+    type: "article",
+    siteName: "beUI v2",
+    images: ["/api/og"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI Agents · beUI v2",
+    images: ["/api/og"],
+  },
 };
 
 const ENDPOINTS: { label: string; url: string; desc: string }[] = [

--- a/app/docs/motion-patterns/page.tsx
+++ b/app/docs/motion-patterns/page.tsx
@@ -2,10 +2,25 @@ import type { Metadata } from "next";
 import { MotionPatterns } from "./motion-patterns";
 
 export const metadata: Metadata = {
-  title: "Motion Patterns · beUI v2",
-  description: "Simple motion patterns used across beUI components.",
+  title: "Motion Patterns",
+  description:
+    "The motion tokens and patterns behind beUI: easing, springs and timing used across every component.",
   alternates: {
     canonical: "/docs/motion-patterns",
+  },
+  openGraph: {
+    title: "Motion Patterns · beUI v2",
+    description:
+      "The motion tokens and patterns behind beUI: easing, springs and timing used across every component.",
+    url: "/docs/motion-patterns",
+    type: "article",
+    siteName: "beUI v2",
+    images: ["/api/og"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Motion Patterns · beUI v2",
+    images: ["/api/og"],
   },
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Inter, JetBrains_Mono } from "next/font/google";
@@ -10,7 +10,9 @@ import { SiteHeader } from "@/components/app/site-header";
 import { SiteDock } from "@/components/app/site-dock";
 import { SiteFrame } from "@/components/app/site-frame";
 import { KeyboardShortcuts } from "@/components/app/keyboard-shortcuts";
+import { JsonLd } from "@/components/app/json-ld";
 import { getGithubStarCount } from "@/lib/github";
+import { AUTHOR, SITE_DESCRIPTION, SITE_NAME, siteJsonLd } from "@/lib/seo";
 import { cn } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
@@ -19,9 +21,18 @@ const pixel = GeistPixelSquare;
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://beui.dev"),
-  applicationName: "beUI v2",
-  title: "beUI v2 · motion components",
-  description: "Simple UI components with motion.",
+  applicationName: SITE_NAME,
+  title: {
+    default: "beUI v2 · React motion components for shadcn",
+    template: "%s · beUI v2",
+  },
+  description: SITE_DESCRIPTION,
+  authors: [{ name: AUTHOR, url: "https://github.com/starc007" }],
+  creator: AUTHOR,
+  publisher: SITE_NAME,
+  category: "technology",
+  formatDetection: { telephone: false, email: false, address: false },
+  manifest: "/manifest.webmanifest",
   alternates: {
     canonical: "/",
     types: {
@@ -30,27 +41,45 @@ export const metadata: Metadata = {
     },
   },
   openGraph: {
-    title: "beUI v2",
-    description: "Simple UI components with motion.",
+    title: "beUI v2 · React motion components",
+    description: SITE_DESCRIPTION,
     type: "website",
     url: "/",
-    siteName: "beUI v2",
+    siteName: SITE_NAME,
+    locale: "en_US",
     images: [
       {
         url: "/api/og",
         width: 1200,
         height: 630,
-        alt: "beUI v2 UI components",
+        alt: "beUI v2 · React motion components",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "beUI v2",
-    description: "Simple UI components with motion.",
+    title: "beUI v2 · React motion components",
+    description: SITE_DESCRIPTION,
     images: ["/api/og"],
   },
-  keywords: ["Motion components", "UI components", "Component library", "Open source"],
+  keywords: [
+    "React motion components",
+    "Tailwind CSS components",
+    "shadcn registry",
+    "shadcn-compatible components",
+    "framer motion components",
+    "animated UI components",
+    "component library",
+    "copy paste components",
+    "open source",
+  ],
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#fcfcfc" },
+    { media: "(prefers-color-scheme: dark)", color: "#151515" },
+  ],
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -66,6 +95,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link rel="alternate" type="application/json" title="shadcn registry" href="/registry.json" />
       </head>
       <body className="min-h-screen antialiased">
+        <JsonLd data={siteJsonLd()} />
         <ThemeProvider>
           <KeyboardShortcuts />
           <SiteHeader githubStarCount={githubStarCount} />

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+import { SITE_DESCRIPTION, SITE_NAME } from "@/lib/seo";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: SITE_NAME,
+    short_name: "beUI",
+    description: SITE_DESCRIPTION,
+    start_url: "/",
+    display: "standalone",
+    background_color: "#151515",
+    theme_color: "#151515",
+    icons: [
+      {
+        src: "/beui-mark.png",
+        sizes: "any",
+        type: "image/png",
+        purpose: "any",
+      },
+    ],
+  };
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -4,7 +4,15 @@ const SITE = "https://beui.dev";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [{ userAgent: "*", allow: "/" }],
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        // Machine endpoints: image generation and raw source text.
+        // Agents fetch these directly; they are not search content.
+        disallow: ["/api/", "/r/*/raw"],
+      },
+    ],
     sitemap: `${SITE}/sitemap.xml`,
     host: SITE,
   };

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,38 +7,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
   const staticPages: MetadataRoute.Sitemap = [
     { url: `${SITE}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
-    { url: `${SITE}/llms.txt`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
-    { url: `${SITE}/r`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
-    { url: `${SITE}/docs/ai-agents`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${SITE}/docs/ai-agents`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${SITE}/docs/motion-patterns`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${SITE}/llms.txt`, lastModified: now, changeFrequency: "weekly", priority: 0.5 },
   ];
 
   const categoryPages: MetadataRoute.Sitemap = registry.map((c) => ({
     url: `${SITE}/components/${c.slug}`,
     lastModified: now,
     changeFrequency: "weekly",
-    priority: 0.7,
+    priority: 0.8,
   }));
 
-  const componentPages: MetadataRoute.Sitemap = allComponents().flatMap((c) => [
-    {
-      url: `${SITE}/components/${c.category.slug}/${c.slug}`,
-      lastModified: now,
-      changeFrequency: "weekly",
-      priority: 0.6,
-    },
-    {
-      url: `${SITE}/r/${c.slug}`,
-      lastModified: now,
-      changeFrequency: "weekly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE}/r/${c.slug}/raw`,
-      lastModified: now,
-      changeFrequency: "weekly",
-      priority: 0.4,
-    },
-  ]);
+  // Component detail pages are the primary content. Machine endpoints
+  // (/r/* JSON and raw text) are intentionally excluded from search.
+  const componentPages: MetadataRoute.Sitemap = allComponents().map((c) => ({
+    url: `${SITE}/components/${c.category.slug}/${c.slug}`,
+    lastModified: now,
+    changeFrequency: "weekly",
+    priority: 0.7,
+  }));
 
   return [...staticPages, ...categoryPages, ...componentPages];
 }

--- a/components/app/json-ld.tsx
+++ b/components/app/json-ld.tsx
@@ -1,0 +1,21 @@
+export type JsonLdSchema = Record<string, unknown>;
+
+/**
+ * Renders JSON-LD structured data. Server component, no client cost.
+ * Pass one schema object or an array; each is emitted as its own script tag.
+ */
+export function JsonLd({ data }: { data: JsonLdSchema | JsonLdSchema[] }) {
+  const items = Array.isArray(data) ? data : [data];
+  return (
+    <>
+      {items.map((item, i) => (
+        <script
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable build-time list
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(item) }}
+        />
+      ))}
+    </>
+  );
+}

--- a/components/motion/tabs.tsx
+++ b/components/motion/tabs.tsx
@@ -163,7 +163,17 @@ export function TabsTrigger({
 export function TabsContent({ value, children, className }: { value: string; children: ReactNode; className?: string }) {
   const { value: current } = useTabs();
   const reduce = useReducedMotion();
-  if (current !== value) return null;
+  const active = current === value;
+  // Inactive panels stay mounted but hidden, so their content (e.g. source
+  // code) is present in the server-rendered HTML for crawlers and assistive
+  // tech, instead of being dropped from the DOM.
+  if (!active) {
+    return (
+      <div hidden className={className}>
+        {children}
+      </div>
+    );
+  }
   return (
     <motion.div
       key={value}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,156 @@
+import type { JsonLdSchema } from "@/components/app/json-ld";
+import {
+  type CategoryEntry,
+  type ComponentEntry,
+  allComponents,
+  registry,
+} from "@/lib/registry";
+
+export const SITE = "https://beui.dev";
+export const SITE_NAME = "beUI v2";
+export const SITE_DESCRIPTION =
+  "Open-source React motion components built on Motion and Tailwind CSS. Copy-paste source or install via the shadcn CLI.";
+export const AUTHOR = "Saurabh";
+
+const abs = (path: string) => (path.startsWith("http") ? path : `${SITE}${path}`);
+
+/** Site-wide WebSite + SoftwareApplication. Rendered once in the root layout. */
+export function siteJsonLd(): JsonLdSchema[] {
+  return [
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "@id": `${SITE}/#website`,
+      url: SITE,
+      name: SITE_NAME,
+      description: SITE_DESCRIPTION,
+      inLanguage: "en",
+      publisher: { "@id": `${SITE}/#org` },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "@id": `${SITE}/#org`,
+      name: SITE_NAME,
+      url: SITE,
+      logo: abs("/beui-mark.png"),
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "@id": `${SITE}/#app`,
+      name: SITE_NAME,
+      description: SITE_DESCRIPTION,
+      url: SITE,
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Web",
+      author: { "@type": "Person", name: AUTHOR },
+      offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    },
+  ];
+}
+
+type Crumb = { name: string; path: string };
+
+export function breadcrumbJsonLd(crumbs: Crumb[]): JsonLdSchema {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: crumbs.map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: c.name,
+      item: abs(c.path),
+    })),
+  };
+}
+
+/** Per-component page: SoftwareSourceCode + TechArticle. */
+export function componentJsonLd(
+  cat: CategoryEntry,
+  comp: ComponentEntry,
+): JsonLdSchema {
+  const url = abs(`/components/${cat.slug}/${comp.slug}`);
+  return {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "@id": `${url}#article`,
+    headline: `${comp.name} · React motion component`,
+    name: comp.name,
+    description: comp.description,
+    url,
+    image: abs(`/api/og?component=${comp.slug}`),
+    inLanguage: "en",
+    isPartOf: { "@id": `${SITE}/#website` },
+    author: { "@type": "Person", name: AUTHOR },
+    publisher: { "@id": `${SITE}/#org` },
+    about: {
+      "@type": "SoftwareSourceCode",
+      name: comp.name,
+      description: comp.description,
+      codeRepository: "https://github.com/starc007/ui-components",
+      programmingLanguage: "TypeScript",
+      runtimePlatform: "React",
+      codeSampleType: "full (compile ready)",
+    },
+  };
+}
+
+/** Category landing page: CollectionPage listing its components. */
+export function categoryJsonLd(cat: CategoryEntry): JsonLdSchema {
+  const url = abs(`/components/${cat.slug}`);
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${url}#collection`,
+    name: `${cat.name} · ${SITE_NAME}`,
+    description: cat.description,
+    url,
+    isPartOf: { "@id": `${SITE}/#website` },
+    hasPart: cat.components.map((comp) => ({
+      "@type": "TechArticle",
+      name: comp.name,
+      description: comp.description,
+      url: abs(`/components/${cat.slug}/${comp.slug}`),
+    })),
+  };
+}
+
+export type RelatedComponent = {
+  category: string;
+  slug: string;
+  name: string;
+  description: string;
+};
+
+/**
+ * Related components for internal cross-linking. Prefers same-category
+ * siblings, then fills from the wider catalog. Deterministic ordering.
+ */
+export function relatedComponents(
+  categorySlug: string,
+  slug: string,
+  limit = 4,
+): RelatedComponent[] {
+  const cat = registry.find((c) => c.slug === categorySlug);
+  const siblings = (cat?.components ?? [])
+    .filter((c) => c.slug !== slug)
+    .map((c) => toRelated(categorySlug, c));
+
+  if (siblings.length >= limit) return siblings.slice(0, limit);
+
+  const rest = allComponents()
+    .filter((c) => c.category.slug !== categorySlug)
+    .map((c) => toRelated(c.category.slug, c));
+
+  return [...siblings, ...rest].slice(0, limit);
+}
+
+function toRelated(categorySlug: string, c: ComponentEntry): RelatedComponent {
+  return {
+    category: categorySlug,
+    slug: c.slug,
+    name: c.name,
+    description: c.description,
+  };
+}


### PR DESCRIPTION
## Summary

SEO pass over the site. No behavior change for users; all gains are in markup, metadata, and crawlability.

### Structured data (JSON-LD) — was zero
- Site-wide: `WebSite` + `Organization` + `SoftwareApplication`
- Per component: `BreadcrumbList` + `TechArticle`/`SoftwareSourceCode`
- Per category: `BreadcrumbList` + `CollectionPage`
- New `lib/seo.ts` (shared constants + schema builders + related-components helper) and `components/app/json-ld.tsx` renderer

### Metadata
- Title template, keyword-rich default, `authors`/`creator`/`publisher`/`category`
- `viewport` themeColor (light/dark), `formatDetection`, `manifest` link
- Per-component and per-category OG/Twitter titles branded; child title suffixes de-duped against the new template
- Docs pages (`ai-agents`, `motion-patterns`): canonical + OG/Twitter added

### New files / routes
- `app/manifest.webmanifest` (PWA/mobile signal)

### Crawlability
- `robots`: disallow `/api/` and `/r/*/raw` to protect crawl budget (agents fetch these directly regardless)
- `sitemap`: content pages only, added `docs/motion-patterns`, dropped thin machine endpoints

### Internal linking + indexable content
- Always-rendered **Related components** section per component page (internal cross-linking + indexable HTML)
- **Tab indexability fix**: `TabsContent` returned `null` for inactive tabs, so component source/usage code never reached the server-rendered HTML. Inactive panels now stay mounted but `hidden`, exposing real per-component content to crawlers and assistive tech while preserving the enter animation.

## Verification
- `bun run typecheck` clean
- `bun run check:registry` validates
- `bun run lint`: only a pre-existing warning in `install-command.tsx`, unrelated to this branch

## Not included (deliberate)
Deep pSEO content layer (per-component overview/props/FAQ, comparison/use-case pages) skipped to avoid thin auto-generated pages. The tab fix already surfaces real per-component content with no authoring.