### PR TITLE
feat: add checkbox and radio components

### DIFF
--- a/components/motion/checkbox.tsx
+++ b/components/motion/checkbox.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useId } from "react";
+import { EASE_OUT, SPRING_PRESS } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+const CHECK_PATH = "M5 13l4 4L19 7";
+const INDETERMINATE_PATH = "M6 12h12";
+
+export interface CheckboxProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  indeterminate?: boolean;
+  label?: string;
+  className?: string;
+  id?: string;
+}
+
+export function Checkbox({
+  checked,
+  onCheckedChange,
+  disabled,
+  indeterminate,
+  label,
+  className,
+  id: idProp,
+}: CheckboxProps) {
+  const autoId = useId();
+  const id = idProp ?? autoId;
+  const reduce = useReducedMotion();
+  const showMark = checked || indeterminate;
+  const path = indeterminate ? INDETERMINATE_PATH : CHECK_PATH;
+
+  return (
+    <span className={cn("inline-flex items-center gap-3", className)}>
+      <motion.button
+        id={id}
+        type="button"
+        role="checkbox"
+        aria-checked={indeterminate ? "mixed" : checked}
+        disabled={disabled}
+        onClick={() => !disabled && onCheckedChange(!checked)}
+        whileTap={reduce || disabled ? undefined : { scale: 0.92 }}
+        transition={SPRING_PRESS}
+        data-state={
+          checked ? "checked" : indeterminate ? "indeterminate" : "unchecked"
+        }
+        className={cn(
+          "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md border-2 outline-none transition-colors duration-200",
+          "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          showMark
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-muted-foreground/50 bg-background hover:border-muted-foreground",
+        )}
+      >
+        <AnimatePresence initial={false}>
+          {showMark ? (
+            <motion.svg
+              key={indeterminate ? "indeterminate" : "checked"}
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={3}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              initial={reduce ? { opacity: 1 } : { opacity: 0, scale: 0.5 }}
+              animate={reduce ? { opacity: 1 } : { opacity: 1, scale: 1 }}
+              exit={
+                reduce
+                  ? { opacity: 0 }
+                  : { opacity: 0, scale: 0.5, filter: "blur(4px)" }
+              }
+              transition={
+                reduce ? { duration: 0 } : { duration: 0.16, ease: EASE_OUT }
+              }
+              aria-hidden
+            >
+              <title>{indeterminate ? "Partially selected" : "Selected"}</title>
+              <motion.path
+                d={path}
+                initial={reduce ? { pathLength: 1 } : { pathLength: 0 }}
+                animate={{ pathLength: 1 }}
+                transition={
+                  reduce
+                    ? { duration: 0 }
+                    : {
+                        duration: indeterminate ? 0.2 : 0.3,
+                        ease: EASE_OUT,
+                        delay: 0.04,
+                      }
+                }
+              />
+            </motion.svg>
+          ) : null}
+        </AnimatePresence>
+      </motion.button>
+      {label ? (
+        <label
+          htmlFor={id}
+          className={cn(
+            "text-sm text-foreground",
+            disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
+          )}
+        >
+          {label}
+        </label>
+      ) : null}
+    </span>
+  );
+}

