### PR TITLE
fix: relabel prediction-market signed-out action to Connect

### DIFF
--- a/components/motion/prediction-market.tsx
+++ b/components/motion/prediction-market.tsx
@@ -673,7 +673,7 @@ export function PredictionMarket({
               classNames?.action,
             )}
           >
-            Sign In
+            Connect
           </StatefulButton>
         </div>
       )}


### PR DESCRIPTION
Relabels the prediction-market signed-out button from "Sign In" to "Connect" to reduce the credential/login phishing signal flagged by Google Safe Browsing. Visible label only; the `onSignIn` prop is unchanged to avoid breaking installed consumers via the registry.

Part of resolving the Safe Browsing false-positive flag on beui.dev.

- `bun run typecheck` clean
- `bun run check:registry` validates