### PR TITLE
fix: stale border-fg token in site dock

### DIFF
--- a/components/app/site-dock.tsx
+++ b/components/app/site-dock.tsx
@@ -26,7 +26,7 @@ export function SiteDock() {
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4">
       <div className="pointer-events-auto">
-        <Dock size={36} className="gap-0 border border-fg/5 px-1.5">
+        <Dock size={36} className="gap-0 border border-foreground/5 px-1.5">
           <DockItem aria-label="Home" active={isHome}>
             <Tooltip
               content="Home"


### PR DESCRIPTION
The shadcn token refactor (#51) removed the `--color-fg` token but only rewrote the arbitrary `(--color-fg)` form. The site dock used the named utility `border-fg/5`, which slipped through and now resolves to nothing. Changed to `border-foreground/5`.

Swept the repo: this was the only named-form leftover.

- typecheck clean
- lint only the pre-existing install-command.tsx warning