### PR TITLE
feat: animated 404 not-found blocks (5 styles)

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { NotFoundGlitch } from "@/components/motion/not-found/glitch";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+  description: "The page you are looking for does not exist.",
+};
+
+export default function NotFound() {
+  return <NotFoundGlitch />;
+}

--- a/components/motion/not-found/glitch.tsx
+++ b/components/motion/not-found/glitch.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "motion/react";
+import {
+  NOT_FOUND_DEFAULTS,
+  NotFoundActions,
+  NotFoundStage,
+  type NotFoundProps,
+} from "./shared";
+
+const GLYPHS = "ABCDEFGHJKLMNPQRSTUVWXYZ0123456789#%&@$?/\\";
+const SCRAMBLE_MS = 700;
+const TICK_MS = 45;
+
+/**
+ * Renders the code, scrambling each character on mount before it settles.
+ * SSR and the first paint show the real code, so the scramble is a pure
+ * client-side enhancement and reduced-motion users see the code immediately.
+ */
+function Scramble({ text }: { text: string }) {
+  const reduce = useReducedMotion();
+  const [display, setDisplay] = useState(text);
+
+  useEffect(() => {
+    if (reduce) {
+      setDisplay(text);
+      return;
+    }
+    const chars = text.split("");
+    const start = performance.now();
+    let raf = 0;
+    let last = 0;
+
+    const loop = (now: number) => {
+      if (now - last >= TICK_MS) {
+        last = now;
+        const progress = Math.min((now - start) / SCRAMBLE_MS, 1);
+        const settled = Math.floor(progress * chars.length);
+        setDisplay(
+          chars
+            .map((ch, i) =>
+              i < settled || ch === " "
+                ? ch
+                : GLYPHS[Math.floor(Math.random() * GLYPHS.length)],
+            )
+            .join(""),
+        );
+      }
+      if (now - start < SCRAMBLE_MS) {
+        raf = requestAnimationFrame(loop);
+      } else {
+        setDisplay(text);
+      }
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [text, reduce]);
+
+  return <span className="tabular-nums">{display}</span>;
+}
+
+export function NotFoundGlitch({
+  className,
+  code = NOT_FOUND_DEFAULTS.code,
+  title = NOT_FOUND_DEFAULTS.title,
+  description = NOT_FOUND_DEFAULTS.description,
+  homeHref,
+  homeLabel,
+  browseHref,
+  browseLabel,
+}: NotFoundProps) {
+  return (
+    <NotFoundStage className={className}>
+      <div className="group relative select-none font-mono font-bold leading-none tracking-tighter text-foreground [font-size:clamp(5rem,18vw,11rem)]">
+        {/* Chromatic ghost layers, nudged apart on hover. */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-0 text-[#ff0040] opacity-0 mix-blend-screen transition-[transform,opacity] duration-150 ease-out group-hover:translate-x-[3px] group-hover:opacity-70 motion-reduce:hidden"
+        >
+          <Scramble text={code} />
+        </span>
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-0 text-[#00e5ff] opacity-0 mix-blend-screen transition-[transform,opacity] duration-150 ease-out group-hover:-translate-x-[3px] group-hover:opacity-70 motion-reduce:hidden"
+        >
+          <Scramble text={code} />
+        </span>
+        <h1 className="relative">
+          <Scramble text={code} />
+        </h1>
+      </div>
+
+      <div className="flex flex-col items-center gap-2">
+        <p className="text-lg font-semibold text-foreground">{title}</p>
+        <p className="max-w-sm text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      <NotFoundActions
+        homeHref={homeHref}
+        homeLabel={homeLabel}
+        browseHref={browseHref}
+        browseLabel={browseLabel}
+      />
+    </NotFoundStage>
+  );
+}

--- a/components/motion/not-found/index.tsx
+++ b/components/motion/not-found/index.tsx
@@ -1,0 +1,11 @@
+export { NotFoundGlitch } from "./glitch";
+export { NotFoundMagnetic } from "./magnetic";
+export { NotFoundSpotlight } from "./spotlight";
+export { NotFoundStacked } from "./stacked";
+export { NotFoundTerminal } from "./terminal";
+export {
+  NOT_FOUND_DEFAULTS,
+  NotFoundActions,
+  NotFoundStage,
+  type NotFoundProps,
+} from "./shared";

--- a/components/motion/not-found/magnetic.tsx
+++ b/components/motion/not-found/magnetic.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Magnetic } from "@/components/motion/magnetic";
+import { cn } from "@/lib/utils";
+import {
+  NOT_FOUND_DEFAULTS,
+  NotFoundActions,
+  NotFoundStage,
+  type NotFoundProps,
+} from "./shared";
+
+export function NotFoundMagnetic({
+  className,
+  code = NOT_FOUND_DEFAULTS.code,
+  title = NOT_FOUND_DEFAULTS.title,
+  description = NOT_FOUND_DEFAULTS.description,
+  homeHref,
+  homeLabel,
+  browseHref,
+  browseLabel,
+}: NotFoundProps) {
+  const chars = code.split("");
+
+  return (
+    <NotFoundStage className={className}>
+      <h1
+        aria-label={code}
+        className="flex select-none items-center justify-center font-bold leading-none tracking-tighter text-foreground [font-size:clamp(5rem,18vw,12rem)]"
+      >
+        {chars.map((ch, i) => (
+          <Magnetic
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed positional glyphs
+            key={i}
+            strength={0.6}
+            className={cn(i > 0 && "-ml-2")}
+          >
+            <span aria-hidden className="inline-block px-1 tabular-nums">
+              {ch}
+            </span>
+          </Magnetic>
+        ))}
+      </h1>
+
+      <div className="flex flex-col items-center gap-2">
+        <p className="text-lg font-semibold text-foreground">{title}</p>
+        <p className="max-w-sm text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      <NotFoundActions
+        homeHref={homeHref}
+        homeLabel={homeLabel}
+        browseHref={browseHref}
+        browseLabel={browseLabel}
+      />
+    </NotFoundStage>
+  );
+}

--- a/components/motion/not-found/shared.tsx
+++ b/components/motion/not-found/shared.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { SPRING_PRESS } from "@/lib/ease";
+import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
+import { cn } from "@/lib/utils";
+
+export interface NotFoundProps {
+  className?: string;
+  /** The big status code. */
+  code?: string;
+  title?: string;
+  description?: string;
+  homeHref?: string;
+  homeLabel?: string;
+  browseHref?: string;
+  browseLabel?: string;
+}
+
+export const NOT_FOUND_DEFAULTS = {
+  code: "404",
+  title: "Page not found",
+  description:
+    "The page you are looking for moved, vanished, or never existed.",
+  homeHref: "/",
+  homeLabel: "Back home",
+  browseHref: "/components/motion",
+  browseLabel: "Browse components",
+} as const;
+
+type ActionsProps = Pick<
+  NotFoundProps,
+  "homeHref" | "homeLabel" | "browseHref" | "browseLabel" | "className"
+>;
+
+/** The shared dual CTA: a primary "Back home" and a secondary "Browse". */
+export function NotFoundActions({
+  homeHref = NOT_FOUND_DEFAULTS.homeHref,
+  homeLabel = NOT_FOUND_DEFAULTS.homeLabel,
+  browseHref = NOT_FOUND_DEFAULTS.browseHref,
+  browseLabel = NOT_FOUND_DEFAULTS.browseLabel,
+  className,
+}: ActionsProps) {
+  const reduce = useReducedMotion();
+  const canHover = useHoverCapable();
+  const whileTap = reduce ? undefined : { scale: 0.96 };
+  const whileHover = reduce || !canHover ? undefined : { scale: 1.02 };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center justify-center gap-3",
+        className,
+      )}
+    >
+      <motion.a
+        href={homeHref}
+        whileTap={whileTap}
+        whileHover={whileHover}
+        transition={SPRING_PRESS}
+        className="inline-flex h-11 select-none items-center justify-center rounded-full bg-primary px-6 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        {homeLabel}
+      </motion.a>
+      <motion.a
+        href={browseHref}
+        whileTap={whileTap}
+        whileHover={whileHover}
+        transition={SPRING_PRESS}
+        className="inline-flex h-11 select-none items-center justify-center rounded-full border border-border bg-card px-6 text-sm font-medium text-foreground transition-colors hover:bg-primary/5"
+      >
+        {browseLabel}
+      </motion.a>
+    </div>
+  );
+}
+
+/** Centers a variant and gives it a consistent minimum stage height. */
+export function NotFoundStage({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-[420px] w-full flex-col items-center justify-center gap-8 px-4 text-center",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/motion/not-found/spotlight.tsx
+++ b/components/motion/not-found/spotlight.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useRef } from "react";
+import {
+  motion,
+  useMotionTemplate,
+  useMotionValue,
+  useReducedMotion,
+} from "motion/react";
+import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
+import { cn } from "@/lib/utils";
+import {
+  NOT_FOUND_DEFAULTS,
+  NotFoundActions,
+  NotFoundStage,
+  type NotFoundProps,
+} from "./shared";
+
+export function NotFoundSpotlight({
+  className,
+  code = NOT_FOUND_DEFAULTS.code,
+  title = NOT_FOUND_DEFAULTS.title,
+  description = NOT_FOUND_DEFAULTS.description,
+  homeHref,
+  homeLabel,
+  browseHref,
+  browseLabel,
+}: NotFoundProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const reduce = useReducedMotion();
+  const canHover = useHoverCapable();
+  const enabled = !reduce && canHover;
+
+  const mx = useMotionValue(50);
+  const my = useMotionValue(50);
+  const mask = useMotionTemplate`radial-gradient(220px circle at ${mx}% ${my}%, #000 25%, transparent 72%)`;
+
+  const onMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const el = ref.current;
+    if (!el || !enabled) return;
+    const rect = el.getBoundingClientRect();
+    mx.set(((e.clientX - rect.left) / rect.width) * 100);
+    my.set(((e.clientY - rect.top) / rect.height) * 100);
+  };
+
+  return (
+    <NotFoundStage className={className}>
+      <motion.div
+        ref={ref}
+        onMouseMove={onMove}
+        className="relative isolate flex aspect-[16/9] w-full max-w-xl items-center justify-center overflow-hidden rounded-3xl border border-border bg-neutral-950"
+      >
+        {/* Dim base layer. */}
+        <span
+          aria-hidden
+          className="select-none font-bold leading-none tracking-tighter text-white/10 [font-size:clamp(5rem,16vw,10rem)]"
+        >
+          {code}
+        </span>
+        {/* Bright layer, revealed only under the spotlight. */}
+        <motion.h1
+          aria-label={code}
+          style={enabled ? { WebkitMaskImage: mask, maskImage: mask } : undefined}
+          className={cn(
+            "absolute select-none font-bold leading-none tracking-tighter text-white [font-size:clamp(5rem,16vw,10rem)]",
+            !enabled && "text-white/90",
+          )}
+        >
+          <span aria-hidden>{code}</span>
+        </motion.h1>
+      </motion.div>
+
+      <div className="flex flex-col items-center gap-2">
+        <p className="text-lg font-semibold text-foreground">{title}</p>
+        <p className="max-w-sm text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      <NotFoundActions
+        homeHref={homeHref}
+        homeLabel={homeLabel}
+        browseHref={browseHref}
+        browseLabel={browseLabel}
+      />
+    </NotFoundStage>
+  );
+}

--- a/components/motion/not-found/stacked.tsx
+++ b/components/motion/not-found/stacked.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { SPRING_PANEL } from "@/lib/ease";
+import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
+import {
+  NOT_FOUND_DEFAULTS,
+  NotFoundActions,
+  NotFoundStage,
+  type NotFoundProps,
+} from "./shared";
+
+const CARD =
+  "absolute inset-0 rounded-3xl border border-border bg-card shadow-sm";
+
+export function NotFoundStacked({
+  className,
+  code = NOT_FOUND_DEFAULTS.code,
+  title = NOT_FOUND_DEFAULTS.title,
+  description = NOT_FOUND_DEFAULTS.description,
+  homeHref,
+  homeLabel,
+  browseHref,
+  browseLabel,
+}: NotFoundProps) {
+  const reduce = useReducedMotion();
+  const canHover = useHoverCapable();
+  const interactive = !reduce && canHover;
+
+  return (
+    <NotFoundStage className={className}>
+      <motion.div
+        initial="rest"
+        animate="rest"
+        whileHover={interactive ? "hover" : undefined}
+        className="relative h-44 w-64"
+      >
+        <motion.div
+          aria-hidden
+          variants={{ rest: { rotate: 0, x: 0, y: 0 }, hover: { rotate: -9, x: -28, y: 8 } }}
+          transition={SPRING_PANEL}
+          className={CARD}
+        />
+        <motion.div
+          aria-hidden
+          variants={{ rest: { rotate: 0, x: 0, y: 0 }, hover: { rotate: 9, x: 28, y: 8 } }}
+          transition={SPRING_PANEL}
+          className={CARD}
+        />
+        <motion.div
+          variants={{ rest: { y: 0 }, hover: { y: -6 } }}
+          transition={SPRING_PANEL}
+          className="absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-3xl border border-border bg-card shadow-md"
+        >
+          <h1 className="select-none font-bold leading-none tracking-tighter text-foreground [font-size:clamp(3.5rem,9vw,5rem)]">
+            {code}
+          </h1>
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            out of the deck
+          </span>
+        </motion.div>
+      </motion.div>
+
+      <div className="flex flex-col items-center gap-2">
+        <p className="text-lg font-semibold text-foreground">{title}</p>
+        <p className="max-w-sm text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      <NotFoundActions
+        homeHref={homeHref}
+        homeLabel={homeLabel}
+        browseHref={browseHref}
+        browseLabel={browseLabel}
+      />
+    </NotFoundStage>
+  );
+}

--- a/components/motion/not-found/terminal.tsx
+++ b/components/motion/not-found/terminal.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { TextReveal } from "@/components/motion/text-reveal";
+import {
+  NOT_FOUND_DEFAULTS,
+  NotFoundActions,
+  NotFoundStage,
+  type NotFoundProps,
+} from "./shared";
+
+const TYPE_SPRING = { stiffness: 320, damping: 30, mass: 0.6 };
+
+export function NotFoundTerminal({
+  className,
+  code = NOT_FOUND_DEFAULTS.code,
+  title = NOT_FOUND_DEFAULTS.title,
+  description = NOT_FOUND_DEFAULTS.description,
+  homeHref,
+  homeLabel,
+  browseHref,
+  browseLabel,
+}: NotFoundProps) {
+  return (
+    <NotFoundStage className={className}>
+      <div className="w-full max-w-md overflow-hidden rounded-xl border border-border bg-neutral-950 text-left shadow-lg">
+        <div className="flex items-center gap-1.5 border-b border-white/10 px-4 py-3">
+          <span className="h-3 w-3 rounded-full bg-[#ff5f57]" />
+          <span className="h-3 w-3 rounded-full bg-[#febc2e]" />
+          <span className="h-3 w-3 rounded-full bg-[#28c840]" />
+          <span className="ml-2 text-xs text-white/40">~/beui</span>
+        </div>
+        <div className="space-y-1.5 p-4 font-mono text-sm leading-relaxed">
+          <TextReveal
+            as="p"
+            split="char"
+            stagger={0.018}
+            blur={6}
+            yOffset={0}
+            spring={TYPE_SPRING}
+            className="text-white/80"
+            text="$ cd /page"
+          />
+          <TextReveal
+            as="p"
+            split="char"
+            stagger={0.012}
+            delay={0.45}
+            blur={6}
+            yOffset={0}
+            spring={TYPE_SPRING}
+            className="text-[#ff5f57]"
+            text="cd: no such file or directory: /page"
+          />
+          <p className="flex items-center text-white/80">
+            <TextReveal
+              as="span"
+              split="char"
+              stagger={0.018}
+              delay={1.1}
+              blur={6}
+              yOffset={0}
+              spring={TYPE_SPRING}
+              text={`$ status ${code}`}
+            />
+            <span className="ml-1 inline-block h-[1.1em] w-[0.55ch] translate-y-[0.12em] bg-white/80 motion-safe:animate-pulse" />
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-2">
+        <p className="text-lg font-semibold text-foreground">{title}</p>
+        <p className="max-w-sm text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      <NotFoundActions
+        homeHref={homeHref}
+        homeLabel={homeLabel}
+        browseHref={browseHref}
+        browseLabel={browseLabel}
+      />
+    </NotFoundStage>
+  );
+}

--- a/components/previews/blocks/not-found-glitch.preview.tsx
+++ b/components/previews/blocks/not-found-glitch.preview.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { NotFoundGlitch } from "@/components/motion/not-found/glitch";
+
+export function NotFoundGlitchPreview() {
+  return (
+    <div className="w-full">
+      <NotFoundGlitch />
+    </div>
+  );
+}

--- a/components/previews/blocks/not-found-magnetic.preview.tsx
+++ b/components/previews/blocks/not-found-magnetic.preview.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { NotFoundMagnetic } from "@/components/motion/not-found/magnetic";
+
+export function NotFoundMagneticPreview() {
+  return (
+    <div className="w-full">
+      <NotFoundMagnetic />
+    </div>
+  );
+}

--- a/components/previews/blocks/not-found-spotlight.preview.tsx
+++ b/components/previews/blocks/not-found-spotlight.preview.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { NotFoundSpotlight } from "@/components/motion/not-found/spotlight";
+
+export function NotFoundSpotlightPreview() {
+  return (
+    <div className="w-full">
+      <NotFoundSpotlight />
+    </div>
+  );
+}

--- a/components/previews/blocks/not-found-stacked.preview.tsx
+++ b/components/previews/blocks/not-found-stacked.preview.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { NotFoundStacked } from "@/components/motion/not-found/stacked";
+
+export function NotFoundStackedPreview() {
+  return (
+    <div className="w-full">
+      <NotFoundStacked />
+    </div>
+  );
+}

--- a/components/previews/blocks/not-found-terminal.preview.tsx
+++ b/components/previews/blocks/not-found-terminal.preview.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { NotFoundTerminal } from "@/components/motion/not-found/terminal";
+
+export function NotFoundTerminalPreview() {
+  return (
+    <div className="w-full">
+      <NotFoundTerminal />
+    </div>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -89,6 +89,21 @@ export const previews: Record<string, ComponentType> = {
   "blocks/otp-input": dynamic(() =>
     import("./blocks/otp-input.preview").then((m) => m.OTPInputPreview),
   ),
+  "blocks/not-found-glitch": dynamic(() =>
+    import("./blocks/not-found-glitch.preview").then((m) => m.NotFoundGlitchPreview),
+  ),
+  "blocks/not-found-magnetic": dynamic(() =>
+    import("./blocks/not-found-magnetic.preview").then((m) => m.NotFoundMagneticPreview),
+  ),
+  "blocks/not-found-spotlight": dynamic(() =>
+    import("./blocks/not-found-spotlight.preview").then((m) => m.NotFoundSpotlightPreview),
+  ),
+  "blocks/not-found-stacked": dynamic(() =>
+    import("./blocks/not-found-stacked.preview").then((m) => m.NotFoundStackedPreview),
+  ),
+  "blocks/not-found-terminal": dynamic(() =>
+    import("./blocks/not-found-terminal.preview").then((m) => m.NotFoundTerminalPreview),
+  ),
   "motion/shared-layout-bg": dynamic(() =>
     import("./motion/shared-layout-bg.preview").then((m) => m.SharedLayoutBgPreview),
   ),

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -330,6 +330,73 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/otp-input.tsx",
         badge: "new",
       },
+      {
+        slug: "not-found",
+        name: "404 / Not Found",
+        description: "Animated 404 pages in five styles: glitch scramble, magnetic digits, cursor spotlight, a fanning card stack and a typed terminal.",
+        file: "components/motion/not-found/index.tsx",
+        extraFiles: [
+          "components/motion/not-found/shared.tsx",
+          "components/motion/not-found/glitch.tsx",
+          "components/motion/not-found/magnetic.tsx",
+          "components/motion/not-found/spotlight.tsx",
+          "components/motion/not-found/stacked.tsx",
+          "components/motion/not-found/terminal.tsx",
+        ],
+        badge: "new",
+        examples: [
+          {
+            slug: "glitch",
+            name: "Glitch",
+            description:
+              "Digits scramble through random glyphs before resolving, with a chromatic split on hover.",
+            installSlug: "not-found-glitch",
+            file: "components/motion/not-found/glitch.tsx",
+            previewKey: "blocks/not-found-glitch",
+            previewFile: "components/previews/blocks/not-found-glitch.preview.tsx",
+          },
+          {
+            slug: "magnetic",
+            name: "Magnetic",
+            description:
+              "Each digit is cursor-attracted via the Magnetic wrapper and springs back on leave.",
+            installSlug: "not-found-magnetic",
+            file: "components/motion/not-found/magnetic.tsx",
+            previewKey: "blocks/not-found-magnetic",
+            previewFile: "components/previews/blocks/not-found-magnetic.preview.tsx",
+          },
+          {
+            slug: "spotlight",
+            name: "Spotlight",
+            description:
+              "A dark panel where a cursor-tracked spotlight reveals the bright code from a dim base.",
+            installSlug: "not-found-spotlight",
+            file: "components/motion/not-found/spotlight.tsx",
+            previewKey: "blocks/not-found-spotlight",
+            previewFile: "components/previews/blocks/not-found-spotlight.preview.tsx",
+          },
+          {
+            slug: "stacked",
+            name: "Stacked",
+            description:
+              "A code card over a hidden stack that fans out with a spring on hover.",
+            installSlug: "not-found-stacked",
+            file: "components/motion/not-found/stacked.tsx",
+            previewKey: "blocks/not-found-stacked",
+            previewFile: "components/previews/blocks/not-found-stacked.preview.tsx",
+          },
+          {
+            slug: "terminal",
+            name: "Terminal",
+            description:
+              "A terminal window that types a failed cd command and a 404 status, with a blinking caret.",
+            installSlug: "not-found-terminal",
+            file: "components/motion/not-found/terminal.tsx",
+            previewKey: "blocks/not-found-terminal",
+            previewFile: "components/previews/blocks/not-found-terminal.preview.tsx",
+          },
+        ],
+      },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
New `not-found` block (blocks category) with five animated 404 styles, plus the site 404 page wired to one of them.

Each variant is its own installable registry item with a preview:

| variant | install slug | motion |
|---|---|---|
| Glitch | `not-found-glitch` | scramble-to-resolve digits + chromatic hover split |
| Magnetic | `not-found-magnetic` | cursor-attracted digits via the `Magnetic` primitive |
| Spotlight | `not-found-spotlight` | cursor-tracked reveal of the code on a dark panel |
| Stacked | `not-found-stacked` | code card over a hidden stack that fans out on hover |
| Terminal | `not-found-terminal` | typed `cd` failure + 404 status via `TextReveal` |

Browse all five at `/components/blocks/not-found`.

## Details
- `components/motion/not-found/` — `shared.tsx` (`NotFoundProps`, `NotFoundActions` dual CTA, `NotFoundStage`), one file per variant, `index.tsx` barrel.
- Reuses existing primitives (`Magnetic`, `TextReveal`); the registry bundles them automatically by following imports.
- All transform motion gated behind `useReducedMotion()`; decorative hover gated behind `useHoverCapable()`. SSR renders the real `404` so reduced-motion and crawlers see it immediately.
- CTAs are portable `<a>` links (not the `Button` or site `PressLink`) to keep the installed bundle framework-light and a11y-clean.
- `app/not-found.tsx` → **Glitch** variant as the site 404.

## Verification
- `bun run typecheck` clean
- `bun run check:registry` validates (28 components)
- `bun run lint` only the pre-existing `install-command.tsx` warning