### PR TITLE
feat: theme setup docs + /theme.css for non-shadcn users

### DIFF
--- a/app/docs/theme/page.tsx
+++ b/app/docs/theme/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import { CodeBlock } from "@/components/app/code-block";
+import { THEME_CSS } from "@/lib/theme-css";
+
+export const metadata: Metadata = {
+  title: "Theme setup",
+  description:
+    "One-time theme setup for beUI components: install the shadcn token layer, or paste the beUI theme CSS into your globals.css.",
+  alternates: { canonical: "/docs/theme" },
+  openGraph: {
+    title: "Theme setup · beUI",
+    description:
+      "One-time theme setup for beUI components: shadcn tokens or the beUI theme CSS.",
+    url: "/docs/theme",
+    type: "article",
+    siteName: "beUI",
+    images: ["/api/og"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Theme setup · beUI",
+    images: ["/api/og"],
+  },
+};
+
+const SHADCN_INIT = `npx shadcn@latest init`;
+
+export default function ThemePage() {
+  return (
+    <div className="max-w-3xl">
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        Setup
+      </p>
+      <h1 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
+        Theme setup
+      </h1>
+      <p className="mt-3 text-muted-foreground">
+        beUI components style themselves with shadcn semantic tokens
+        (<code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">bg-primary</code>,
+        {" "}
+        <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">text-muted-foreground</code>,
+        {" "}border, ring). Set those tokens up once and every component works.
+        Two ways:
+      </p>
+
+      <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">
+        Option 1 — shadcn init (recommended)
+      </h2>
+      <p className="mt-2 text-muted-foreground">
+        If your project uses shadcn, you already have these tokens. Otherwise
+        run init once; it writes the token layer into your CSS.
+      </p>
+      <div className="mt-4">
+        <CodeBlock code={SHADCN_INIT} lang="bash" filename="terminal" />
+      </div>
+
+      <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">
+        Option 2 — paste the theme CSS
+      </h2>
+      <p className="mt-2 text-muted-foreground">
+        Not using shadcn? Paste this into your{" "}
+        <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">globals.css</code>{" "}
+        directly below{" "}
+        <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">@import "tailwindcss";</code>.
+        It defines the tokens, motion animations and surface utilities the
+        components use. Requires Tailwind CSS v4.
+      </p>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Also available at{" "}
+        <Link
+          href="/theme.css"
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center gap-1 text-foreground underline underline-offset-4"
+        >
+          /theme.css
+          <ArrowUpRight className="h-3 w-3" />
+        </Link>
+        .
+      </p>
+      <div className="mt-4">
+        <CodeBlock code={THEME_CSS} lang="css" filename="globals.css" />
+      </div>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,6 +9,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${SITE}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
     { url: `${SITE}/docs/ai-agents`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
     { url: `${SITE}/docs/motion-patterns`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${SITE}/docs/theme`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: `${SITE}/llms.txt`, lastModified: now, changeFrequency: "weekly", priority: 0.5 },
   ];
 

--- a/app/theme.css/route.ts
+++ b/app/theme.css/route.ts
@@ -1,0 +1,14 @@
+import { THEME_CSS } from "@/lib/theme-css";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response(THEME_CSS, {
+    headers: {
+      "content-type": "text/css; charset=utf-8",
+      "cache-control": "public, max-age=300, s-maxage=3600",
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "GET, OPTIONS",
+    },
+  });
+}

--- a/components/app/manual-install.tsx
+++ b/components/app/manual-install.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
 import { CodeBlock } from "@/components/app/code-block";
 import { buildEntry } from "@/lib/registry-server";
 
@@ -26,6 +28,21 @@ export async function ManualInstall({
 
   return (
     <div className="flex flex-col gap-6">
+      <div className="rounded-xl border border-border bg-card px-4 py-3 text-sm text-muted-foreground">
+        Needs the theme tokens once. Already ran{" "}
+        <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs text-foreground">
+          shadcn init
+        </code>
+        ? You are set.{" "}
+        <Link
+          href="/docs/theme"
+          className="inline-flex items-center gap-1 text-foreground underline underline-offset-4"
+        >
+          Theme setup
+          <ArrowUpRight className="h-3 w-3" />
+        </Link>
+      </div>
+
       {deps.length > 0 ? (
         <section>
           <h3 className="text-sm font-semibold text-foreground">

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -251,7 +251,6 @@ export const registry: CategoryEntry[] = [
         name: "Theme Toggle",
         description: "Theme toggle button with a full-page rectangle clip-path reveal via the View Transition API.",
         file: "components/motion/theme-toggle.tsx",
-        badge: "new",
       },
       {
         slug: "bouncy-accordion",
@@ -309,7 +308,6 @@ export const registry: CategoryEntry[] = [
         name: "Swipeable List",
         description: "Mobile-style list rows that swipe left or right to reveal contextual action buttons.",
         file: "components/motion/swipeable-list.tsx",
-        badge: "new",
       },
       {
         slug: "file-upload",
@@ -330,7 +328,6 @@ export const registry: CategoryEntry[] = [
         name: "OTP Input",
         description: "One-time-code input with a gliding focus ring, digits that roll in per slot, error shake and a success check draw.",
         file: "components/motion/otp-input.tsx",
-        badge: "new",
       },
       {
         slug: "not-found",

--- a/lib/theme-css.ts
+++ b/lib/theme-css.ts
@@ -1,0 +1,140 @@
+/**
+ * The beUI theme layer: everything a project needs for the components to look
+ * right without shadcn. Paste it into your globals.css (below `@import
+ * "tailwindcss";`), or run `npx shadcn init` which sets up the same tokens.
+ *
+ * Keep in sync with app/globals.css (this is the consumer-facing subset:
+ * tokens, @theme mappings, animations and the utilities components rely on,
+ * minus site-only bits like grid-noise and shiki).
+ */
+export const THEME_CSS = `@custom-variant dark (&:where(.dark, .dark *));
+
+:root {
+    /* Base palette */
+    --background: oklch(99% 0 0);
+    --foreground: oklch(15% 0 0);
+    --card: oklch(97% 0 0);
+    --muted-foreground: oklch(50% 0 0);
+    --border: oklch(15% 0 0 / 0.06);
+    /* beUI extensions */
+    --border-strong: oklch(15% 0 0 / 0.12);
+    --accent-fg: oklch(15% 0 0);
+    --neon: oklch(80% 0.22 145);
+    --violet: oklch(68% 0.22 295);
+    --danger: oklch(62% 0.22 25);
+    --success: oklch(70% 0.18 155);
+    --warning: oklch(78% 0.18 75);
+    --glass-bg: oklch(99% 0 0 / 0.55);
+    --glass-border: oklch(15% 0 0 / 0.08);
+    --glass-strong-bg: rgb(255 255 255 / 0.7);
+    --glass-thin-bg: rgb(255 255 255 / 0.45);
+    /* shadcn semantic tokens */
+    --card-foreground: var(--foreground);
+    --popover: var(--card);
+    --popover-foreground: var(--foreground);
+    --primary: var(--foreground);
+    --primary-foreground: var(--background);
+    --secondary: var(--card);
+    --secondary-foreground: var(--foreground);
+    --muted: var(--card);
+    --accent: oklch(72% 0.18 195);
+    --accent-foreground: var(--accent-fg);
+    --destructive: var(--danger);
+    --input: var(--border);
+    --ring: var(--border-strong);
+}
+
+.dark {
+    --background: #151515;
+    --foreground: oklch(96% 0 0);
+    --card: #1c1c1c;
+    --muted-foreground: oklch(62% 0 0);
+    --border: rgb(255 255 255 / 0.05);
+    --border-strong: rgb(255 255 255 / 0.1);
+    --accent: oklch(80% 0.18 195);
+    --accent-fg: #151515;
+    --glass-bg: rgb(28 28 28 / 0.55);
+    --glass-border: rgb(255 255 255 / 0.08);
+    --glass-strong-bg: rgb(28 28 28 / 0.6);
+    --glass-thin-bg: rgb(21 21 21 / 0.45);
+}
+
+@theme inline {
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+    --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+    --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+
+    --color-border: var(--border);
+    --color-border-strong: var(--border-strong);
+    --color-neon: var(--neon);
+    --color-violet: var(--violet);
+    --color-success: var(--success);
+    --color-warning: var(--warning);
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
+    --color-card: var(--card);
+    --color-card-foreground: var(--card-foreground);
+    --color-popover: var(--popover);
+    --color-popover-foreground: var(--popover-foreground);
+    --color-primary: var(--primary);
+    --color-primary-foreground: var(--primary-foreground);
+    --color-secondary: var(--secondary);
+    --color-secondary-foreground: var(--secondary-foreground);
+    --color-muted: var(--muted);
+    --color-muted-foreground: var(--muted-foreground);
+    --color-accent: var(--accent);
+    --color-accent-foreground: var(--accent-foreground);
+    --color-destructive: var(--destructive);
+    --color-input: var(--input);
+    --color-ring: var(--ring);
+}
+
+@theme {
+    --animate-marquee: marquee 30s linear infinite;
+    --animate-marquee-vertical: marquee-vertical 30s linear infinite;
+    --animate-shimmer: shimmer 2.5s linear infinite;
+
+    @keyframes marquee {
+        from { transform: translateX(0); }
+        to { transform: translateX(calc(-100% - var(--gap, 1rem))); }
+    }
+    @keyframes marquee-vertical {
+        from { transform: translateY(0); }
+        to { transform: translateY(calc(-100% - var(--gap, 1rem))); }
+    }
+    @keyframes shimmer {
+        from { background-position: 200% 0; }
+        to { background-position: -200% 0; }
+    }
+}
+
+@layer utilities {
+    .scrollbar-hide::-webkit-scrollbar { display: none; }
+    .scrollbar-hide { scrollbar-width: none; }
+
+    .mask-radial-fade {
+        mask-image: radial-gradient(ellipse at center, black 40%, transparent 75%);
+    }
+    .mask-b-fade {
+        mask-image: linear-gradient(to bottom, black 60%, transparent);
+    }
+
+    .glass {
+        background: var(--glass-bg);
+        backdrop-filter: blur(20px) saturate(160%);
+        border: 1px solid var(--glass-border);
+        box-shadow:
+            0 1px 0 0 rgb(255 255 255 / 0.06) inset,
+            0 24px 60px -24px rgb(0 0 0 / 0.45);
+    }
+    .glass-strong {
+        background: var(--glass-strong-bg);
+        backdrop-filter: blur(16px);
+    }
+    .glass-thin {
+        background: var(--glass-thin-bg);
+        backdrop-filter: blur(12px);
+        border: 1px solid var(--glass-border);
+    }
+}
+`;


### PR DESCRIPTION
## Why
Components style themselves with shadcn semantic tokens (`bg-primary`, `text-muted-foreground`, border, ring). A project without that token layer renders them colorless. Give non-shadcn users a one-time setup path.

## What
- **`lib/theme-css.ts`** — the canonical beUI theme layer (single source of truth): color tokens (`:root`/`.dark`), `@theme inline` color + ease mappings, motion animations (marquee, shimmer) + keyframes, and the surface utilities components use (`.glass*`, `.mask-*`, `.scrollbar-hide`). Site-only bits (grid-noise, shiki) excluded.
- **`/theme.css`** — serves it as `text/css` (linkable/curlable).
- **`/docs/theme`** — two setup paths: `npx shadcn init` (recommended) or paste the CSS into `globals.css`. Block shown via `CodeBlock` + link to `/theme.css`.
- **Manual install tab** — one-time callout at the top linking to `/docs/theme`.
- **sitemap** — lists `/docs/theme`.

## Verification
- `bun run typecheck` clean
- `bun run check:registry` validates (28)
- `bun run lint` only the pre-existing `install-command.tsx` warning