### PR TITLE
feat: manual (shadcn-free) install path

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -9,7 +9,7 @@ import {
   type ComponentExample,
 } from "@/lib/registry";
 import { CodeBlock } from "@/components/app/code-block";
-import { InstallCommand } from "@/components/app/install-command";
+import { InstallBlock } from "@/components/app/install-block";
 import {
   Tabs,
   TabsContent,
@@ -169,7 +169,7 @@ export default async function ComponentPage({
       {comp.examples?.length ? (
         <div className="mt-10 flex flex-col gap-12">
           {comp.examples.map((ex) => (
-            <ExampleBlock key={ex.slug} example={ex} />
+            <ExampleBlock key={ex.slug} category={cat.slug} example={ex} />
           ))}
         </div>
       ) : (
@@ -181,10 +181,10 @@ export default async function ComponentPage({
           <div className="min-w-0">
             <h2 className="text-sm font-semibold text-(--color-fg)">Install</h2>
             <p className="mt-1 text-sm text-(--color-fg-muted)">
-              Add this component with the shadcn CLI.
+              Add it with the shadcn CLI, or copy the source manually.
             </p>
             <div className="mt-3">
-              <InstallCommand slug={comp.slug} />
+              <InstallBlock category={cat.slug} slug={comp.slug} />
             </div>
           </div>
         </section>
@@ -213,7 +213,13 @@ export default async function ComponentPage({
   );
 }
 
-async function ExampleBlock({ example }: { example: ComponentExample }) {
+async function ExampleBlock({
+  category,
+  example,
+}: {
+  category: string;
+  example: ComponentExample;
+}) {
   const Preview = previews[example.previewKey];
   const source = await loadSource(example.file);
   const usage = await loadSource(example.previewFile);
@@ -256,7 +262,7 @@ async function ExampleBlock({ example }: { example: ComponentExample }) {
         <div className="mt-5 min-w-0 border-t border-(--color-border) pt-5">
           <h3 className="text-sm font-semibold text-(--color-fg)">Install</h3>
           <div className="mt-3">
-            <InstallCommand slug={installSlug} />
+            <InstallBlock category={category} slug={installSlug} />
           </div>
         </div>
       ) : null}

--- a/components/app/install-block.tsx
+++ b/components/app/install-block.tsx
@@ -1,0 +1,22 @@
+import { InstallCommand } from "@/components/app/install-command";
+import { InstallTabs } from "@/components/app/install-tabs";
+import { ManualInstall } from "@/components/app/manual-install";
+
+/**
+ * Install UI for a component: the shadcn CLI command plus a shadcn-free
+ * manual path (deps + files), switchable via tabs.
+ */
+export function InstallBlock({
+  category,
+  slug,
+}: {
+  category: string;
+  slug: string;
+}) {
+  return (
+    <InstallTabs
+      cli={<InstallCommand slug={slug} />}
+      manual={<ManualInstall category={category} slug={slug} />}
+    />
+  );
+}

--- a/components/app/install-tabs.tsx
+++ b/components/app/install-tabs.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/motion/tabs";
+
+/**
+ * CLI / Manual switch for installing a component. Both panels are rendered on
+ * the server and passed in as nodes; this only owns the tab state.
+ */
+export function InstallTabs({
+  cli,
+  manual,
+}: {
+  cli: ReactNode;
+  manual: ReactNode;
+}) {
+  return (
+    <Tabs defaultValue="cli" variant="segment">
+      <TabsList>
+        <TabsTrigger value="cli">CLI</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
+      </TabsList>
+      <TabsContent value="cli" className="mt-4">
+        {cli}
+      </TabsContent>
+      <TabsContent value="manual" className="mt-4">
+        {manual}
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/components/app/manual-install.tsx
+++ b/components/app/manual-install.tsx
@@ -1,0 +1,65 @@
+import { CodeBlock } from "@/components/app/code-block";
+import { buildEntry } from "@/lib/registry-server";
+
+// Already present in any React project; not worth a copy-paste install line.
+const SKIP_DEPS = new Set(["react", "react-dom", "next"]);
+
+/**
+ * The shadcn-free install path: install deps, drop in the util files, copy the
+ * source. Everything is derived from the same source graph the registry uses.
+ */
+export async function ManualInstall({
+  category,
+  slug,
+}: {
+  category: string;
+  slug: string;
+}) {
+  const entry = await buildEntry(category, slug);
+  if (!entry) return null;
+
+  const deps = entry.dependencies.filter((dep) => !SKIP_DEPS.has(dep));
+  const utilFiles = entry.files.filter((file) => file.path.startsWith("lib/"));
+  const sourceFiles = entry.files.filter(
+    (file) => file.type !== "preview" && !file.path.startsWith("lib/"),
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      {deps.length > 0 ? (
+        <section>
+          <h3 className="text-sm font-semibold text-(--color-fg)">
+            Install dependencies
+          </h3>
+          <div className="mt-3">
+            <CodeBlock code={`npm i ${deps.join(" ")}`} lang="bash" />
+          </div>
+        </section>
+      ) : null}
+
+      {utilFiles.length > 0 ? (
+        <section>
+          <h3 className="text-sm font-semibold text-(--color-fg)">
+            Add util file{utilFiles.length > 1 ? "s" : ""}
+          </h3>
+          <div className="mt-3 flex flex-col gap-4">
+            {utilFiles.map((file) => (
+              <CodeBlock key={file.path} code={file.content} filename={file.path} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section>
+        <h3 className="text-sm font-semibold text-(--color-fg)">
+          Copy the source code
+        </h3>
+        <div className="mt-3 flex flex-col gap-4">
+          {sourceFiles.map((file) => (
+            <CodeBlock key={file.path} code={file.content} filename={file.path} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
The install widget only emitted a `shadcn add` command, which requires a shadcn-initialized project (`components.json`). Adds a **CLI / Manual** switch so non-shadcn users (plain React/Vite) have a real path.

Manual mirrors what shadcn would do, all derived from `buildEntry`:
1. **Install dependencies** — `npm i <deps>` (external deps, minus react/react-dom/next)
2. **Add util files** — every `lib/*` helper (`lib/utils.ts`, `lib/ease.ts`, hooks) in its own `CodeBlock` with the target path
3. **Copy the source code** — the component file(s) in `CodeBlock`s

## Components
- `install-tabs.tsx` (client) — owns the CLI/Manual tab state; both panels rendered on the server and passed in
- `manual-install.tsx` (server) — reads the source graph via `buildEntry`, groups files into util vs source
- `install-block.tsx` (server) — composes `InstallCommand` (CLI) + `ManualInstall`

Wired into both the main install section and per-variant example blocks.

## Verification
- `bun run typecheck` clean
- `bun run check:registry` validates (28)
- `bun run lint` only the pre-existing `install-command.tsx` warning