### PR TITLE
fix: model category collection as ItemList in JSON-LD

### DIFF
--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -107,12 +107,16 @@ export function categoryJsonLd(cat: CategoryEntry): JsonLdSchema {
     description: cat.description,
     url,
     isPartOf: { "@id": `${SITE}/#website` },
-    hasPart: cat.components.map((comp) => ({
-      "@type": "TechArticle",
-      name: comp.name,
-      description: comp.description,
-      url: abs(`/components/${cat.slug}/${comp.slug}`),
-    })),
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: cat.components.length,
+      itemListElement: cat.components.map((comp, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        name: comp.name,
+        url: abs(`/components/${cat.slug}/${comp.slug}`),
+      })),
+    },
   };
 }
 


### PR DESCRIPTION
## Problem

Rich Results Test on `/components/motion` flagged each detected item as an **Unnamed item** under *Articles* with 3 non-critical warnings (missing `image`/`author`/`headline`).

Root cause: `categoryJsonLd` listed every component in the `CollectionPage.hasPart` array as a `TechArticle`. Google evaluated each entry as an Article, titled Articles by `headline` (which these lacked → "Unnamed item"), and warned about the other optional Article fields.

## Fix

A category page lists links, not articles. Switched `hasPart: TechArticle[]` → `mainEntity: ItemList` of `ListItem`. Google does not validate `ListItem` as Articles, so:
- no "Unnamed item"
- no missing optional-field warnings
- correct semantics for a component index

Per-component pages keep their full `TechArticle` (with `headline`/`image`/`author`) and were never affected.

## Verification
- `bun run typecheck` clean
- `bun run check:registry` validates