### PR TITLE
refactor: match Related components to site card style

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   TabsTrigger,
 } from "@/components/motion/tabs";
 import { NewBadge } from "@/components/app/new-badge";
+import { ComponentCard } from "@/components/app/component-card";
 import { JsonLd } from "@/components/app/json-ld";
 import { getPreview, previews } from "@/components/previews";
 import { readSourceFile } from "@/lib/source-files";
@@ -135,7 +136,7 @@ export default async function ComponentPage({
   if (!cat || !comp) notFound();
   const hasVariantInstallCommands =
     comp.examples?.some((example) => example.installSlug) ?? false;
-  const related = relatedComponents(cat.slug, comp.slug);
+  const related = relatedComponents(cat.slug, comp.slug, 3);
 
   return (
     <div>
@@ -201,23 +202,18 @@ export default async function ComponentPage({
           <h2 className="text-sm font-semibold text-(--color-fg)">
             Related components
           </h2>
-          <ul className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {related.map((rel) => (
-              <li key={`${rel.category}/${rel.slug}`}>
-                <Link
-                  href={`/components/${rel.category}/${rel.slug}`}
-                  className="group/rel flex h-full flex-col rounded-2xl border border-(--color-border) bg-(--color-bg-elev) p-4 transition-colors hover:bg-(--color-bg-elev)/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
-                >
-                  <span className="font-medium text-(--color-fg)">
-                    {rel.name}
-                  </span>
-                  <span className="mt-1 line-clamp-2 text-sm text-(--color-fg-muted)">
-                    {rel.description}
-                  </span>
-                </Link>
-              </li>
+              <ComponentCard
+                key={`${rel.category}/${rel.slug}`}
+                categorySlug={rel.category}
+                slug={rel.slug}
+                name={rel.name}
+                description={rel.description}
+                badge={rel.badge}
+              />
             ))}
-          </ul>
+          </div>
         </section>
       ) : null}
     </div>

--- a/app/components/[category]/page.tsx
+++ b/app/components/[category]/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Link from "next/link";
-import { findCategory, registry, type ComponentEntry } from "@/lib/registry";
-import { NewBadge } from "@/components/app/new-badge";
+import { findCategory, registry } from "@/lib/registry";
+import { ComponentCard } from "@/components/app/component-card";
 import { JsonLd } from "@/components/app/json-ld";
 import { breadcrumbJsonLd, categoryJsonLd } from "@/lib/seo";
 
@@ -109,10 +108,13 @@ export default async function CategoryPage({
           </p>
           <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {newComponents.map((comp) => (
-              <CategoryComponentCard
+              <ComponentCard
                 key={comp.slug}
                 categorySlug={cat.slug}
-                component={comp}
+                slug={comp.slug}
+                name={comp.name}
+                description={comp.description}
+                badge={comp.badge}
               />
             ))}
           </div>
@@ -125,42 +127,17 @@ export default async function CategoryPage({
         </p>
         <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {components.map((comp) => (
-            <CategoryComponentCard
+            <ComponentCard
               key={comp.slug}
               categorySlug={cat.slug}
-              component={comp}
+              slug={comp.slug}
+              name={comp.name}
+              description={comp.description}
+              badge={comp.badge}
             />
           ))}
         </div>
       </section>
     </div>
-  );
-}
-
-function CategoryComponentCard({
-  categorySlug,
-  component,
-}: {
-  categorySlug: string;
-  component: ComponentEntry;
-}) {
-  return (
-    <Link
-      href={`/components/${categorySlug}/${component.slug}`}
-      className="group/card relative flex h-40 flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
-    >
-      <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
-        <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
-          {component.name}
-        </h3>
-        {component.badge === "new" ? <NewBadge /> : null}
-      </div>
-
-      <div className="mx-2 mb-2 flex min-h-0 flex-1 items-start overflow-hidden rounded-3xl bg-(--color-bg) px-4 py-4 transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-(--color-bg)/80 group-focus-visible/card:bg-(--color-bg)/80">
-        <p className="line-clamp-3 text-sm leading-relaxed text-(--color-fg-muted)">
-          {component.description}
-        </p>
-      </div>
-    </Link>
   );
 }

--- a/components/app/component-card.tsx
+++ b/components/app/component-card.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { NewBadge } from "@/components/app/new-badge";
+
+export function ComponentCard({
+  categorySlug,
+  slug,
+  name,
+  description,
+  badge,
+}: {
+  categorySlug: string;
+  slug: string;
+  name: string;
+  description: string;
+  badge?: "new";
+}) {
+  return (
+    <Link
+      href={`/components/${categorySlug}/${slug}`}
+      className="group/card relative flex h-40 flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
+    >
+      <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
+        <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
+          {name}
+        </h3>
+        {badge === "new" ? <NewBadge /> : null}
+      </div>
+
+      <div className="mx-2 mb-2 flex min-h-0 flex-1 items-start overflow-hidden rounded-3xl bg-(--color-bg) px-4 py-4 transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-(--color-bg)/80 group-focus-visible/card:bg-(--color-bg)/80">
+        <p className="line-clamp-3 text-sm leading-relaxed text-(--color-fg-muted)">
+          {description}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -125,6 +125,7 @@ export type RelatedComponent = {
   slug: string;
   name: string;
   description: string;
+  badge?: "new";
 };
 
 /**
@@ -156,5 +157,6 @@ function toRelated(categorySlug: string, c: ComponentEntry): RelatedComponent {
     slug: c.slug,
     name: c.name,
     description: c.description,
+    badge: c.badge,
   };
 }


### PR DESCRIPTION
Related components on the component detail page used a one-off bordered card. Now they use the same card as the category listing.

- Extract `CategoryComponentCard` into a shared `components/app/component-card.tsx` (`ComponentCard`).
- Category page uses it (no behavior change).
- Related section renders `ComponentCard` in the same 3-col grid, with `new` badge passthrough; related count trimmed to 3 for a clean row.

## Verification
- `bun run typecheck` clean
- `bun run check:registry` validates
- `bun run lint` only the pre-existing `install-command.tsx` warning