--- a/components/motion/radio.tsx
+++ b/components/motion/radio.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { motion, MotionConfig, useReducedMotion } from "motion/react";
+import {
+  createContext,
+  useContext,
+  useId,
+  useState,
+  type ReactNode,
+} from "react";
+import { SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+type RadioCtx = {
+  value: string;
+  setValue: (value: string) => void;
+  layoutId: string;
+};
+
+const RadioCtx = createContext<RadioCtx | null>(null);
+
+function useRadioGroup() {
+  const ctx = useContext(RadioCtx);
+  if (!ctx) {
+    throw new Error("RadioGroupItem must be used inside <RadioGroup>");
+  }
+  return ctx;
+}
+
+export interface RadioGroupProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  children: ReactNode;
+  className?: string;
+  orientation?: "vertical" | "horizontal";
+}
+
+export function RadioGroup({
+  value,
+  defaultValue = "",
+  onValueChange,
+  children,
+  className,
+  orientation = "vertical",
+}: RadioGroupProps) {
+  const [internal, setInternal] = useState(defaultValue);
+  const layoutId = useId();
+  const reduce = useReducedMotion();
+  const controlled = value !== undefined;
+  const current = controlled ? value : internal;
+  const setValue = (next: string) => {
+    if (!controlled) setInternal(next);
+    onValueChange?.(next);
+  };
+
+  return (
+    <MotionConfig transition={reduce ? { duration: 0 } : SPRING_LAYOUT}>
+      <RadioCtx.Provider value={{ value: current, setValue, layoutId }}>
+        <div
+          role="radiogroup"
+          className={cn(
+            "flex gap-3",
+            orientation === "vertical" ? "flex-col" : "flex-row flex-wrap",
+            className,
+          )}
+        >
+          {children}
+        </div>
+      </RadioCtx.Provider>
+    </MotionConfig>
+  );
+}
+
+export interface RadioGroupItemProps {
+  value: string;
+  label?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+}
+
+export function RadioGroupItem({
+  value,
+  label,
+  disabled,
+  className,
+  id: idProp,
+}: RadioGroupItemProps) {
+  const { value: groupValue, setValue, layoutId } = useRadioGroup();
+  const autoId = useId();
+  const id = idProp ?? autoId;
+  const reduce = useReducedMotion();
+  const selected = groupValue === value;
+
+  return (
+    <span className={cn("inline-flex items-center gap-3", className)}>
+      <motion.button
+        id={id}
+        type="button"
+        role="radio"
+        aria-checked={selected}
+        disabled={disabled}
+        onClick={() => !disabled && setValue(value)}
+        whileTap={reduce || disabled ? undefined : { scale: 0.92 }}
+        transition={SPRING_PRESS}
+        data-state={selected ? "checked" : "unchecked"}
+        className={cn(
+          "relative inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 outline-none transition-colors duration-200",
+          "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          selected
+            ? "border-primary"
+            : "border-muted-foreground/50 hover:border-muted-foreground",
+        )}
+      >
+        {selected ? (
+          <motion.span
+            layoutId={layoutId}
+            className="absolute inset-1 rounded-full bg-primary"
+            transition={reduce ? { duration: 0 } : SPRING_LAYOUT}
+          />
+        ) : null}
+      </motion.button>
+      {label ? (
+        <label
+          htmlFor={id}
+          className={cn(
+            "text-sm text-foreground",
+            disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
+          )}
+        >
+          {label}
+        </label>
+      ) : null}
+    </span>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -86,6 +86,12 @@ export const previews: Record<string, ComponentType> = {
   "motion/switch": dynamic(() =>
     import("./motion/switch.preview").then((m) => m.SwitchPreview),
   ),
+  "motion/checkbox": dynamic(() =>
+    import("./motion/checkbox.preview").then((m) => m.CheckboxPreview),
+  ),
+  "motion/radio": dynamic(() =>
+    import("./motion/radio.preview").then((m) => m.RadioPreview),
+  ),
   "blocks/otp-input": dynamic(() =>
     import("./blocks/otp-input.preview").then((m) => m.OTPInputPreview),
   ),

--- a/components/previews/motion/checkbox.preview.tsx
+++ b/components/previews/motion/checkbox.preview.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import { Checkbox } from "@/components/motion/checkbox";
+
+export function CheckboxPreview() {
+  const [terms, setTerms] = useState(true);
+  const [updates, setUpdates] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Checkbox
+        checked={terms}
+        onCheckedChange={setTerms}
+        label="Accept terms and conditions"
+      />
+      <Checkbox
+        checked={updates}
+        onCheckedChange={setUpdates}
+        label="Email me product updates"
+      />
+      <Checkbox checked indeterminate onCheckedChange={() => {}} label="Select all (partial)" />
+      <Checkbox checked disabled onCheckedChange={() => {}} label="Disabled" />
+    </div>
+  );
+}

--- a/components/previews/motion/radio.preview.tsx
+++ b/components/previews/motion/radio.preview.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useState } from "react";
+import { RadioGroup, RadioGroupItem } from "@/components/motion/radio";
+
+export function RadioPreview() {
+  const [plan, setPlan] = useState("pro");
+
+  return (
+    <RadioGroup value={plan} onValueChange={setPlan} className="min-w-48">
+      <RadioGroupItem value="starter" label="Starter — free" />
+      <RadioGroupItem value="pro" label="Pro — $12/mo" />
+      <RadioGroupItem value="team" label="Team — $29/mo" />
+      <RadioGroupItem value="legacy" label="Legacy plan" disabled />
+    </RadioGroup>
+  );
+}

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -104,6 +104,22 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/switch.tsx",
       },
       {
+        slug: "checkbox",
+        name: "Checkbox",
+        description:
+          "Form choice control with a draw-on checkmark, spring press feedback and indeterminate state support.",
+        file: "components/motion/checkbox.tsx",
+        badge: "new",
+      },
+      {
+        slug: "radio",
+        name: "Radio Group",
+        description:
+          "Single-select choice control with a gliding layoutId indicator dot and spring press feedback.",
+        file: "components/motion/radio.tsx",
+        badge: "new",
+      },
+      {
         slug: "bottom-sheet",
         name: "Bottom Sheet",
         description: "Vaul-inspired draggable bottom sheet with snap points, inertia and glass surface.",


### PR DESCRIPTION
## Summary
- add standalone `Checkbox` and `RadioGroup` motion primitives with reduced-motion-safe press and selection feedback
- register each control independently so they appear as separate installable components with their own previews
- include preview examples covering checked, indeterminate, disabled, and grouped selection states

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run check:registry`

Made with [Cursor](https://cursor.com)