### PR TITLE
refactor: single shadcn token system (drop --bg/--fg aliases)

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -149,20 +149,20 @@ export default async function ComponentPage({
       >
         <Link
           href={`/components/${cat.slug}`}
-          className="text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+          className="text-muted-foreground transition-colors hover:text-foreground"
         >
           {cat.name}
         </Link>
-        <ChevronRight className="h-3.5 w-3.5 text-(--color-fg-muted)" />
-        <span className="font-medium text-(--color-fg)">{comp.name}</span>
+        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="font-medium text-foreground">{comp.name}</span>
       </nav>
       <div className="mt-4 flex items-center gap-3">
-        <h1 className="text-3xl font-semibold tracking-tight text-(--color-fg)">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
           {comp.name}
         </h1>
         {comp.badge === "new" ? <NewBadge className="mt-1" /> : null}
       </div>
-      <p className="mt-2 max-w-2xl text-(--color-fg-muted)">
+      <p className="mt-2 max-w-2xl text-muted-foreground">
         {comp.description}
       </p>
 
@@ -177,10 +177,10 @@ export default async function ComponentPage({
       )}
 
       {!hasVariantInstallCommands ? (
-        <section className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-6 border-t border-(--color-border) pt-8">
+        <section className="mt-12 grid grid-cols-[minmax(0,1fr)] gap-6 border-t border-border pt-8">
           <div className="min-w-0">
-            <h2 className="text-sm font-semibold text-(--color-fg)">Install</h2>
-            <p className="mt-1 text-sm text-(--color-fg-muted)">
+            <h2 className="text-sm font-semibold text-foreground">Install</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
               Add it with the shadcn CLI, or copy the source manually.
             </p>
             <div className="mt-3">
@@ -191,8 +191,8 @@ export default async function ComponentPage({
       ) : null}
 
       {related.length ? (
-        <section className="mt-12 border-t border-(--color-border) pt-8">
-          <h2 className="text-sm font-semibold text-(--color-fg)">
+        <section className="mt-12 border-t border-border pt-8">
+          <h2 className="text-sm font-semibold text-foreground">
             Related components
           </h2>
           <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
@@ -228,15 +228,15 @@ async function ExampleBlock({
   return (
     <section>
       <div className="mb-4 flex items-baseline justify-between gap-3">
-        <h2 className="text-xl font-semibold tracking-tight text-(--color-fg)">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
           {example.name}
         </h2>
-        <code className="rounded-md bg-(--color-fg)/5 px-2 py-0.5 font-mono text-[11px] text-(--color-fg-muted)">
+        <code className="rounded-md bg-foreground/5 px-2 py-0.5 font-mono text-[11px] text-muted-foreground">
           {example.file.split("/").pop()}
         </code>
       </div>
       {example.description ? (
-        <p className="mb-4 text-sm text-(--color-fg-muted)">
+        <p className="mb-4 text-sm text-muted-foreground">
           {example.description}
         </p>
       ) : null}
@@ -247,7 +247,7 @@ async function ExampleBlock({
           <TabsTrigger value="source">Code</TabsTrigger>
         </TabsList>
         <TabsContent value="preview" className="mt-4">
-          <div className="flex min-h-[260px] items-center justify-center rounded-2xl border border-(--color-border) bg-(--color-bg-elev) py-10">
+          <div className="flex min-h-[260px] items-center justify-center rounded-2xl border border-border bg-card py-10">
             {Preview ? <Preview /> : null}
           </div>
         </TabsContent>
@@ -259,8 +259,8 @@ async function ExampleBlock({
         </TabsContent>
       </Tabs>
       {installSlug ? (
-        <div className="mt-5 min-w-0 border-t border-(--color-border) pt-5">
-          <h3 className="text-sm font-semibold text-(--color-fg)">Install</h3>
+        <div className="mt-5 min-w-0 border-t border-border pt-5">
+          <h3 className="text-sm font-semibold text-foreground">Install</h3>
           <div className="mt-3">
             <InstallBlock category={category} slug={installSlug} />
           </div>

--- a/app/components/[category]/page.tsx
+++ b/app/components/[category]/page.tsx
@@ -98,18 +98,18 @@ export default async function CategoryPage({
         aria-label="Breadcrumb"
         className="flex items-center gap-1.5 text-sm"
       >
-        <span className="font-medium text-(--color-fg)">{cat.name}</span>
+        <span className="font-medium text-foreground">{cat.name}</span>
       </nav>
-      <h1 className="mt-4 text-3xl font-semibold tracking-tight text-(--color-fg)">
+      <h1 className="mt-4 text-3xl font-semibold tracking-tight text-foreground">
         {cat.name}
       </h1>
-      <p className="mt-2 max-w-2xl text-(--color-fg-muted)">
+      <p className="mt-2 max-w-2xl text-muted-foreground">
         {cat.description}
       </p>
 
       {newComponents.length ? (
         <section className="mt-10">
-          <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
+          <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
             New
           </p>
           <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
@@ -128,7 +128,7 @@ export default async function CategoryPage({
       ) : null}
 
       <section className="mt-10">
-        <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
+        <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
           All {cat.name}
         </p>
         <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/app/docs/ai-agents/page.tsx
+++ b/app/docs/ai-agents/page.tsx
@@ -73,29 +73,29 @@ const ENTRY_SHAPE = `{
 export default function AIAgentsPage() {
   return (
     <div className="max-w-3xl">
-      <p className="text-xs font-semibold uppercase tracking-wider text-(--color-fg-muted)">Intro</p>
-      <h1 className="mt-2 text-3xl font-semibold tracking-tight text-(--color-fg)">For AI agents</h1>
-      <p className="mt-3 text-(--color-fg-muted)">
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Intro</p>
+      <h1 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">For AI agents</h1>
+      <p className="mt-3 text-muted-foreground">
         beUI exposes a static, agent-friendly surface. Coding agents (Cursor, Claude, GPT, custom MCP) can list components, fetch source with all deps, and drop files into the user&apos;s project with one HTTP call.
       </p>
 
-      <h2 className="mt-10 text-xl font-semibold tracking-tight text-(--color-fg)">Endpoints</h2>
-      <ul className="mt-4 divide-y divide-(--color-border) rounded-2xl border border-(--color-border) bg-(--color-bg-elev)">
+      <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">Endpoints</h2>
+      <ul className="mt-4 divide-y divide-border rounded-2xl border border-border bg-card">
         {ENDPOINTS.map((e) => (
           <li key={e.url} className="flex items-start justify-between gap-4 p-4">
             <div className="min-w-0">
               <div className="flex items-center gap-2">
-                <code className="rounded-md bg-(--color-fg)/5 px-2 py-0.5 font-mono text-xs text-(--color-fg)">{e.url}</code>
-                <span className="text-sm font-medium text-(--color-fg)">{e.label}</span>
+                <code className="rounded-md bg-foreground/5 px-2 py-0.5 font-mono text-xs text-foreground">{e.url}</code>
+                <span className="text-sm font-medium text-foreground">{e.label}</span>
               </div>
-              <p className="mt-1 text-sm text-(--color-fg-muted)">{e.desc}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{e.desc}</p>
             </div>
             {!e.url.includes("{") ? (
               <Link
                 href={e.url}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex shrink-0 items-center gap-1 rounded-full border border-(--color-border) bg-(--color-bg) px-3 py-1 text-xs text-(--color-fg-muted) hover:text-(--color-fg)"
+                className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border bg-background px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
               >
                 Open
                 <ArrowUpRight className="h-3 w-3" />
@@ -105,31 +105,31 @@ export default function AIAgentsPage() {
         ))}
       </ul>
 
-      <h2 className="mt-10 text-xl font-semibold tracking-tight text-(--color-fg)">Agent flow</h2>
-      <p className="mt-2 text-(--color-fg-muted)">Four calls, then install. Components are self-contained and own their files.</p>
+      <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">Agent flow</h2>
+      <p className="mt-2 text-muted-foreground">Four calls, then install. Components are self-contained and own their files.</p>
       <div className="mt-4">
         <CodeBlock code={FETCH_SNIPPET} lang="ts" filename="agent.ts" />
       </div>
 
-      <h2 className="mt-10 text-xl font-semibold tracking-tight text-(--color-fg)">shadcn flow</h2>
-      <p className="mt-2 text-(--color-fg-muted)">
+      <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">shadcn flow</h2>
+      <p className="mt-2 text-muted-foreground">
         The shadcn item installs source files and package dependencies. Components use shadcn semantic color utilities directly, so they inherit the target app&apos;s theme without beUI-specific color variables.
       </p>
       <div className="mt-4">
         <CodeBlock code={SHADCN_SNIPPET} lang="bash" filename="terminal" />
       </div>
 
-      <h2 className="mt-10 text-xl font-semibold tracking-tight text-(--color-fg)">Entry shape</h2>
-      <p className="mt-2 text-(--color-fg-muted)">
-        Internal helpers (e.g. <code className="rounded bg-(--color-fg)/5 px-1.5 py-0.5 font-mono text-xs">@/lib/utils</code>) ship inline as <code className="rounded bg-(--color-fg)/5 px-1.5 py-0.5 font-mono text-xs">type: util</code> so the agent does not have to chase imports.
+      <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">Entry shape</h2>
+      <p className="mt-2 text-muted-foreground">
+        Internal helpers (e.g. <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">@/lib/utils</code>) ship inline as <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">type: util</code> so the agent does not have to chase imports.
       </p>
       <div className="mt-4">
         <CodeBlock code={ENTRY_SHAPE} lang="json" filename="r/swap.json" />
       </div>
 
-      <h2 className="mt-10 text-xl font-semibold tracking-tight text-(--color-fg)">Caching</h2>
-      <p className="mt-2 text-(--color-fg-muted)">
-        All routes are pre-rendered at build, served with <code className="rounded bg-(--color-fg)/5 px-1.5 py-0.5 font-mono text-xs">cache-control: public, max-age=300, s-maxage=3600</code>.
+      <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">Caching</h2>
+      <p className="mt-2 text-muted-foreground">
+        All routes are pre-rendered at build, served with <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">cache-control: public, max-age=300, s-maxage=3600</code>.
       </p>
     </div>
   );

--- a/app/docs/motion-patterns/motion-patterns.tsx
+++ b/app/docs/motion-patterns/motion-patterns.tsx
@@ -120,20 +120,20 @@ export function MotionPatterns() {
               key={pattern.title}
               type="button"
               onClick={() => setActive(pattern)}
-              className="group min-h-32 rounded-2xl border border-(--color-border) bg-(--color-bg-elev) p-4 text-left transition-colors hover:border-(--color-border-strong) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-ring) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
+              className="group min-h-32 rounded-2xl border border-border bg-card p-4 text-left transition-colors hover:border-(--color-border-strong) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             >
               <div className="flex items-start justify-between gap-3">
-                <span className="flex h-9 w-9 items-center justify-center rounded-full border border-(--color-border) bg-(--color-bg)">
-                  <Icon className="h-4 w-4 text-(--color-fg)" aria-hidden="true" />
+                <span className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background">
+                  <Icon className="h-4 w-4 text-foreground" aria-hidden="true" />
                 </span>
-                <span className="rounded-full border border-(--color-border) bg-(--color-bg) px-2 py-1 font-mono text-[10px] text-(--color-fg-muted)">
+                <span className="rounded-full border border-border bg-background px-2 py-1 font-mono text-[10px] text-muted-foreground">
                   {pattern.spec}
                 </span>
               </div>
-              <h2 className="mt-4 font-pixel text-base uppercase text-(--color-fg)">
+              <h2 className="mt-4 font-pixel text-base uppercase text-foreground">
                 {pattern.title}
               </h2>
-              <p className="mt-1 text-sm leading-5 text-(--color-fg-muted)">
+              <p className="mt-1 text-sm leading-5 text-muted-foreground">
                 {pattern.short}
               </p>
             </button>
@@ -165,20 +165,20 @@ function PatternDetails({ pattern }: { pattern: Pattern }) {
 
   return (
     <div className="space-y-3 pt-2">
-      <section className="rounded-2xl border border-(--color-border) bg-(--color-bg) p-4">
+      <section className="rounded-2xl border border-border bg-background p-4">
         <div className="flex items-center justify-between gap-3">
-          <h3 className="font-pixel text-sm uppercase text-(--color-fg)">
+          <h3 className="font-pixel text-sm uppercase text-foreground">
             Live example
           </h3>
-          <span className="rounded-full border border-(--color-border) bg-(--color-bg-elev) px-2.5 py-1 font-mono text-[11px] text-(--color-fg-muted)">
+          <span className="rounded-full border border-border bg-card px-2.5 py-1 font-mono text-[11px] text-muted-foreground">
             {pattern.spec}
           </span>
         </div>
         <LiveExample pattern={pattern} />
       </section>
 
-      <section className="rounded-2xl border border-(--color-border) bg-(--color-bg) p-4">
-        <h3 className="font-pixel text-sm uppercase text-(--color-fg)">
+      <section className="rounded-2xl border border-border bg-background p-4">
+        <h3 className="font-pixel text-sm uppercase text-foreground">
           Simple guide
         </h3>
         <div className="mt-3 grid gap-3">
@@ -187,10 +187,10 @@ function PatternDetails({ pattern }: { pattern: Pattern }) {
               key={row.label}
               className="grid grid-cols-[72px_minmax(0,1fr)] items-start gap-4"
             >
-              <p className="pt-1 font-mono text-[11px] uppercase text-(--color-fg-muted)">
+              <p className="pt-1 font-mono text-[11px] uppercase text-muted-foreground">
                 {row.label}
               </p>
-              <p className="text-sm leading-6 text-(--color-fg-muted)">
+              <p className="text-sm leading-6 text-muted-foreground">
                 {row.value}
               </p>
             </div>
@@ -198,11 +198,11 @@ function PatternDetails({ pattern }: { pattern: Pattern }) {
         </div>
       </section>
 
-      <section className="rounded-2xl border border-(--color-border) bg-(--color-bg) p-4">
-        <h3 className="font-pixel text-sm uppercase text-(--color-fg)">
+      <section className="rounded-2xl border border-border bg-background p-4">
+        <h3 className="font-pixel text-sm uppercase text-foreground">
           Pseudo code
         </h3>
-        <pre className="mt-3 overflow-x-auto rounded-xl border border-(--color-border) bg-(--color-bg-elev) p-3 text-xs leading-6 text-(--color-fg)">
+        <pre className="mt-3 overflow-x-auto rounded-xl border border-border bg-card p-3 text-xs leading-6 text-foreground">
           <code>{pattern.code}</code>
         </pre>
       </section>
@@ -221,7 +221,7 @@ function LiveExample({ pattern }: { pattern: Pattern }) {
       <DemoFrame>
         <button
           type="button"
-          className="group inline-flex h-11 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-4 text-sm font-medium text-(--color-fg)"
+          className="group inline-flex h-11 items-center gap-2 rounded-full border border-border bg-card px-4 text-sm font-medium text-foreground"
         >
           <Bell className="h-4 w-4 origin-top motion-safe:group-hover:animate-action-bell" />
           Hover bell
@@ -242,10 +242,10 @@ function LiveExample({ pattern }: { pattern: Pattern }) {
           initial={{ opacity: 0, y: 12, filter: "blur(6px)" }}
           animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
           transition={{ duration: 0.52, ease: EASE_OUT }}
-          className="w-56 rounded-2xl bg-(--color-bg-elev) p-4"
+          className="w-56 rounded-2xl bg-card p-4"
         >
-          <p className="font-pixel text-sm uppercase text-(--color-fg)">New card</p>
-          <p className="mt-2 text-sm text-(--color-fg-muted)">Soft reveal with lift.</p>
+          <p className="font-pixel text-sm uppercase text-foreground">New card</p>
+          <p className="mt-2 text-sm text-muted-foreground">Soft reveal with lift.</p>
         </motion.div>
       </DemoFrame>
     );
@@ -258,7 +258,7 @@ function LiveExample({ pattern }: { pattern: Pattern }) {
           type="button"
           whileTap={{ scale: 0.97 }}
           transition={{ type: "spring", stiffness: 500, damping: 32 }}
-          className="h-11 rounded-full bg-(--color-fg) px-5 text-sm font-medium text-(--color-bg)"
+          className="h-11 rounded-full bg-foreground px-5 text-sm font-medium text-background"
         >
           Press me
         </motion.button>
@@ -281,26 +281,26 @@ function LiveExample({ pattern }: { pattern: Pattern }) {
           onBlur={() => setHoverExpand(false)}
           animate={{ width: expanded ? 136 : 44 }}
           transition={{ type: "spring", stiffness: 320, damping: 32 }}
-          className="relative h-11 overflow-hidden rounded-full border border-(--color-border) bg-(--color-bg-elev) text-left"
+          className="relative h-11 overflow-hidden rounded-full border border-border bg-card text-left"
         >
           <motion.span
             animate={{ opacity: expanded ? 0 : 1 }}
             transition={{ duration: 0.12 }}
             className="absolute inset-0 flex items-center justify-center"
           >
-            <PanelTopOpen className="h-4 w-4 text-(--color-fg)" />
+            <PanelTopOpen className="h-4 w-4 text-foreground" />
           </motion.span>
           <motion.span
             animate={{ opacity: expanded ? 1 : 0 }}
             transition={{ duration: 0.12, delay: expanded ? 0.04 : 0 }}
             className="absolute left-3.5 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center"
           >
-            <PanelTopOpen className="h-4 w-4 text-(--color-fg)" />
+            <PanelTopOpen className="h-4 w-4 text-foreground" />
           </motion.span>
           <motion.span
             animate={{ opacity: expanded ? 1 : 0, x: expanded ? 0 : -4 }}
             transition={{ duration: 0.18, delay: expanded ? 0.06 : 0 }}
-            className="absolute left-10 top-1/2 -translate-y-1/2 whitespace-nowrap text-sm text-(--color-fg)"
+            className="absolute left-10 top-1/2 -translate-y-1/2 whitespace-nowrap text-sm text-foreground"
           >
             Open panel
           </motion.span>
@@ -311,7 +311,7 @@ function LiveExample({ pattern }: { pattern: Pattern }) {
 
   return (
     <DemoFrame>
-      <div className="w-64 rounded-2xl bg-(--color-bg-elev) p-2">
+      <div className="w-64 rounded-2xl bg-card p-2">
         <div className="grid grid-cols-2 gap-1">
           {["Preview", "Code"].map((item) => (
             <button
@@ -321,8 +321,8 @@ function LiveExample({ pattern }: { pattern: Pattern }) {
               className={cn(
                 "rounded-full px-3 py-1.5 text-xs transition-colors",
                 tab === item
-                  ? "bg-(--color-fg) text-(--color-bg)"
-                  : "text-(--color-fg-muted)",
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground",
               )}
             >
               {item}
@@ -336,7 +336,7 @@ function LiveExample({ pattern }: { pattern: Pattern }) {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -4 }}
             transition={{ duration: 0.18, ease: EASE_OUT }}
-            className="mt-3 rounded-xl bg-(--color-bg) p-4 text-sm text-(--color-fg)"
+            className="mt-3 rounded-xl bg-background p-4 text-sm text-foreground"
           >
             {tab === "Preview" ? "Live component view" : "Code sample view"}
           </motion.div>
@@ -354,14 +354,14 @@ function DemoFrame({
   action?: ReactNode;
 }) {
   return (
-    <div className="mt-4 rounded-2xl bg-(--color-bg-elev) p-3">
+    <div className="mt-4 rounded-2xl bg-card p-3">
       <div className="mb-3 flex items-center justify-between gap-3">
-        <span className="font-mono text-[11px] uppercase text-(--color-fg-muted)">
+        <span className="font-mono text-[11px] uppercase text-muted-foreground">
           Try it
         </span>
         {action}
       </div>
-      <div className="flex min-h-32 items-center justify-center rounded-xl bg-(--color-bg) p-4">
+      <div className="flex min-h-32 items-center justify-center rounded-xl bg-background p-4">
         {children}
       </div>
     </div>
@@ -373,7 +373,7 @@ function ReplayButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-3 py-1.5 text-xs text-(--color-fg)"
+      className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-3 py-1.5 text-xs text-foreground"
     >
       <RefreshCw className="h-3 w-3" />
       Replay

--- a/app/docs/motion-patterns/page.tsx
+++ b/app/docs/motion-patterns/page.tsx
@@ -27,10 +27,10 @@ export const metadata: Metadata = {
 export default function MotionPatternsPage() {
   return (
     <div className="max-w-4xl">
-      <h1 className="font-pixel text-4xl uppercase tracking-tight text-(--color-fg)">
+      <h1 className="font-pixel text-4xl uppercase tracking-tight text-foreground">
         Motion Patterns
       </h1>
-      <p className="mt-3 max-w-2xl text-(--color-fg-muted)">
+      <p className="mt-3 max-w-2xl text-muted-foreground">
         Small cards for quick scanning. Open one to see the rule, example and what to avoid.
       </p>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,13 +3,14 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-    --bg: oklch(99% 0 0);
-    --bg-elev: oklch(97% 0 0);
-    --fg: oklch(15% 0 0);
-    --fg-muted: oklch(50% 0 0);
+    /* Base palette (concrete values). */
+    --background: oklch(99% 0 0);
+    --foreground: oklch(15% 0 0);
+    --card: oklch(97% 0 0);
+    --muted-foreground: oklch(50% 0 0);
     --border: oklch(15% 0 0 / 0.06);
+    /* beUI extensions (no shadcn equivalent). */
     --border-strong: oklch(15% 0 0 / 0.12);
-    --accent: oklch(72% 0.18 195);
     --accent-fg: oklch(15% 0 0);
     --neon: oklch(80% 0.22 145);
     --violet: oklch(68% 0.22 295);
@@ -20,29 +21,28 @@
     --glass-border: oklch(15% 0 0 / 0.08);
     --glass-strong-bg: rgb(255 255 255 / 0.7);
     --glass-thin-bg: rgb(255 255 255 / 0.45);
-    --background: var(--bg);
-    --foreground: var(--fg);
-    --card: var(--bg-elev);
-    --card-foreground: var(--fg);
-    --popover: var(--bg-elev);
-    --popover-foreground: var(--fg);
-    --primary: var(--fg);
-    --primary-foreground: var(--bg);
-    --secondary: var(--bg-elev);
-    --secondary-foreground: var(--fg);
-    --muted: var(--bg-elev);
-    --muted-foreground: var(--fg-muted);
+    /* shadcn semantic tokens, mapped onto the base. */
+    --card-foreground: var(--foreground);
+    --popover: var(--card);
+    --popover-foreground: var(--foreground);
+    --primary: var(--foreground);
+    --primary-foreground: var(--background);
+    --secondary: var(--card);
+    --secondary-foreground: var(--foreground);
+    --muted: var(--card);
+    --accent: oklch(72% 0.18 195);
     --accent-foreground: var(--accent-fg);
     --destructive: var(--danger);
     --input: var(--border);
     --ring: var(--border-strong);
 }
 
+/* Dark mode overrides only the base; semantic tokens follow via var(). */
 .dark {
-    --bg: #151515;
-    --bg-elev: #1c1c1c;
-    --fg: oklch(96% 0 0);
-    --fg-muted: oklch(62% 0 0);
+    --background: #151515;
+    --foreground: oklch(96% 0 0);
+    --card: #1c1c1c;
+    --muted-foreground: oklch(62% 0 0);
     --border: rgb(255 255 255 / 0.05);
     --border-strong: rgb(255 255 255 / 0.1);
     --accent: oklch(80% 0.18 195);
@@ -51,22 +51,6 @@
     --glass-border: rgb(255 255 255 / 0.08);
     --glass-strong-bg: rgb(28 28 28 / 0.6);
     --glass-thin-bg: rgb(21 21 21 / 0.45);
-    --background: var(--bg);
-    --foreground: var(--fg);
-    --card: var(--bg-elev);
-    --card-foreground: var(--fg);
-    --popover: var(--bg-elev);
-    --popover-foreground: var(--fg);
-    --primary: var(--fg);
-    --primary-foreground: var(--bg);
-    --secondary: var(--bg-elev);
-    --secondary-foreground: var(--fg);
-    --muted: var(--bg-elev);
-    --muted-foreground: var(--fg-muted);
-    --accent-foreground: var(--accent-fg);
-    --destructive: var(--danger);
-    --input: var(--border);
-    --ring: var(--border-strong);
 }
 
 @theme inline {
@@ -75,17 +59,10 @@
     --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
     --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
 
-    --color-bg: var(--bg);
-    --color-bg-elev: var(--bg-elev);
-    --color-fg: var(--fg);
-    --color-fg-muted: var(--fg-muted);
     --color-border: var(--border);
     --color-border-strong: var(--border-strong);
-    --color-accent: var(--accent);
-    --color-accent-fg: var(--accent-fg);
     --color-neon: var(--neon);
     --color-violet: var(--violet);
-    --color-danger: var(--danger);
     --color-success: var(--success);
     --color-warning: var(--warning);
     --color-background: var(--background);
@@ -100,6 +77,7 @@
     --color-secondary-foreground: var(--secondary-foreground);
     --color-muted: var(--muted);
     --color-muted-foreground: var(--muted-foreground);
+    --color-accent: var(--accent);
     --color-accent-foreground: var(--accent-foreground);
     --color-destructive: var(--destructive);
     --color-input: var(--input);
@@ -225,8 +203,8 @@
         overflow-x: clip;
     }
     body {
-        background: var(--bg);
-        color: var(--fg);
+        background: var(--background);
+        color: var(--foreground);
         font-family: var(--font-sans);
         overflow-x: clip;
         -webkit-font-smoothing: antialiased;
@@ -234,7 +212,7 @@
     }
     ::selection {
         background: color-mix(in oklch, var(--accent) 30%, transparent);
-        color: var(--fg);
+        color: var(--foreground);
     }
 }
 
@@ -250,12 +228,12 @@
         background-image:
             linear-gradient(
                 to right,
-                color-mix(in oklch, var(--fg) 6%, transparent) 1px,
+                color-mix(in oklch, var(--foreground) 6%, transparent) 1px,
                 transparent 1px
             ),
             linear-gradient(
                 to bottom,
-                color-mix(in oklch, var(--fg) 6%, transparent) 1px,
+                color-mix(in oklch, var(--foreground) 6%, transparent) 1px,
                 transparent 1px
             );
         background-size: 32px 32px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
       </section>
 
       <section className="mx-auto max-w-2xl px-4 pb-24">
-        <p className="mb-5 text-center text-sm text-(--color-fg-muted)">
+        <p className="mb-5 text-center text-sm text-muted-foreground">
           Built on Motion. Distributed via shadcn.
         </p>
         <InstallCommand />
@@ -47,12 +47,12 @@ export default function Home() {
 
       {newComponents.length ? (
         <section className="mx-auto max-w-7xl px-4 pb-16">
-          <div className="mb-8 flex flex-col gap-4 border-t border-(--color-border) pt-12 md:flex-row md:items-center md:justify-between">
+          <div className="mb-8 flex flex-col gap-4 border-t border-border pt-12 md:flex-row md:items-center md:justify-between">
             <div>
-              <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
+              <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
                 New
               </p>
-              <h2 className="mt-2 font-pixel text-3xl font-medium leading-tight text-(--color-fg) md:text-4xl">
+              <h2 className="mt-2 font-pixel text-3xl font-medium leading-tight text-foreground md:text-4xl">
                 Recently launched.
               </h2>
             </div>
@@ -70,18 +70,18 @@ export default function Home() {
       ) : null}
 
       <section className="mx-auto max-w-7xl px-4 pb-16">
-        <div className="mb-8 flex flex-col gap-4 border-t border-(--color-border) pt-12 md:flex-row md:items-center md:justify-between">
+        <div className="mb-8 flex flex-col gap-4 border-t border-border pt-12 md:flex-row md:items-center md:justify-between">
           <div>
-            <p className="font-pixel text-xs font-medium uppercase text-(--color-fg-muted)">
+            <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
               Components
             </p>
-            <h2 className="mt-2 font-pixel text-3xl font-medium leading-tight text-(--color-fg) md:text-4xl">
+            <h2 className="mt-2 font-pixel text-3xl font-medium leading-tight text-foreground md:text-4xl">
               Motion primitives.
             </h2>
           </div>
           <Link
             href="/components/motion"
-            className="inline-flex items-center self-start text-sm font-medium text-(--color-fg-muted) hover:text-(--color-fg) md:self-center"
+            className="inline-flex items-center self-start text-sm font-medium text-muted-foreground hover:text-foreground md:self-center"
           >
             Browse all <ArrowRight className="ml-1 h-3.5 w-3.5" />
           </Link>

--- a/components/app/code-block.tsx
+++ b/components/app/code-block.tsx
@@ -67,22 +67,22 @@ export async function CodeBlock({
   return (
     <div
       className={cn(
-        "group relative overflow-hidden rounded-xl border border-(--color-border) bg-(--color-bg-elev)",
+        "group relative overflow-hidden rounded-xl border border-border bg-card",
         "font-mono text-[13px]",
         className,
       )}
     >
       {filename ? (
-        <div className="flex items-center justify-between gap-3 border-b border-(--color-border) bg-(--color-bg)/60 px-4 py-2.5">
+        <div className="flex items-center justify-between gap-3 border-b border-border bg-background/60 px-4 py-2.5">
           <div className="flex min-w-0 items-center gap-2 text-xs">
-            <span className="inline-flex h-5 shrink-0 items-center rounded border border-(--color-border) bg-(--color-bg-elev) px-1.5 font-mono text-[10px] font-semibold tracking-wider text-(--color-fg-muted) uppercase">
+            <span className="inline-flex h-5 shrink-0 items-center rounded border border-border bg-card px-1.5 font-mono text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
               {langLabel}
             </span>
 
-            <FileIcon className="h-3.5 w-3.5 shrink-0 text-(--color-fg-muted)" />
-            <span className="truncate font-mono text-(--color-fg-muted)">
+            <FileIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="truncate font-mono text-muted-foreground">
               {fileDir && <span className="opacity-60">{fileDir}/</span>}
-              <span className="text-(--color-fg) font-medium">{fileName}</span>
+              <span className="text-foreground font-medium">{fileName}</span>
             </span>
           </div>
 
@@ -103,7 +103,7 @@ export async function CodeBlock({
             "[&_code]:font-mono [&_code]:text-[13px]",
             "[&_.shiki]:bg-transparent",
             "[&_.line]:px-5",
-            "[&_.highlighted]:bg-(--color-fg)/[0.07] [&_.highlighted]:border-l-2 [&_.highlighted]:border-blue-500 [&_.highlighted]:!pl-[18px]",
+            "[&_.highlighted]:bg-foreground/[0.07] [&_.highlighted]:border-l-2 [&_.highlighted]:border-blue-500 [&_.highlighted]:!pl-[18px]",
             "[&_.diff.add]:bg-green-500/10 [&_.diff.add]:border-l-2 [&_.diff.add]:border-green-500 [&_.diff.add]:!pl-[18px]",
             "[&_.diff.remove]:bg-red-500/10 [&_.diff.remove]:border-l-2 [&_.diff.remove]:border-red-500 [&_.diff.remove]:!pl-[18px]",
             "[&_.focused]:opacity-100 [&_pre:has(.focused)_.line:not(.focused)]:opacity-30",

--- a/components/app/component-card.tsx
+++ b/components/app/component-card.tsx
@@ -17,17 +17,17 @@ export function ComponentCard({
   return (
     <Link
       href={`/components/${categorySlug}/${slug}`}
-      className="group/card relative flex h-40 flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
+      className="group/card relative flex h-40 flex-col overflow-hidden rounded-3xl bg-card transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
-        <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
+        <h3 className="truncate font-pixel text-base font-medium text-foreground">
           {name}
         </h3>
         {badge === "new" ? <NewBadge /> : null}
       </div>
 
-      <div className="mx-2 mb-2 flex min-h-0 flex-1 items-start overflow-hidden rounded-3xl bg-(--color-bg) px-4 py-4 transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-(--color-bg)/80 group-focus-visible/card:bg-(--color-bg)/80">
-        <p className="line-clamp-3 text-sm leading-relaxed text-(--color-fg-muted)">
+      <div className="mx-2 mb-2 flex min-h-0 flex-1 items-start overflow-hidden rounded-3xl bg-background px-4 py-4 transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-background/80 group-focus-visible/card:bg-background/80">
+        <p className="line-clamp-3 text-sm leading-relaxed text-muted-foreground">
           {description}
         </p>
       </div>

--- a/components/app/copy-button.tsx
+++ b/components/app/copy-button.tsx
@@ -27,7 +27,7 @@ export function CopyButton({
       }}
       aria-label={copied ? "Copied" : "Copy code"}
       className={cn(
-        "text-(--color-fg-muted) hover:text-(--color-fg)",
+        "text-muted-foreground hover:text-foreground",
         className,
       )}
     >

--- a/components/app/expandable-code.tsx
+++ b/components/app/expandable-code.tsx
@@ -43,11 +43,11 @@ export function ExpandableCode({ children }: { children: React.ReactNode }) {
         {children}
       </div>
       {!expanded && canExpand && (
-        <div className="absolute bottom-0 left-0 right-0 flex h-32 items-end justify-center bg-gradient-to-t from-(--color-bg-elev) to-transparent pb-4">
+        <div className="absolute bottom-0 left-0 right-0 flex h-32 items-end justify-center bg-gradient-to-t from-card to-transparent pb-4">
           <button
             type="button"
             onClick={() => setExpanded(true)}
-            className="rounded-full bg-(--color-bg)/80 px-4 py-1.5 text-xs font-medium text-(--color-fg) shadow-sm backdrop-blur-sm transition-colors hover:bg-(--color-bg) border border-(--color-border)"
+            className="rounded-full bg-background/80 px-4 py-1.5 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-background border border-border"
           >
             Expand Code
           </button>

--- a/components/app/hero-preview-dock.tsx
+++ b/components/app/hero-preview-dock.tsx
@@ -19,24 +19,24 @@ export function HeroPreviewDock() {
     >
 
       <div className="overflow-hidden rounded-3xl glass-strong">
-        <div className="flex items-center gap-2 border-b border-(--color-border) px-4 py-2.5">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
           <div className="flex items-center gap-1.5">
             <span className="h-2.5 w-2.5 rounded-full border border-(--color-border-strong)" />
             <span className="h-2.5 w-2.5 rounded-full border border-(--color-border-strong)" />
             <span className="h-2.5 w-2.5 rounded-full border border-(--color-border-strong)" />
           </div>
-          <div className="mx-auto flex items-center gap-2 rounded-md border border-(--color-border) bg-(--color-bg)/60 px-3 py-1 text-xs text-(--color-fg-muted)">
-            <span className="h-1.5 w-1.5 rounded-full bg-(--color-fg)" />
+          <div className="mx-auto flex items-center gap-2 rounded-md border border-border bg-background/60 px-3 py-1 text-xs text-muted-foreground">
+            <span className="h-1.5 w-1.5 rounded-full bg-foreground" />
             beui.dev / dashboard
           </div>
-          <div className="flex items-center gap-1 text-(--color-fg-muted)">
-            <kbd className="hidden items-center gap-1 rounded border border-(--color-border) bg-(--color-bg) px-1.5 py-0.5 text-[10px] sm:inline-flex">
+          <div className="flex items-center gap-1 text-muted-foreground">
+            <kbd className="hidden items-center gap-1 rounded border border-border bg-background px-1.5 py-0.5 text-[10px] sm:inline-flex">
               <Command className="h-2.5 w-2.5" /> K
             </kbd>
           </div>
         </div>
 
-        <div className="grid grid-cols-1 gap-px bg-(--color-border) md:grid-cols-[280px_1fr]">
+        <div className="grid grid-cols-1 gap-px bg-border md:grid-cols-[280px_1fr]">
           <SidePanel />
           <MainPanel />
         </div>
@@ -51,8 +51,8 @@ function Pill({ children, solid = false }: { children: React.ReactNode; solid?: 
       className={cn(
         "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium",
         solid
-          ? "border-(--color-fg) bg-(--color-fg) text-(--color-bg)"
-          : "border-(--color-border) bg-(--color-bg-elev) text-(--color-fg-muted)",
+          ? "border-foreground bg-foreground text-background"
+          : "border-border bg-card text-muted-foreground",
       )}
     >
       {children}
@@ -62,9 +62,9 @@ function Pill({ children, solid = false }: { children: React.ReactNode; solid?: 
 
 function SidePanel() {
   return (
-    <div className="bg-(--color-bg)/40 p-4">
+    <div className="bg-background/40 p-4">
       <div className="mb-3 flex items-center justify-between">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
           Workspace
         </span>
         <Pill solid>Pro</Pill>
@@ -82,13 +82,13 @@ function SidePanel() {
               className={cn(
                 "flex h-8 items-center justify-between rounded-md px-2 text-sm transition-colors",
                 item.active
-                  ? "bg-(--color-bg-elev) text-(--color-fg) font-medium border border-(--color-border)"
-                  : "text-(--color-fg-muted)",
+                  ? "bg-card text-foreground font-medium border border-border"
+                  : "text-muted-foreground",
               )}
             >
               <span>{item.label}</span>
               {item.badge ? (
-                <span className="rounded bg-(--color-bg-elev) px-1.5 py-0.5 text-[10px] text-(--color-fg-muted)">
+                <span className="rounded bg-card px-1.5 py-0.5 text-[10px] text-muted-foreground">
                   {item.badge}
                 </span>
               ) : null}
@@ -97,12 +97,12 @@ function SidePanel() {
         ))}
       </ul>
 
-      <div className="mt-6 rounded-2xl border border-(--color-border) bg-(--color-bg-elev) p-3">
-        <div className="flex items-center gap-2 text-xs text-(--color-fg)">
-          <Sparkles className="h-3.5 w-3.5 text-(--color-fg)" />
+      <div className="mt-6 rounded-2xl border border-border bg-card p-3">
+        <div className="flex items-center gap-2 text-xs text-foreground">
+          <Sparkles className="h-3.5 w-3.5 text-foreground" />
           Bespoke motion components
         </div>
-        <p className="mt-1 text-[11px] text-(--color-fg-muted)">
+        <p className="mt-1 text-[11px] text-muted-foreground">
           Tabs, switches, sheets, palettes. All motion-driven.
         </p>
       </div>
@@ -114,29 +114,29 @@ function MainPanel() {
   const [notifs, setNotifs] = useState(true);
 
   return (
-    <div className="bg-(--color-bg)/40 p-5">
+    <div className="bg-background/40 p-5">
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-xs text-(--color-fg-muted)">Monthly recurring</p>
+          <p className="text-xs text-muted-foreground">Monthly recurring</p>
           <div className="mt-1 flex items-baseline gap-2">
             <NumberTicker
               value={129480}
               prefix="$"
               locale
-              className="text-3xl font-semibold tracking-tight text-(--color-fg)"
+              className="text-3xl font-semibold tracking-tight text-foreground"
             />
-            <span className="inline-flex items-center gap-0.5 rounded-md border border-(--color-border) bg-(--color-bg-elev) px-1.5 py-0.5 text-[11px] font-medium text-(--color-fg)">
+            <span className="inline-flex items-center gap-0.5 rounded-md border border-border bg-card px-1.5 py-0.5 text-[11px] font-medium text-foreground">
               <ArrowUpRight className="h-3 w-3" />
               12.4%
             </span>
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <button type="button" className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-(--color-border) bg-(--color-bg-elev) text-(--color-fg-muted) press hover:text-(--color-fg)">
+          <button type="button" className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-card text-muted-foreground press hover:text-foreground">
             <Bell className="h-3.5 w-3.5" />
           </button>
-          <button type="button" className="inline-flex h-8 items-center gap-1.5 rounded-md border border-(--color-border) bg-(--color-bg-elev) px-2.5 text-xs text-(--color-fg) press">
-            <Search className="h-3.5 w-3.5 text-(--color-fg-muted)" />
+          <button type="button" className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-card px-2.5 text-xs text-foreground press">
+            <Search className="h-3.5 w-3.5 text-muted-foreground" />
             Search
           </button>
         </div>
@@ -167,34 +167,34 @@ function MainPanel() {
             ].map((row) => (
               <li
                 key={row.who}
-                className="flex items-center justify-between rounded-lg border border-(--color-border) bg-(--color-bg-elev) px-3 py-2 text-sm"
+                className="flex items-center justify-between rounded-lg border border-border bg-card px-3 py-2 text-sm"
               >
                 <div className="flex items-center gap-2.5">
-                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-(--color-bg) text-[10px] font-semibold text-(--color-fg)">
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-background text-[10px] font-semibold text-foreground">
                     {row.who[0]}
                   </span>
-                  <span className="text-(--color-fg)">
+                  <span className="text-foreground">
                     <span className="font-medium">{row.who}</span>{" "}
-                    <span className="text-(--color-fg-muted)">{row.what}</span>
+                    <span className="text-muted-foreground">{row.what}</span>
                   </span>
                 </div>
-                <span className="text-xs text-(--color-fg-muted)">{row.when}</span>
+                <span className="text-xs text-muted-foreground">{row.when}</span>
               </li>
             ))}
           </ul>
         </TabsContent>
 
         <TabsContent value="billing">
-          <div className="flex items-center justify-between rounded-lg border border-(--color-border) bg-(--color-bg-elev) p-4">
+          <div className="flex items-center justify-between rounded-lg border border-border bg-card p-4">
             <div>
-              <p className="text-sm font-medium text-(--color-fg)">Notifications</p>
-              <p className="text-xs text-(--color-fg-muted)">Email me when invoices are paid.</p>
+              <p className="text-sm font-medium text-foreground">Notifications</p>
+              <p className="text-xs text-muted-foreground">Email me when invoices are paid.</p>
             </div>
             <Switch checked={notifs} onCheckedChange={setNotifs} />
           </div>
-          <div className="mt-3 flex items-center justify-between rounded-lg border border-(--color-border) bg-(--color-bg-elev) p-4">
-            <div className="flex items-center gap-2 text-sm text-(--color-fg)">
-              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-(--color-border) bg-(--color-bg-elev) text-(--color-fg)">
+          <div className="mt-3 flex items-center justify-between rounded-lg border border-border bg-card p-4">
+            <div className="flex items-center gap-2 text-sm text-foreground">
+              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-border bg-card text-foreground">
                 <Check className="h-3 w-3" strokeWidth={3} />
               </span>
               Plan: Pro
@@ -209,13 +209,13 @@ function MainPanel() {
 
 function Stat({ label, value, suffix }: { label: string; value: number; suffix?: string }) {
   return (
-    <div className="rounded-lg border border-(--color-border) bg-(--color-bg-elev) p-3">
-      <p className="text-[11px] text-(--color-fg-muted)">{label}</p>
+    <div className="rounded-lg border border-border bg-card p-3">
+      <p className="text-[11px] text-muted-foreground">{label}</p>
       <NumberTicker
         value={value}
         suffix={suffix}
         locale
-        className="mt-1 text-lg font-semibold text-(--color-fg)"
+        className="mt-1 text-lg font-semibold text-foreground"
       />
     </div>
   );
@@ -233,20 +233,20 @@ function Spark() {
   const area = `${path} L ${w} ${h} L 0 ${h} Z`;
 
   return (
-    <div className="mt-4 overflow-hidden rounded-lg border border-(--color-border) bg-(--color-bg-elev) p-4">
+    <div className="mt-4 overflow-hidden rounded-lg border border-border bg-card p-4">
       <div className="flex items-center justify-between">
-        <p className="text-xs text-(--color-fg-muted)">Last 14 days</p>
-        <p className="text-xs font-medium text-(--color-fg)">+24%</p>
+        <p className="text-xs text-muted-foreground">Last 14 days</p>
+        <p className="text-xs font-medium text-foreground">+24%</p>
       </div>
       <svg viewBox={`0 0 ${w} ${h}`} className="mt-3 h-16 w-full" preserveAspectRatio="none" aria-hidden="true">
         <defs>
           <linearGradient id="spark" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="var(--fg)" stopOpacity="0.25" />
-            <stop offset="100%" stopColor="var(--fg)" stopOpacity="0" />
+            <stop offset="0%" stopColor="var(--foreground)" stopOpacity="0.25" />
+            <stop offset="100%" stopColor="var(--foreground)" stopOpacity="0" />
           </linearGradient>
         </defs>
         <path d={area} fill="url(#spark)" />
-        <path d={path} fill="none" stroke="var(--fg)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+        <path d={path} fill="none" stroke="var(--foreground)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
       </svg>
     </div>
   );

--- a/components/app/hero.tsx
+++ b/components/app/hero.tsx
@@ -29,11 +29,11 @@ export function Hero() {
           href="https://github.com/starc007/ui-components"
           target="_blank"
           rel="noreferrer noopener"
-          className="group mb-7 inline-flex min-h-9 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-3 text-xs font-medium text-(--color-fg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
+          className="group mb-7 inline-flex min-h-9 items-center gap-2 rounded-full border border-border bg-card px-3 text-xs font-medium text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
-          <span className="h-1.5 w-1.5 rounded-full bg-(--color-accent)" />
+          <span className="h-1.5 w-1.5 rounded-full bg-accent" />
           Tailwind 4 + React 19
-          <ArrowUpRight className="h-3 w-3 text-(--color-fg-muted) transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+          <ArrowUpRight className="h-3 w-3 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
         </PressLink>
       </motion.div>
 
@@ -42,14 +42,14 @@ export function Hero() {
         text={HEADLINE}
         delay={START}
         stagger={STAGGER}
-        className="mx-auto font-pixel text-5xl font-medium leading-[0.9] text-(--color-fg) sm:text-6xl md:text-7xl"
+        className="mx-auto font-pixel text-5xl font-medium leading-[0.9] text-foreground sm:text-6xl md:text-7xl"
       />
 
       <motion.p
         initial={{ opacity: 0, y: 10, filter: "blur(6px)" }}
         animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
         transition={{ duration: 0.5, ease: EASE_OUT, delay: subDelay }}
-        className="mx-auto mt-6 max-w-sm text-pretty text-base leading-7 text-(--color-fg-muted)"
+        className="mx-auto mt-6 max-w-sm text-pretty text-base leading-7 text-muted-foreground"
       >
         Copy-ready components with clean motion.
       </motion.p>
@@ -62,7 +62,7 @@ export function Hero() {
       >
         <PressLink
           href="/components/motion"
-          className="group inline-flex h-10 items-center gap-2 rounded-full bg-(--color-fg) px-4 text-sm font-medium text-(--color-bg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
+          className="group inline-flex h-10 items-center gap-2 rounded-full bg-foreground px-4 text-sm font-medium text-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           Browse components
           <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
@@ -71,7 +71,7 @@ export function Hero() {
           href="https://github.com/starc007/ui-components"
           target="_blank"
           rel="noreferrer noopener"
-          className="inline-flex h-10 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-4 text-sm font-medium text-(--color-fg) hover:border-(--color-border-strong) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)"
+          className="inline-flex h-10 items-center gap-2 rounded-full border border-border bg-card px-4 text-sm font-medium text-foreground hover:border-(--color-border-strong) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           <GithubIcon className="h-4 w-4" />
           GitHub

--- a/components/app/install-command.tsx
+++ b/components/app/install-command.tsx
@@ -52,11 +52,11 @@ export function InstallCommand({
   return (
     <div
       className={cn(
-        "relative overflow-hidden rounded-xl border border-(--color-border) bg-(--color-bg-elev) text-sm",
+        "relative overflow-hidden rounded-xl border border-border bg-card text-sm",
         className,
       )}
     >
-      <div className="flex items-center gap-2 border-b border-(--color-border) px-3 py-1.5">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
         <Tabs
           value={pm}
           onValueChange={(v) => setPm(v as PM)}
@@ -67,8 +67,8 @@ export function InstallCommand({
               <TabsTrigger
                 key={p}
                 value={p}
-                indicatorClassName="bg-(--color-bg) border border-(--color-border) shadow-none"
-                className="h-7 px-2.5 text-xs font-medium text-(--color-fg-muted) hover:text-(--color-fg) aria-[selected=true]:text-(--color-fg)"
+                indicatorClassName="bg-background border border-border shadow-none"
+                className="h-7 px-2.5 text-xs font-medium text-muted-foreground hover:text-foreground aria-[selected=true]:text-foreground"
               >
                 {p}
               </TabsTrigger>

--- a/components/app/landing-component-card.tsx
+++ b/components/app/landing-component-card.tsx
@@ -17,24 +17,24 @@ export function LandingComponentCard({
       <Link
         href={`/components/${category}/${component.slug}`}
         aria-label={`View ${component.name}`}
-        className="absolute inset-0 z-20 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg)"
+        className="absolute inset-0 z-20 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       />
-      <div className="relative flex h-full flex-col overflow-hidden rounded-3xl bg-(--color-bg-elev) transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint]">
+      <div className="relative flex h-full flex-col overflow-hidden rounded-3xl bg-card transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint]">
         <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
-          <h3 className="truncate font-pixel text-base font-medium text-(--color-fg)">
+          <h3 className="truncate font-pixel text-base font-medium text-foreground">
             {component.name}
           </h3>
           {component.badge === "new" ? <NewBadge /> : null}
         </div>
 
-        <div className="relative mx-2 mb-2 flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-3xl bg-(--color-bg) px-5 py-5 contain-[paint]">
+        <div className="relative mx-2 mb-2 flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-3xl bg-background px-5 py-5 contain-[paint]">
           <div className="pointer-events-none flex w-full max-w-full origin-center scale-80 items-center justify-center overflow-hidden transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] group-hover/card:scale-[0.84] group-focus-within/card:scale-[0.84] [&_*]:!cursor-default">
             {Preview ? <Preview /> : null}
           </div>
 
-          <div className="pointer-events-none absolute inset-0 rounded-3xl bg-transparent backdrop-blur-0 transition-[background-color,backdrop-filter] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-(--color-bg-elev)/55 group-hover/card:backdrop-blur-md group-focus-within/card:bg-(--color-bg-elev)/55 group-focus-within/card:backdrop-blur-md">
+          <div className="pointer-events-none absolute inset-0 rounded-3xl bg-transparent backdrop-blur-0 transition-[background-color,backdrop-filter] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-card/55 group-hover/card:backdrop-blur-md group-focus-within/card:bg-card/55 group-focus-within/card:backdrop-blur-md">
             <div className="absolute inset-x-0 bottom-0 overflow-hidden rounded-b-3xl px-4 py-3">
-              <p className="line-clamp-2 translate-y-full text-xs leading-relaxed text-(--color-fg-muted) transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-focus-within/card:translate-y-0">
+              <p className="line-clamp-2 translate-y-full text-xs leading-relaxed text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-focus-within/card:translate-y-0">
                 {component.description}
               </p>
             </div>

--- a/components/app/manual-install.tsx
+++ b/components/app/manual-install.tsx
@@ -28,7 +28,7 @@ export async function ManualInstall({
     <div className="flex flex-col gap-6">
       {deps.length > 0 ? (
         <section>
-          <h3 className="text-sm font-semibold text-(--color-fg)">
+          <h3 className="text-sm font-semibold text-foreground">
             Install dependencies
           </h3>
           <div className="mt-3">
@@ -39,7 +39,7 @@ export async function ManualInstall({
 
       {utilFiles.length > 0 ? (
         <section>
-          <h3 className="text-sm font-semibold text-(--color-fg)">
+          <h3 className="text-sm font-semibold text-foreground">
             Add util file{utilFiles.length > 1 ? "s" : ""}
           </h3>
           <div className="mt-3 flex flex-col gap-4">
@@ -51,7 +51,7 @@ export async function ManualInstall({
       ) : null}
 
       <section>
-        <h3 className="text-sm font-semibold text-(--color-fg)">
+        <h3 className="text-sm font-semibold text-foreground">
           Copy the source code
         </h3>
         <div className="mt-3 flex flex-col gap-4">

--- a/components/app/mobile-nav.tsx
+++ b/components/app/mobile-nav.tsx
@@ -46,8 +46,8 @@ export function MobileNav() {
               className={cn(
                 "rounded-md px-3 py-1.5 text-sm transition-colors",
                 pathname.startsWith("/components/motion") || (pathname.startsWith("/components") && !pathname.startsWith("/components/blocks"))
-                  ? "text-(--color-fg)"
-                  : "text-(--color-fg-muted) hover:text-(--color-fg)",
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
               )}
             >
               Components
@@ -58,8 +58,8 @@ export function MobileNav() {
               className={cn(
                 "rounded-md px-3 py-1.5 text-sm transition-colors",
                 pathname.startsWith("/components/blocks")
-                  ? "text-(--color-fg)"
-                  : "text-(--color-fg-muted) hover:text-(--color-fg)",
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
               )}
             >
               Blocks

--- a/components/app/new-badge.tsx
+++ b/components/app/new-badge.tsx
@@ -4,7 +4,7 @@ export function NewBadge({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        "inline-flex shrink-0 items-center rounded-full border border-(--color-border-strong) bg-(--color-accent)/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-(--color-accent)",
+        "inline-flex shrink-0 items-center rounded-full border border-(--color-border-strong) bg-accent/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-accent",
         className,
       )}
     >

--- a/components/app/site-footer.tsx
+++ b/components/app/site-footer.tsx
@@ -7,23 +7,23 @@ const blockComponents = registry.find((c) => c.slug === "blocks")?.components ??
 
 export function SiteFooter() {
   return (
-    <footer className="border-t border-(--color-border) px-4 pt-14 pb-10">
+    <footer className="border-t border-border px-4 pt-14 pb-10">
       <div className="mx-auto max-w-7xl">
         {/* Main grid */}
         <div className="grid grid-cols-2 gap-10 md:grid-cols-[1.5fr_1fr_1fr_1fr]">
           {/* Brand */}
           <div className="col-span-2 md:col-span-1">
-            <p className="font-pixel text-lg font-medium text-(--color-fg)">beUI</p>
-            <p className="mt-2 max-w-[220px] text-sm leading-6 text-(--color-fg-muted)">
+            <p className="font-pixel text-lg font-medium text-foreground">beUI</p>
+            <p className="mt-2 max-w-[220px] text-sm leading-6 text-muted-foreground">
               Motion components for React. Copy-paste via shadcn registry.
             </p>
-            <p className="mt-5 text-xs text-(--color-fg-muted)">
+            <p className="mt-5 text-xs text-muted-foreground">
               Created by{" "}
               <Link
                 href="https://x.com/saurra3h"
                 target="_blank"
                 rel="noreferrer noopener"
-                className="font-medium text-(--color-fg) underline-offset-2 hover:underline"
+                className="font-medium text-foreground underline-offset-2 hover:underline"
               >
                 Saurabh
               </Link>
@@ -34,7 +34,7 @@ export function SiteFooter() {
                 target="_blank"
                 rel="noreferrer noopener"
                 aria-label="GitHub"
-                className="text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                className="text-muted-foreground transition-colors hover:text-foreground"
               >
                 <GithubIcon className="h-4 w-4" />
               </Link>
@@ -43,7 +43,7 @@ export function SiteFooter() {
                 target="_blank"
                 rel="noreferrer noopener"
                 aria-label="X / Twitter"
-                className="text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                className="text-muted-foreground transition-colors hover:text-foreground"
               >
                 <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor" aria-hidden="true">
                   <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
@@ -54,7 +54,7 @@ export function SiteFooter() {
 
           {/* Components */}
           <div>
-            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               Components
             </p>
             <ul className="space-y-2.5">
@@ -62,7 +62,7 @@ export function SiteFooter() {
                 <li key={c.slug}>
                   <Link
                     href={`/components/motion/${c.slug}`}
-                    className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                    className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                   >
                     {c.name}
                   </Link>
@@ -73,7 +73,7 @@ export function SiteFooter() {
 
           {/* Blocks */}
           <div>
-            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               Blocks
             </p>
             <ul className="space-y-2.5">
@@ -81,7 +81,7 @@ export function SiteFooter() {
                 <li key={c.slug}>
                   <Link
                     href={`/components/blocks/${c.slug}`}
-                    className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                    className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                   >
                     {c.name}
                   </Link>
@@ -92,14 +92,14 @@ export function SiteFooter() {
 
           {/* Links */}
           <div>
-            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               Links
             </p>
             <ul className="space-y-2.5">
               <li>
                 <Link
                   href="/components/motion"
-                  className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                 >
                   Browse all
                 </Link>
@@ -109,7 +109,7 @@ export function SiteFooter() {
                   href="https://github.com/starc007/ui-components"
                   target="_blank"
                   rel="noreferrer noopener"
-                  className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                 >
                   GitHub
                 </Link>
@@ -119,7 +119,7 @@ export function SiteFooter() {
                   href="https://x.com/saurra3h"
                   target="_blank"
                   rel="noreferrer noopener"
-                  className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                 >
                   X / Twitter
                 </Link>
@@ -127,7 +127,7 @@ export function SiteFooter() {
               <li>
                 <Link
                   href="/llms.txt"
-                  className="text-sm text-(--color-fg-muted) transition-colors hover:text-(--color-fg)"
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                 >
                   llms.txt
                 </Link>
@@ -137,8 +137,8 @@ export function SiteFooter() {
         </div>
 
         {/* Bottom bar */}
-        <div className="mt-14 border-t border-(--color-border) pt-6">
-          <p className="text-xs text-(--color-fg-muted)">© 2026 beUI. MIT License.</p>
+        <div className="mt-14 border-t border-border pt-6">
+          <p className="text-xs text-muted-foreground">© 2026 beUI. MIT License.</p>
         </div>
       </div>
     </footer>

--- a/components/app/site-header.tsx
+++ b/components/app/site-header.tsx
@@ -47,7 +47,7 @@ export function SiteHeader({
       className={cn(
         "fixed inset-x-0 top-0 z-40 transition-[background,border-color,backdrop-filter] duration-300",
         scrolled
-          ? "border-b border-(--color-border) bg-(--color-bg)/70 backdrop-blur-xl backdrop-saturate-150"
+          ? "border-b border-border bg-background/70 backdrop-blur-xl backdrop-saturate-150"
           : "border-b border-transparent bg-transparent",
       )}
     >
@@ -56,7 +56,7 @@ export function SiteHeader({
           <MobileNav />
           <Link
             href="/"
-            className="group flex items-center gap-2.5 text-sm font-semibold tracking-tight text-(--color-fg)"
+            className="group flex items-center gap-2.5 text-sm font-semibold tracking-tight text-foreground"
           >
             <Image
               src="/beui-mark.png"
@@ -74,8 +74,8 @@ export function SiteHeader({
               className={cn(
                 "rounded-md px-3 py-1.5 text-sm transition-colors",
                 isComponents
-                  ? "text-(--color-fg)"
-                  : "text-(--color-fg-muted) hover:text-(--color-fg)",
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
               )}
             >
               Components
@@ -85,8 +85,8 @@ export function SiteHeader({
               className={cn(
                 "rounded-md px-3 py-1.5 text-sm transition-colors",
                 isBlocks
-                  ? "text-(--color-fg)"
-                  : "text-(--color-fg-muted) hover:text-(--color-fg)",
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
               )}
             >
               Blocks
@@ -100,7 +100,7 @@ export function SiteHeader({
             href="https://github.com/starc007/ui-components"
             target="_blank"
             rel="noreferrer noopener"
-            className="group inline-flex items-center gap-1.5 rounded-2xl border border-(--color-border) bg-(--color-bg-elev)/20 px-3 py-2 text-xs font-medium text-(--color-fg) hover:border-(--color-border-strong)"
+            className="group inline-flex items-center gap-1.5 rounded-2xl border border-border bg-card/20 px-3 py-2 text-xs font-medium text-foreground hover:border-(--color-border-strong)"
             aria-label={
               formattedStarCount
                 ? `Star on GitHub, ${formattedStarCount} stars`
@@ -109,7 +109,7 @@ export function SiteHeader({
           >
             <GithubIcon className="h-3.5 w-3.5" />
             <span className="hidden sm:inline">Github</span>
-            <span className="inline-flex items-center gap-0.5 text-(--color-fg-muted)">
+            <span className="inline-flex items-center gap-0.5 text-muted-foreground">
               <Star className="h-3 w-3" />
               {formattedStarCount ? <span>{formattedStarCount}</span> : null}
             </span>

--- a/components/app/site-search.tsx
+++ b/components/app/site-search.tsx
@@ -57,13 +57,13 @@ export function SiteSearch({ className }: { className?: string }) {
         aria-label="Search components"
         onClick={() => setOpen(true)}
         className={cn(
-          "flex h-9 w-full items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-3 text-sm text-(--color-fg-muted) transition-colors hover:border-(--color-border-strong) hover:text-(--color-fg)",
+          "flex h-9 w-full items-center gap-2 rounded-full border border-border bg-card px-3 text-sm text-muted-foreground transition-colors hover:border-(--color-border-strong) hover:text-foreground",
           className,
         )}
       >
         <Search className="h-3.5 w-3.5 shrink-0" />
         <span className="hidden flex-1 text-left sm:block">Search</span>
-        <kbd className="hidden rounded border border-(--color-border) bg-(--color-bg) px-1.5 py-0.5 text-[10px] text-(--color-fg-muted) md:inline-block">
+        <kbd className="hidden rounded border border-border bg-background px-1.5 py-0.5 text-[10px] text-muted-foreground md:inline-block">
           ⌘K
         </kbd>
       </button>

--- a/components/app/site-sidebar.tsx
+++ b/components/app/site-sidebar.tsx
@@ -28,17 +28,17 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
     cn(
       "relative block rounded-lg px-3 py-1.5 text-sm transition-colors",
       active
-        ? "text-(--color-fg) font-medium bg-(--color-fg)/[0.06]"
-        : "text-(--color-fg-muted) hover:text-(--color-fg)",
+        ? "text-foreground font-medium bg-foreground/[0.06]"
+        : "text-muted-foreground hover:text-foreground",
     );
 
   return (
     <nav className="flex flex-col gap-8">
       <div>
-        <p className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+        <p className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
           Intro
         </p>
-        <SharedLayoutBg inset={0} pillClassName="rounded-lg bg-(--color-fg)/[0.05]">
+        <SharedLayoutBg inset={0} pillClassName="rounded-lg bg-foreground/[0.05]">
           {INTRO.map((item) => (
             <Link
               key={item.slug}
@@ -52,10 +52,10 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
         </SharedLayoutBg>
       </div>
       <div>
-        <p className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-(--color-fg-muted)">
+        <p className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
           Guides
         </p>
-        <SharedLayoutBg inset={0} pillClassName="rounded-lg bg-(--color-fg)/[0.05]">
+        <SharedLayoutBg inset={0} pillClassName="rounded-lg bg-foreground/[0.05]">
           {PATTERNS.map((item) => (
             <Link
               key={item.slug}
@@ -73,11 +73,11 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
           <Link
             href={`/components/${cat.slug}`}
             onClick={onNavigate}
-            className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-(--color-fg-muted)"
+            className="mb-2 block px-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
           >
             {cat.name}
           </Link>
-          <SharedLayoutBg inset={0} pillClassName="rounded-lg bg-(--color-fg)/[0.05]">
+          <SharedLayoutBg inset={0} pillClassName="rounded-lg bg-foreground/[0.05]">
             {moveFirstItemsToBottom(cat.components, 3).map((comp) => {
               const href = `/components/${cat.slug}/${comp.slug}`;
               return (

--- a/components/app/theme-toggle.tsx
+++ b/components/app/theme-toggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle({ className }: { className?: string }) {
       aria-label="Toggle theme"
       onClick={() => setTheme(isDark ? "light" : "dark")}
       className={cn(
-        "inline-flex h-9 w-9 items-center justify-center rounded-md border border-(--color-border) bg-(--color-bg-elev) text-(--color-fg-muted) hover:text-(--color-fg) hover:border-(--color-border-strong) transition-colors",
+        "inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-card text-muted-foreground hover:text-foreground hover:border-(--color-border-strong) transition-colors",
         className,
       )}
     >

--- a/components/previews/blocks/command-palette.preview.tsx
+++ b/components/previews/blocks/command-palette.preview.tsx
@@ -12,16 +12,16 @@ export function CommandPalettePreview() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="inline-flex h-10 items-center rounded-full border border-(--color-border) bg-(--color-bg-elev) px-5 text-sm font-medium text-(--color-fg) press hover:border-(--color-border-strong)"
+        className="inline-flex h-10 items-center rounded-full border border-border bg-card px-5 text-sm font-medium text-foreground press hover:border-(--color-border-strong)"
       >
         Open command palette
       </button>
-      <p className="text-sm text-(--color-fg-muted)">
+      <p className="text-sm text-muted-foreground">
         Press{" "}
-        <kbd className="rounded border border-(--color-border) bg-(--color-bg-elev) px-1.5 py-0.5 text-xs text-(--color-fg)">
+        <kbd className="rounded border border-border bg-card px-1.5 py-0.5 text-xs text-foreground">
           ⌘ J
         </kbd>{" "}
-        (or <kbd className="rounded border border-(--color-border) bg-(--color-bg-elev) px-1.5 py-0.5 text-xs text-(--color-fg)">Ctrl J</kbd>) to open.
+        (or <kbd className="rounded border border-border bg-card px-1.5 py-0.5 text-xs text-foreground">Ctrl J</kbd>) to open.
       </p>
       <CommandPalette
         open={open}

--- a/components/previews/blocks/dynamic-island.preview.tsx
+++ b/components/previews/blocks/dynamic-island.preview.tsx
@@ -72,7 +72,7 @@ export function DynamicIslandPreview() {
               type="button"
               aria-label="Decline"
               onClick={() => setView(null)}
-              className="flex h-8 w-8 items-center justify-center rounded-full bg-(--color-danger) text-white"
+              className="flex h-8 w-8 items-center justify-center rounded-full bg-destructive text-white"
             >
               <PhoneOff className="h-3.5 w-3.5" />
             </button>

--- a/components/previews/blocks/expandable-action-bar.preview.tsx
+++ b/components/previews/blocks/expandable-action-bar.preview.tsx
@@ -84,7 +84,7 @@ export function ExpandableActionBarPreview() {
         <motion.button
           type="button"
           onClick={() => setExpanded((current) => !current)}
-          className="relative flex h-9 w-[110px] items-center justify-center overflow-hidden rounded-full border border-(--color-border) bg-(--color-bg-elev) text-xs font-medium text-(--color-fg) transition-colors hover:border-(--color-border-strong)"
+          className="relative flex h-9 w-[110px] items-center justify-center overflow-hidden rounded-full border border-border bg-card text-xs font-medium text-foreground transition-colors hover:border-(--color-border-strong)"
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.96 }}
         >

--- a/components/previews/motion/animated-number.preview.tsx
+++ b/components/previews/motion/animated-number.preview.tsx
@@ -5,8 +5,8 @@ import { AnimatedNumber } from "@/components/motion/animated-number";
 export function AnimatedNumberPreview() {
   return (
     <div className="flex flex-col items-center gap-3">
-      <p className="text-xs text-(--color-fg-muted)">Monthly recurring revenue</p>
-      <div className="text-4xl font-semibold tracking-tight text-(--color-fg) tabular-nums">
+      <p className="text-xs text-muted-foreground">Monthly recurring revenue</p>
+      <div className="text-4xl font-semibold tracking-tight text-foreground tabular-nums">
         <AnimatedNumber value={129480} format={(n) => `$${Math.round(n).toLocaleString()}`} />
       </div>
       <p className="text-xs text-(--color-success)">+12.4% vs last month</p>

--- a/components/previews/motion/animated-toast-stack.preview.tsx
+++ b/components/previews/motion/animated-toast-stack.preview.tsx
@@ -86,7 +86,7 @@ export function AnimatedToastStackPreview() {
         placement="fixed"
         maxVisible={4}
         classNames={{
-          surface: "bg-(--color-bg-elev)/95",
+          surface: "bg-card/95",
         }}
         icons={{
           neutral: <Sparkles className="h-3.5 w-3.5" />,
@@ -94,8 +94,8 @@ export function AnimatedToastStackPreview() {
       />
 
       <div className="flex flex-col items-center gap-2 text-center">
-        <p className="text-sm font-medium text-(--color-fg)">Open a real toast</p>
-        <p className="max-w-sm text-xs leading-5 text-(--color-fg-muted)">
+        <p className="text-sm font-medium text-foreground">Open a real toast</p>
+        <p className="max-w-sm text-xs leading-5 text-muted-foreground">
           Toasts render fixed on the screen. Change position to open a toast from that edge.
         </p>
       </div>
@@ -107,7 +107,7 @@ export function AnimatedToastStackPreview() {
               key={example.label}
               type="button"
               onClick={() => openToast(example)}
-              className="inline-flex h-9 items-center gap-2 rounded-full border border-(--color-border) bg-(--color-bg-elev) px-4 text-xs font-medium text-(--color-fg) transition-colors press hover:border-(--color-border-strong)"
+              className="inline-flex h-9 items-center gap-2 rounded-full border border-border bg-card px-4 text-xs font-medium text-foreground transition-colors press hover:border-(--color-border-strong)"
             >
               {example.status === "loading" ? (
                 <LoaderCircle className="h-3.5 w-3.5" />
@@ -123,7 +123,7 @@ export function AnimatedToastStackPreview() {
         <button
           type="button"
           onClick={clearToasts}
-          className="inline-flex h-9 items-center rounded-full px-4 text-xs font-medium text-(--color-fg-muted) press hover:bg-(--color-fg)/[0.06] hover:text-(--color-fg)"
+          className="inline-flex h-9 items-center rounded-full px-4 text-xs font-medium text-muted-foreground press hover:bg-foreground/[0.06] hover:text-foreground"
         >
           Clear
         </button>
@@ -138,8 +138,8 @@ export function AnimatedToastStackPreview() {
             className={cn(
               "rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors press",
               position === positionOption
-                ? "bg-(--color-fg) text-(--color-bg)"
-                : "bg-(--color-fg)/[0.04] text-(--color-fg-muted) hover:bg-(--color-fg)/[0.08] hover:text-(--color-fg)",
+                ? "bg-foreground text-background"
+                : "bg-foreground/[0.04] text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground",
             )}
           >
             {positionOption}

--- a/components/previews/motion/bottom-sheet.preview.tsx
+++ b/components/previews/motion/bottom-sheet.preview.tsx
@@ -10,7 +10,7 @@ export function BottomSheetPreview() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="inline-flex h-10 items-center rounded-full border border-(--color-border) bg-(--color-bg-elev) px-5 text-sm font-medium text-(--color-fg) press hover:border-(--color-border-strong)"
+        className="inline-flex h-10 items-center rounded-full border border-border bg-card px-5 text-sm font-medium text-foreground press hover:border-(--color-border-strong)"
       >
         Open bottom sheet
       </button>
@@ -21,12 +21,12 @@ export function BottomSheetPreview() {
         title="Quick actions"
         description="Drag the handle, fling, or swipe down to dismiss."
       >
-        <ul className="divide-y divide-(--color-border)">
+        <ul className="divide-y divide-border">
           {["Share", "Duplicate", "Move to folder", "Rename", "Archive", "Delete"].map((item) => (
-            <li key={item} className="py-3 text-sm text-(--color-fg)">{item}</li>
+            <li key={item} className="py-3 text-sm text-foreground">{item}</li>
           ))}
         </ul>
-        <div className="py-12 text-center text-xs text-(--color-fg-muted)">
+        <div className="py-12 text-center text-xs text-muted-foreground">
           Fling up to expand, fling down to dismiss.
         </div>
       </BottomSheet>

--- a/components/previews/motion/marquee.preview.tsx
+++ b/components/previews/motion/marquee.preview.tsx
@@ -11,7 +11,7 @@ export function MarqueePreview() {
         {logos.map((l) => (
           <div
             key={l}
-            className="mx-4 flex h-12 items-center justify-center rounded-lg border border-(--color-border) bg-(--color-bg-elev) px-6 text-sm font-medium text-(--color-fg)"
+            className="mx-4 flex h-12 items-center justify-center rounded-lg border border-border bg-card px-6 text-sm font-medium text-foreground"
           >
             {l}
           </div>

--- a/components/previews/motion/morphing-modal.preview.tsx
+++ b/components/previews/motion/morphing-modal.preview.tsx
@@ -14,11 +14,11 @@ export function MorphingModalPreview() {
       <button
         type="button"
         onClick={() => setView("options")}
-        className="inline-flex h-10 items-center rounded-full border border-(--color-border) bg-(--color-bg-elev) px-5 text-sm font-medium text-(--color-fg) press hover:border-(--color-border-strong)"
+        className="inline-flex h-10 items-center rounded-full border border-border bg-card px-5 text-sm font-medium text-foreground press hover:border-(--color-border-strong)"
       >
         Open wallet options
       </button>
-      <p className="text-xs text-(--color-fg-muted)">Click a row. The modal morphs height to match new content.</p>
+      <p className="text-xs text-muted-foreground">Click a row. The modal morphs height to match new content.</p>
 
       <MorphingModal viewId={view} onClose={() => setView(null)}>
         {view === "options" ? (
@@ -40,12 +40,12 @@ export function MorphingModalPreview() {
 function Header({ title, onClose }: { title: string; onClose: () => void }) {
   return (
     <div className="mb-4 flex items-center justify-between">
-      <h2 className="text-base font-semibold text-(--color-fg)">{title}</h2>
+      <h2 className="text-base font-semibold text-foreground">{title}</h2>
       <button
         type="button"
         onClick={onClose}
         aria-label="Close"
-        className="inline-flex h-7 w-7 items-center justify-center rounded-full text-(--color-fg-muted) hover:bg-(--color-fg)/[0.06]"
+        className="inline-flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground hover:bg-foreground/[0.06]"
       >
         ✕
       </button>
@@ -70,8 +70,8 @@ function Row({
       onClick={onClick}
       className={`flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition-colors press ${
         destructive
-          ? "bg-(--color-danger)/10 text-(--color-danger) hover:bg-(--color-danger)/15"
-          : "bg-(--color-fg)/[0.04] text-(--color-fg) hover:bg-(--color-fg)/[0.08]"
+          ? "bg-destructive/10 text-destructive hover:bg-destructive/15"
+          : "bg-foreground/[0.04] text-foreground hover:bg-foreground/[0.08]"
       }`}
     >
       <Icon className="h-4 w-4" />
@@ -105,22 +105,22 @@ function PrivateKey({ onBack }: { onBack: () => void }) {
   return (
     <div>
       <div className="mb-3 flex items-start justify-between">
-        <Lock className="h-5 w-5 text-(--color-fg)" />
+        <Lock className="h-5 w-5 text-foreground" />
         <button
           type="button"
           onClick={onBack}
           aria-label="Back"
-          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-(--color-fg-muted) hover:bg-(--color-fg)/[0.06]"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground hover:bg-foreground/[0.06]"
         >
           ✕
         </button>
       </div>
-      <h2 className="text-xl font-semibold tracking-tight text-(--color-fg)">Private Key</h2>
-      <p className="mt-2 text-sm text-(--color-fg-muted)">
+      <h2 className="text-xl font-semibold tracking-tight text-foreground">Private Key</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
         Your Private Key is the key used to back up your wallet. Keep it secret and secure at all times.
       </p>
-      <hr className="my-4 border-(--color-border)" />
-      <ul className="flex flex-col gap-2.5 text-sm text-(--color-fg-muted)">
+      <hr className="my-4 border-border" />
+      <ul className="flex flex-col gap-2.5 text-sm text-muted-foreground">
         <li className="flex items-center gap-2.5"><ShieldCheck className="h-4 w-4" /> Keep your private key safe</li>
         <li className="flex items-center gap-2.5"><ScrollText className="h-4 w-4" /> Don&apos;t share it with anyone else</li>
         <li className="flex items-center gap-2.5"><Ban className="h-4 w-4" /> If you lose it, we can&apos;t recover it</li>
@@ -129,14 +129,14 @@ function PrivateKey({ onBack }: { onBack: () => void }) {
         <button
           type="button"
           onClick={onBack}
-          className="inline-flex h-10 flex-1 items-center justify-center rounded-full bg-(--color-fg)/[0.06] text-sm font-medium text-(--color-fg) press"
+          className="inline-flex h-10 flex-1 items-center justify-center rounded-full bg-foreground/[0.06] text-sm font-medium text-foreground press"
         >
           Cancel
         </button>
         <button
           type="button"
           onClick={onBack}
-          className="inline-flex h-10 flex-1 items-center justify-center gap-2 rounded-full bg-(--color-fg) text-sm font-medium text-(--color-bg) press"
+          className="inline-flex h-10 flex-1 items-center justify-center gap-2 rounded-full bg-foreground text-sm font-medium text-background press"
         >
           <ScanFace className="h-4 w-4" />
           Reveal
@@ -150,24 +150,24 @@ function Recovery({ onBack }: { onBack: () => void }) {
   return (
     <div>
       <div className="mb-3 flex items-start justify-between">
-        <ScrollText className="h-5 w-5 text-(--color-fg)" />
+        <ScrollText className="h-5 w-5 text-foreground" />
         <button
           type="button"
           onClick={onBack}
           aria-label="Back"
-          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-(--color-fg-muted) hover:bg-(--color-fg)/[0.06]"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground hover:bg-foreground/[0.06]"
         >
           ✕
         </button>
       </div>
-      <h2 className="text-xl font-semibold tracking-tight text-(--color-fg)">Recovery Phrase</h2>
-      <p className="mt-2 text-sm text-(--color-fg-muted)">
+      <h2 className="text-xl font-semibold tracking-tight text-foreground">Recovery Phrase</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
         12 words you can use to restore your wallet on any device. Write them down somewhere safe.
       </p>
       <div className="mt-4 grid grid-cols-3 gap-2">
         {["mountain", "river", "candle", "harbor", "amber", "violet", "spring", "ocean", "marble", "thunder", "willow", "crystal"].map((w, i) => (
-          <div key={w} className="rounded-lg border border-(--color-border) bg-(--color-bg)/40 px-2 py-1.5 text-xs text-(--color-fg)">
-            <span className="mr-1 text-(--color-fg-muted)">{i + 1}.</span>
+          <div key={w} className="rounded-lg border border-border bg-background/40 px-2 py-1.5 text-xs text-foreground">
+            <span className="mr-1 text-muted-foreground">{i + 1}.</span>
             {w}
           </div>
         ))}
@@ -175,7 +175,7 @@ function Recovery({ onBack }: { onBack: () => void }) {
       <button
         type="button"
         onClick={onBack}
-        className="mt-5 inline-flex h-10 w-full items-center justify-center rounded-full bg-(--color-fg) text-sm font-medium text-(--color-bg) press"
+        className="mt-5 inline-flex h-10 w-full items-center justify-center rounded-full bg-foreground text-sm font-medium text-background press"
       >
         Done
       </button>

--- a/components/previews/motion/number-ticker.preview.tsx
+++ b/components/previews/motion/number-ticker.preview.tsx
@@ -11,14 +11,14 @@ export function NumberTickerPreview() {
   }, []);
   return (
     <div className="flex flex-col items-center gap-3">
-      <p className="text-xs text-(--color-fg-muted)">Active users</p>
+      <p className="text-xs text-muted-foreground">Active users</p>
       <NumberTicker
         value={value}
         prefix=""
-        className="text-4xl font-semibold tracking-tight text-(--color-fg) tabular-nums"
+        className="text-4xl font-semibold tracking-tight text-foreground tabular-nums"
         format={(n) => n.toLocaleString()}
       />
-      <p className="text-xs text-(--color-fg-muted)">live · updates every 2.5s</p>
+      <p className="text-xs text-muted-foreground">live · updates every 2.5s</p>
     </div>
   );
 }

--- a/components/previews/motion/number.preview.tsx
+++ b/components/previews/motion/number.preview.tsx
@@ -36,17 +36,17 @@ export function NumberPreview() {
         >
           {variant === "ticker" ? (
             <div>
-              <p className="text-xs text-(--color-fg-muted)">Active users</p>
+              <p className="text-xs text-muted-foreground">Active users</p>
               <NumberTicker
                 value={value}
-                className="text-3xl font-semibold tracking-tight text-(--color-fg) tabular-nums"
+                className="text-3xl font-semibold tracking-tight text-foreground tabular-nums"
                 format={(number) => number.toLocaleString()}
               />
             </div>
           ) : (
             <div>
-              <p className="text-xs text-(--color-fg-muted)">Revenue</p>
-              <div className="text-3xl font-semibold tracking-tight text-(--color-fg) tabular-nums">
+              <p className="text-xs text-muted-foreground">Revenue</p>
+              <div className="text-3xl font-semibold tracking-tight text-foreground tabular-nums">
                 <AnimatedNumber
                   value={129480}
                   format={(number) => `$${Math.round(number).toLocaleString()}`}

--- a/components/previews/motion/shared-layout-bg.preview.tsx
+++ b/components/previews/motion/shared-layout-bg.preview.tsx
@@ -21,10 +21,10 @@ export function SharedLayoutBgPreview() {
             className="group flex flex-col gap-1 px-2 py-3 text-left"
           >
             <div className="flex items-center justify-between gap-3">
-              <span className="text-sm font-medium text-(--color-fg)">{it.title}</span>
-              <ArrowUpRight className="h-3.5 w-3.5 text-(--color-fg-muted) transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+              <span className="text-sm font-medium text-foreground">{it.title}</span>
+              <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
             </div>
-            <p className="text-sm text-(--color-fg-muted)">{it.body}</p>
+            <p className="text-sm text-muted-foreground">{it.body}</p>
           </button>
         ))}
       </SharedLayoutBg>

--- a/components/previews/motion/tabs.preview.tsx
+++ b/components/previews/motion/tabs.preview.tsx
@@ -12,9 +12,9 @@ export function TabsPreview() {
             <TabsTrigger value="activity">Activity</TabsTrigger>
             <TabsTrigger value="settings">Settings</TabsTrigger>
           </TabsList>
-          <TabsContent value="overview" className="text-sm text-(--color-fg-muted)">High-level summary.</TabsContent>
-          <TabsContent value="activity" className="text-sm text-(--color-fg-muted)">Recent events.</TabsContent>
-          <TabsContent value="settings" className="text-sm text-(--color-fg-muted)">Preferences.</TabsContent>
+          <TabsContent value="overview" className="text-sm text-muted-foreground">High-level summary.</TabsContent>
+          <TabsContent value="activity" className="text-sm text-muted-foreground">Recent events.</TabsContent>
+          <TabsContent value="settings" className="text-sm text-muted-foreground">Preferences.</TabsContent>
         </Tabs>
       </Section>
       <Section title="Segment">
@@ -42,7 +42,7 @@ export function TabsPreview() {
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-2">
-      <span className="text-[10px] font-semibold uppercase tracking-wider text-(--color-fg-muted)">{title}</span>
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{title}</span>
       {children}
     </div>
   );

--- a/components/previews/motion/text-animation.preview.tsx
+++ b/components/previews/motion/text-animation.preview.tsx
@@ -33,7 +33,7 @@ export function TextAnimationPreview() {
               stagger={0.045}
               blur={6}
               yOffset="18%"
-              className="text-balance text-3xl font-semibold tracking-tight text-(--color-fg)"
+              className="text-balance text-3xl font-semibold tracking-tight text-foreground"
             />
           ) : (
             <TextShimmer duration={1.8} className="text-xl font-semibold">

--- a/components/previews/motion/text-reveal.preview.tsx
+++ b/components/previews/motion/text-reveal.preview.tsx
@@ -11,7 +11,7 @@ export function TextRevealPreview() {
         <TextReveal
           as="h2"
           text={["Motion that feels", "considered."]}
-          className="text-balance text-4xl font-semibold leading-[0.95] tracking-[-0.04em] text-(--color-fg) sm:text-5xl"
+          className="text-balance text-4xl font-semibold leading-[0.95] tracking-[-0.04em] text-foreground sm:text-5xl"
         />
         <TextReveal
           text="Word by word, with a soft blur."
@@ -19,14 +19,14 @@ export function TextRevealPreview() {
           stagger={0.05}
           blur={6}
           yOffset="20%"
-          className="text-sm text-(--color-fg-muted)"
+          className="text-sm text-muted-foreground"
         />
       </div>
 
       <button
         type="button"
         onClick={() => setKey((k) => k + 1)}
-        className="inline-flex h-9 items-center rounded-full border border-(--color-border) bg-(--color-bg-elev) px-4 text-xs font-medium text-(--color-fg) press hover:border-(--color-border-strong)"
+        className="inline-flex h-9 items-center rounded-full border border-border bg-card px-4 text-xs font-medium text-foreground press hover:border-(--color-border-strong)"
       >
         Replay
       </button>

--- a/components/previews/motion/tilt-card.preview.tsx
+++ b/components/previews/motion/tilt-card.preview.tsx
@@ -5,10 +5,10 @@ import { TiltCard } from "@/components/motion/tilt-card";
 export function TiltCardPreview() {
   return (
     <div className="flex items-center justify-center p-6">
-      <TiltCard className="w-[280px] border border-(--color-border) bg-(--color-bg-elev) p-8">
-        <div className="text-xs uppercase tracking-wider text-(--color-fg-muted)">Premium</div>
-        <h3 className="mt-2 text-2xl font-semibold text-(--color-fg)">Tilt me</h3>
-        <p className="mt-3 text-sm text-(--color-fg-muted)">Move your cursor across the card to see 3D tilt + glare.</p>
+      <TiltCard className="w-[280px] border border-border bg-card p-8">
+        <div className="text-xs uppercase tracking-wider text-muted-foreground">Premium</div>
+        <h3 className="mt-2 text-2xl font-semibold text-foreground">Tilt me</h3>
+        <p className="mt-3 text-sm text-muted-foreground">Move your cursor across the card to see 3D tilt + glare.</p>
       </TiltCard>
     </div>
   );

--- a/components/previews/motion/tooltip.preview.tsx
+++ b/components/previews/motion/tooltip.preview.tsx
@@ -8,27 +8,27 @@ export function TooltipPreview() {
     <div className="flex flex-col items-center gap-12">
       <div className="flex flex-wrap items-center justify-center gap-4">
         <Tooltip content="Like this post" side="top">
-          <button type="button" className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-(--color-border) bg-(--color-bg-elev) text-(--color-fg) press">
+          <button type="button" className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-foreground press">
             <Heart className="h-4 w-4" />
           </button>
         </Tooltip>
         <Tooltip content="Share" side="bottom">
-          <button type="button" className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-(--color-border) bg-(--color-bg-elev) text-(--color-fg) press">
+          <button type="button" className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-foreground press">
             <Share className="h-4 w-4" />
           </button>
         </Tooltip>
         <Tooltip content="Open settings" side="left">
-          <button type="button" className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-(--color-border) bg-(--color-bg-elev) text-(--color-fg) press">
+          <button type="button" className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-foreground press">
             <Settings className="h-4 w-4" />
           </button>
         </Tooltip>
         <Tooltip content="Move to trash" side="right">
-          <button type="button" className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-(--color-border) bg-(--color-bg-elev) text-(--color-fg) press">
+          <button type="button" className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-foreground press">
             <Trash2 className="h-4 w-4" />
           </button>
         </Tooltip>
       </div>
-      <p className="text-xs text-(--color-fg-muted)">Hover or focus each button. Content fades and un-blurs in.</p>
+      <p className="text-xs text-muted-foreground">Hover or focus each button. Content fades and un-blurs in.</p>
     </div>
   );
 }


### PR DESCRIPTION
## Why
Two parallel token systems: the site used `--color-bg/--color-fg/--color-bg-elev/--color-fg-muted` utilities aliased onto shadcn vars, while library components already used shadcn names (`bg-primary`, `text-foreground`, …). Double maintenance, and it complicated the non-shadcn install story.

## What
One system, shadcn-named:
- `globals.css`: shadcn tokens defined directly on a concrete base palette. **Dark mode overrides only the base**; semantic tokens (`--primary`, `--card-foreground`, …) follow automatically via `var()` — no more duplicated `.dark` block.
- ~440 usages across `app/`, `components/app/`, `components/previews/` rewritten: `bg`→`background`, `bg-elev`→`card`, `fg`→`foreground`, `fg-muted`→`muted-foreground`, `border`, `danger`→`destructive`, `accent`, `ring`.
- beUI-only extensions kept (`border-strong`, `neon`, `violet`, `danger`, `success`, `warning`, `glass`) — no shadcn equivalent.

Library components (`components/motion/`) were already shadcn-pure; untouched.

## Note
This is a visual refactor — `typecheck`/`lint`/`check:registry` pass but can't confirm rendering. **Please eyeball the Vercel preview (light + dark)** before merge.

## Verification
- `bun run typecheck` clean
- `bun run check:registry` validates (28)
- `bun run lint` only the pre-existing `install-command.tsx` warning
- zero references to removed tokens remain