### PR TITLE
feat: complete per-theme token sets + copy theme CSS

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -53,56 +53,8 @@
     --glass-thin-bg: rgb(21 21 21 / 0.45);
 }
 
-/* Color theme presets. Selected via data-theme on <html>; default (no
-   attribute) keeps the mono palette. Each shifts primary/accent/ring only. */
-[data-theme="violet"] {
-    --primary: oklch(55% 0.2 290);
-    --primary-foreground: oklch(99% 0 0);
-    --accent: oklch(55% 0.2 290);
-    --ring: oklch(55% 0.2 290 / 0.5);
-}
-.dark[data-theme="violet"] {
-    --primary: oklch(72% 0.16 290);
-    --primary-foreground: oklch(15% 0 0);
-    --accent: oklch(72% 0.16 290);
-    --ring: oklch(72% 0.16 290 / 0.55);
-}
-[data-theme="blue"] {
-    --primary: oklch(55% 0.18 255);
-    --primary-foreground: oklch(99% 0 0);
-    --accent: oklch(55% 0.18 255);
-    --ring: oklch(55% 0.18 255 / 0.5);
-}
-.dark[data-theme="blue"] {
-    --primary: oklch(70% 0.15 255);
-    --primary-foreground: oklch(15% 0 0);
-    --accent: oklch(70% 0.15 255);
-    --ring: oklch(70% 0.15 255 / 0.55);
-}
-[data-theme="green"] {
-    --primary: oklch(56% 0.14 150);
-    --primary-foreground: oklch(99% 0 0);
-    --accent: oklch(56% 0.14 150);
-    --ring: oklch(56% 0.14 150 / 0.5);
-}
-.dark[data-theme="green"] {
-    --primary: oklch(72% 0.15 150);
-    --primary-foreground: oklch(15% 0 0);
-    --accent: oklch(72% 0.15 150);
-    --ring: oklch(72% 0.15 150 / 0.55);
-}
-[data-theme="amber"] {
-    --primary: oklch(74% 0.15 70);
-    --primary-foreground: oklch(20% 0.02 70);
-    --accent: oklch(74% 0.15 70);
-    --ring: oklch(74% 0.15 70 / 0.5);
-}
-.dark[data-theme="amber"] {
-    --primary: oklch(80% 0.15 75);
-    --primary-foreground: oklch(18% 0.02 75);
-    --accent: oklch(80% 0.15 75);
-    --ring: oklch(80% 0.15 75 / 0.55);
-}
+/* Color theme presets (full token sets) are injected at runtime from
+   lib/themes.ts via PreferencesProvider, keyed by data-theme on <html>. */
 
 @theme inline {
     /* Strong easing curves shared across every component. */

--- a/components/app/preferences-panel.tsx
+++ b/components/app/preferences-panel.tsx
@@ -1,21 +1,14 @@
 "use client";
 
-import { Check, X } from "lucide-react";
+import { useState } from "react";
+import { Check, Copy, X } from "lucide-react";
 import { Drawer } from "@/components/motion/drawer";
 import { cn } from "@/lib/utils";
+import { THEME_LIST, themeExportCss } from "@/lib/themes";
 import {
-  type ColorTheme,
   type IconSet,
   usePreferences,
 } from "@/components/app/preferences-provider";
-
-const COLOR_THEMES: { id: ColorTheme; name: string; swatch: string }[] = [
-  { id: "default", name: "Mono", swatch: "oklch(40% 0 0)" },
-  { id: "violet", name: "Violet", swatch: "oklch(55% 0.2 290)" },
-  { id: "blue", name: "Blue", swatch: "oklch(55% 0.18 255)" },
-  { id: "green", name: "Green", swatch: "oklch(56% 0.14 150)" },
-  { id: "amber", name: "Amber", swatch: "oklch(74% 0.15 70)" },
-];
 
 const ICON_SETS: { id: IconSet | string; name: string; soon?: boolean }[] = [
   { id: "lucide", name: "Lucide" },
@@ -32,6 +25,13 @@ export function PreferencesPanel() {
     panelOpen,
     setPanelOpen,
   } = usePreferences();
+  const [copied, setCopied] = useState(false);
+
+  const copyTheme = async () => {
+    await navigator.clipboard.writeText(themeExportCss(colorTheme));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   return (
     <Drawer
@@ -58,7 +58,7 @@ export function PreferencesPanel() {
           Theme
         </p>
         <div className="mt-3 flex items-center gap-2.5">
-          {COLOR_THEMES.map((t) => {
+          {THEME_LIST.map((t) => {
             const active = colorTheme === t.id;
             return (
               <button
@@ -79,6 +79,18 @@ export function PreferencesPanel() {
             );
           })}
         </div>
+        <button
+          type="button"
+          onClick={copyTheme}
+          className="mt-4 inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-xs font-medium text-foreground transition-colors hover:bg-card/70"
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+          {copied ? "Copied CSS" : "Copy theme CSS"}
+        </button>
       </section>
 
       <section>

--- a/components/app/preferences-panel.tsx
+++ b/components/app/preferences-panel.tsx
@@ -57,7 +57,7 @@ export function PreferencesPanel() {
         <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
           Theme
         </p>
-        <div className="mt-3 flex items-center gap-2.5">
+        <div className="mt-3 flex flex-wrap items-center gap-2.5">
           {THEME_LIST.map((t) => {
             const active = colorTheme === t.id;
             return (

--- a/components/app/preferences-provider.tsx
+++ b/components/app/preferences-provider.tsx
@@ -7,8 +7,9 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { type ColorTheme, themesStylesheet } from "@/lib/themes";
 
-export type ColorTheme = "default" | "violet" | "blue" | "green" | "amber";
+export type { ColorTheme };
 // Future: "hugeicons" | "phosphor" | "tabler"
 export type IconSet = "lucide";
 
@@ -56,6 +57,8 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
         setPanelOpen,
       }}
     >
+      {/* Full per-theme token sets, applied via data-theme on <html>. */}
+      <style dangerouslySetInnerHTML={{ __html: themesStylesheet() }} />
       {children}
     </PreferencesCtx.Provider>
   );

--- a/lib/themes.ts
+++ b/lib/themes.ts
@@ -1,0 +1,159 @@
+export type ColorTheme = "default" | "violet" | "blue" | "green" | "amber";
+
+type Vars = Record<string, string>;
+type Theme = { name: string; swatch: string; light: Vars; dark: Vars };
+
+// Full neutral token set. Colored themes start here and override the brand
+// tokens, so every theme exports a complete, drop-in palette.
+const BASE_LIGHT: Vars = {
+  "--background": "oklch(99% 0 0)",
+  "--foreground": "oklch(15% 0 0)",
+  "--card": "oklch(97% 0 0)",
+  "--card-foreground": "oklch(15% 0 0)",
+  "--popover": "oklch(97% 0 0)",
+  "--popover-foreground": "oklch(15% 0 0)",
+  "--primary": "oklch(15% 0 0)",
+  "--primary-foreground": "oklch(99% 0 0)",
+  "--secondary": "oklch(97% 0 0)",
+  "--secondary-foreground": "oklch(15% 0 0)",
+  "--muted": "oklch(97% 0 0)",
+  "--muted-foreground": "oklch(50% 0 0)",
+  "--accent": "oklch(72% 0.18 195)",
+  "--accent-foreground": "oklch(15% 0 0)",
+  "--destructive": "oklch(62% 0.22 25)",
+  "--border": "oklch(15% 0 0 / 0.06)",
+  "--input": "oklch(15% 0 0 / 0.06)",
+  "--ring": "oklch(15% 0 0 / 0.12)",
+};
+
+const BASE_DARK: Vars = {
+  "--background": "#151515",
+  "--foreground": "oklch(96% 0 0)",
+  "--card": "#1c1c1c",
+  "--card-foreground": "oklch(96% 0 0)",
+  "--popover": "#1c1c1c",
+  "--popover-foreground": "oklch(96% 0 0)",
+  "--primary": "oklch(96% 0 0)",
+  "--primary-foreground": "#151515",
+  "--secondary": "#1c1c1c",
+  "--secondary-foreground": "oklch(96% 0 0)",
+  "--muted": "#1c1c1c",
+  "--muted-foreground": "oklch(62% 0 0)",
+  "--accent": "oklch(80% 0.18 195)",
+  "--accent-foreground": "#151515",
+  "--destructive": "oklch(62% 0.22 25)",
+  "--border": "rgb(255 255 255 / 0.05)",
+  "--input": "rgb(255 255 255 / 0.05)",
+  "--ring": "rgb(255 255 255 / 0.1)",
+};
+
+/** Build a colored theme: neutral surfaces + a hue-tinted brand ramp. */
+function brand(opts: {
+  light: { hue: string; onHue: string };
+  dark: { hue: string; onHue: string };
+  tintL?: string;
+  tintD?: string;
+}): { light: Vars; dark: Vars } {
+  const lHue = opts.light.hue;
+  const dHue = opts.dark.hue;
+  return {
+    light: {
+      ...BASE_LIGHT,
+      "--primary": lHue,
+      "--primary-foreground": opts.light.onHue,
+      "--accent": lHue,
+      "--accent-foreground": opts.light.onHue,
+      "--ring": opts.tintL ?? lHue,
+    },
+    dark: {
+      ...BASE_DARK,
+      "--primary": dHue,
+      "--primary-foreground": opts.dark.onHue,
+      "--accent": dHue,
+      "--accent-foreground": opts.dark.onHue,
+      "--ring": opts.tintD ?? dHue,
+    },
+  };
+}
+
+export const THEMES: Record<ColorTheme, Theme> = {
+  default: {
+    name: "Mono",
+    swatch: "oklch(40% 0 0)",
+    light: BASE_LIGHT,
+    dark: BASE_DARK,
+  },
+  violet: {
+    name: "Violet",
+    swatch: "oklch(55% 0.2 290)",
+    ...brand({
+      light: { hue: "oklch(55% 0.2 290)", onHue: "oklch(99% 0 0)" },
+      dark: { hue: "oklch(72% 0.16 290)", onHue: "oklch(15% 0 0)" },
+      tintL: "oklch(55% 0.2 290 / 0.5)",
+      tintD: "oklch(72% 0.16 290 / 0.55)",
+    }),
+  },
+  blue: {
+    name: "Blue",
+    swatch: "oklch(55% 0.18 255)",
+    ...brand({
+      light: { hue: "oklch(55% 0.18 255)", onHue: "oklch(99% 0 0)" },
+      dark: { hue: "oklch(70% 0.15 255)", onHue: "oklch(15% 0 0)" },
+      tintL: "oklch(55% 0.18 255 / 0.5)",
+      tintD: "oklch(70% 0.15 255 / 0.55)",
+    }),
+  },
+  green: {
+    name: "Green",
+    swatch: "oklch(56% 0.14 150)",
+    ...brand({
+      light: { hue: "oklch(56% 0.14 150)", onHue: "oklch(99% 0 0)" },
+      dark: { hue: "oklch(72% 0.15 150)", onHue: "oklch(15% 0 0)" },
+      tintL: "oklch(56% 0.14 150 / 0.5)",
+      tintD: "oklch(72% 0.15 150 / 0.55)",
+    }),
+  },
+  amber: {
+    name: "Amber",
+    swatch: "oklch(74% 0.15 70)",
+    ...brand({
+      light: { hue: "oklch(74% 0.15 70)", onHue: "oklch(20% 0.02 70)" },
+      dark: { hue: "oklch(80% 0.15 75)", onHue: "oklch(18% 0.02 75)" },
+      tintL: "oklch(74% 0.15 70 / 0.5)",
+      tintD: "oklch(80% 0.15 75 / 0.55)",
+    }),
+  },
+};
+
+export const THEME_LIST = Object.entries(THEMES).map(([id, t]) => ({
+  id: id as ColorTheme,
+  name: t.name,
+  swatch: t.swatch,
+}));
+
+function block(selector: string, vars: Vars): string {
+  const body = Object.entries(vars)
+    .map(([k, v]) => `  ${k}: ${v};`)
+    .join("\n");
+  return `${selector} {\n${body}\n}`;
+}
+
+/** Stylesheet injected once: full token sets keyed by data-theme. */
+export function themesStylesheet(): string {
+  return (Object.entries(THEMES) as [ColorTheme, Theme][])
+    .filter(([id]) => id !== "default")
+    .map(
+      ([id, t]) =>
+        `${block(`[data-theme="${id}"]`, t.light)}\n${block(
+          `.dark[data-theme="${id}"]`,
+          t.dark,
+        )}`,
+    )
+    .join("\n\n");
+}
+
+/** Copyable theme for a user's globals.css: standard :root / .dark blocks. */
+export function themeExportCss(id: ColorTheme): string {
+  const t = THEMES[id];
+  return `${block(":root", t.light)}\n\n${block(".dark", t.dark)}`;
+}

--- a/lib/themes.ts
+++ b/lib/themes.ts
@@ -1,4 +1,15 @@
-export type ColorTheme = "default" | "violet" | "blue" | "green" | "amber";
+export type ColorTheme =
+  | "default"
+  | "violet"
+  | "blue"
+  | "green"
+  | "amber"
+  | "blood-orange"
+  | "rose"
+  | "red"
+  | "teal"
+  | "indigo"
+  | "lime";
 
 type Vars = Record<string, string>;
 type Theme = { name: string; swatch: string; light: Vars; dark: Vars };
@@ -121,6 +132,66 @@ export const THEMES: Record<ColorTheme, Theme> = {
       dark: { hue: "oklch(80% 0.15 75)", onHue: "oklch(18% 0.02 75)" },
       tintL: "oklch(74% 0.15 70 / 0.5)",
       tintD: "oklch(80% 0.15 75 / 0.55)",
+    }),
+  },
+  "blood-orange": {
+    name: "Blood Orange",
+    swatch: "oklch(60% 0.19 40)",
+    ...brand({
+      light: { hue: "oklch(60% 0.19 40)", onHue: "oklch(99% 0 0)" },
+      dark: { hue: "oklch(72% 0.17 42)", onHue: "oklch(15% 0 0)" },
+      tintL: "oklch(60% 0.19 40 / 0.5)",
+      tintD: "oklch(72% 0.17 42 / 0.55)",
+    }),
+  },
+  rose: {
+    name: "Rose",
+    swatch: "oklch(58% 0.2 12)",
+    ...brand({
+      light: { hue: "oklch(58% 0.2 12)", onHue: "oklch(99% 0 0)" },
+      dark: { hue: "oklch(70% 0.17 12)", onHue: "oklch(15% 0 0)" },
+      tintL: "oklch(58% 0.2 12 / 0.5)",
+      tintD: "oklch(70% 0.17 12 / 0.55)",
+    }),
+  },
+  red: {
+    name: "Red",
+    swatch: "oklch(55% 0.22 25)",
+    ...brand({
+      light: { hue: "oklch(55% 0.22 25)", onHue: "oklch(99% 0 0)" },
+      dark: { hue: "oklch(68% 0.19 25)", onHue: "oklch(15% 0 0)" },
+      tintL: "oklch(55% 0.22 25 / 0.5)",
+      tintD: "oklch(68% 0.19 25 / 0.55)",
+    }),
+  },
+  teal: {
+    name: "Teal",
+    swatch: "oklch(55% 0.12 185)",
+    ...brand({
+      light: { hue: "oklch(55% 0.12 185)", onHue: "oklch(99% 0 0)" },
+      dark: { hue: "oklch(72% 0.13 185)", onHue: "oklch(15% 0 0)" },
+      tintL: "oklch(55% 0.12 185 / 0.5)",
+      tintD: "oklch(72% 0.13 185 / 0.55)",
+    }),
+  },
+  indigo: {
+    name: "Indigo",
+    swatch: "oklch(50% 0.2 275)",
+    ...brand({
+      light: { hue: "oklch(50% 0.2 275)", onHue: "oklch(99% 0 0)" },
+      dark: { hue: "oklch(70% 0.16 275)", onHue: "oklch(15% 0 0)" },
+      tintL: "oklch(50% 0.2 275 / 0.5)",
+      tintD: "oklch(70% 0.16 275 / 0.55)",
+    }),
+  },
+  lime: {
+    name: "Lime",
+    swatch: "oklch(72% 0.18 130)",
+    ...brand({
+      light: { hue: "oklch(72% 0.18 130)", onHue: "oklch(20% 0.04 130)" },
+      dark: { hue: "oklch(80% 0.18 130)", onHue: "oklch(18% 0.04 130)" },
+      tintL: "oklch(72% 0.18 130 / 0.5)",
+      tintD: "oklch(80% 0.18 130 / 0.55)",
     }),
   },
 };


### PR DESCRIPTION
## Why
Themes were a 4-token accent shift (primary/accent/ring) — a playground, not something a user could take. Now each theme is a complete, copyable palette.

## What
- **`lib/themes.ts`** — single source of truth. Each theme defines the **full shadcn token set** (18 tokens: background/foreground/card/popover/primary/secondary/muted/accent/destructive/border/input/ring + foregrounds) for **light + dark**, built from a neutral base plus a hue-tinted brand ramp.
- **`PreferencesProvider`** injects the generated per-theme stylesheet (keyed by `data-theme`); the hand-written presets are removed from `globals.css`.
- **Copy theme CSS** button in the preferences panel — copies the active theme as standard `:root { … } .dark { … }` blocks, ready to paste into any `globals.css`.
- Still in-memory (resets on refresh).

## Notes
- Colored themes keep neutral surfaces + a colored brand ramp (primary/accent/ring). Values live in `lib/themes.ts` — easy to tune or extend with more themes.
- Visual feature: eyeball the preview — switch themes (light + dark), hit Copy theme CSS and confirm the pasted block is a complete palette.

## Verification
- `bun run typecheck` clean
- `bun run check:registry` validates (29)
- `bun run lint` only the pre-existing `install-command.tsx` warning