### PR TITLE
feat: add spinner component

### DIFF
--- a/components/motion/spinner.tsx
+++ b/components/motion/spinner.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+export type SpinnerVariant = "ring" | "dots";
+
+export interface SpinnerProps {
+  className?: string;
+  size?: number;
+  variant?: SpinnerVariant;
+  label?: string;
+}
+
+export function Spinner({
+  className,
+  size = 28,
+  variant = "ring",
+  label = "Loading",
+}: SpinnerProps) {
+  const reduce = useReducedMotion();
+
+  if (variant === "dots") {
+    return (
+      <span
+        role="status"
+        aria-label={label}
+        className={cn("inline-flex items-center justify-center", className)}
+        style={{ width: size, height: size }}
+      >
+        <span className="inline-flex items-center gap-1">
+          {[0, 1, 2].map((dot) => (
+            <motion.span
+              key={dot}
+              aria-hidden
+              animate={
+                reduce
+                  ? { opacity: [0.5, 1, 0.5] }
+                  : { y: [0, -3, 0], opacity: [0.45, 1, 0.45], scale: [0.92, 1, 0.92] }
+              }
+              transition={{
+                duration: 0.9,
+                delay: dot * 0.12,
+                repeat: Infinity,
+                ease: "easeInOut",
+              }}
+              className="block rounded-full bg-current"
+              style={{ width: Math.max(size / 5.5, 4), height: Math.max(size / 5.5, 4) }}
+            />
+          ))}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <motion.span
+      role="status"
+      aria-label={label}
+      animate={reduce ? undefined : { rotate: 360 }}
+      transition={reduce ? undefined : { duration: 0.9, ease: "linear", repeat: Infinity }}
+      className={cn("inline-flex items-center justify-center", className)}
+      style={{ width: size, height: size }}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        className="text-current"
+        aria-hidden
+      >
+        <title>{label}</title>
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          className="stroke-current/20"
+          strokeWidth="3"
+        />
+        <motion.circle
+          cx="12"
+          cy="12"
+          r="9"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          fill="none"
+          initial={false}
+          animate={
+            reduce
+              ? { pathLength: 0.35, opacity: 1 }
+              : { pathLength: [0.2, 0.46, 0.2], opacity: [0.75, 1, 0.75] }
+          }
+          transition={{
+            duration: 1.1,
+            repeat: Infinity,
+            ease: "easeInOut",
+          }}
+          style={{ pathLength: 0.28, pathOffset: 0.1 }}
+        />
+      </svg>
+    </motion.span>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -140,6 +140,9 @@ export const previews: Record<string, ComponentType> = {
   "motion/theme-toggle": dynamic(() =>
     import("./motion/theme-toggle.preview").then((m) => m.ThemeTogglePreview),
   ),
+  "motion/spinner": dynamic(() =>
+    import("./motion/spinner.preview").then((m) => m.SpinnerPreview),
+  ),
 };
 
 export function getPreview(category: string, slug: string) {

--- a/components/previews/motion/spinner.preview.tsx
+++ b/components/previews/motion/spinner.preview.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Spinner } from "@/components/motion/spinner";
+
+export function SpinnerPreview() {
+  return (
+    <div className="flex flex-col items-center gap-4 text-primary">
+      <Spinner size={34} />
+      <div className="flex items-center gap-4 text-muted-foreground">
+        <Spinner size={18} />
+        <Spinner size={18} variant="dots" />
+        <Spinner size={24} />
+      </div>
+    </div>
+  );
+}

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -253,6 +253,13 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/theme-toggle.tsx",
       },
       {
+        slug: "spinner",
+        name: "Spinner",
+        description: "Loading indicator with a sweeping ring or pulsing dots, tuned for compact UI states.",
+        file: "components/motion/spinner.tsx",
+        badge: "new",
+      },
+      {
         slug: "bouncy-accordion",
         name: "Bouncy Accordion",
         description: "Single-open accordion with weighted spring layout, icon rows and reduced-motion-safe content reveals.",


### PR DESCRIPTION
## Summary
- add a standalone `Spinner` primitive for compact loading states
- support both sweeping ring and pulsing dot variants with reduced-motion-safe fallbacks
- register the component with a preview showing multiple inline sizes and variants

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run check:registry`

Made with [Cursor](https://cursor.com)