### PR TITLE
feat: smooth-scroll provider + useSmoothScroll hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `theme-toggle` | `components/motion/theme-toggle.tsx` | Theme toggle with full-page clip-path reveal via View Transition API |
 | `bouncy-accordion` | `components/motion/bouncy-accordion.tsx` | Single-open accordion with weighted spring layout and icon rows |
 | `magnetic` | `components/motion/magnetic.tsx` | Cursor-attracted magnetic pull wrapper |
+| `smooth-scroll` | `components/motion/smooth-scroll.tsx` | Page-level smooth-scroll provider over Lenis with a `useSmoothScroll` hook (scroll offset/progress/velocity, `scrollTo`); reduced-motion falls back to native |
 
 ### Blocks (`blocks` category — composed product widgets)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `theme-toggle` | `components/motion/theme-toggle.tsx` | Theme toggle with full-page clip-path reveal via View Transition API |
 | `bouncy-accordion` | `components/motion/bouncy-accordion.tsx` | Single-open accordion with weighted spring layout and icon rows |
 | `magnetic` | `components/motion/magnetic.tsx` | Cursor-attracted magnetic pull wrapper |
-| `smooth-scroll` | `components/motion/smooth-scroll.tsx` | Page-level smooth-scroll provider over Lenis with a `useSmoothScroll` hook (scroll offset/progress/velocity, `scrollTo`); reduced-motion falls back to native |
+| `smooth-scroll` | `components/motion/smooth-scroll.tsx` | Smooth-scroll provider over Lenis (`root` for the page, `root={false}` for a contained area) with a `useSmoothScroll` hook (scroll offset/progress/velocity, `scrollTo`); reduced-motion falls back to native |
 
 ### Blocks (`blocks` category — composed product widgets)
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@vercel/speed-insights": "^1.1.0",
         "clsx": "^2.1.1",
         "geist": "^1.7.2",
+        "lenis": "^1.3.23",
         "lucide-react": "^1.16.0",
         "motion": "^11.15.0",
         "next": "^15.1.4",
@@ -345,6 +346,8 @@
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "lenis": ["lenis@1.3.23", "", { "peerDependencies": { "@nuxt/kit": ">=3.0.0", "react": ">=17.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["@nuxt/kit", "react", "vue"] }, "sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 

--- a/components/motion/smooth-scroll.tsx
+++ b/components/motion/smooth-scroll.tsx
@@ -43,6 +43,8 @@ const SmoothScrollContext = createContext<SmoothScrollApi | null>(null);
 
 export interface SmoothScrollProps {
   children: ReactNode;
+  /** Drive the page (window) when true, or a contained scroll area when false. */
+  root?: boolean;
   /** Smoothing factor; lower is smoother and heavier. */
   lerp?: number;
   /** Wheel / programmatic ease duration in seconds. */
@@ -55,19 +57,38 @@ export interface SmoothScrollProps {
   className?: string;
 }
 
-function maxScroll() {
-  return Math.max(
-    0,
-    document.documentElement.scrollHeight - window.innerHeight,
-  );
+type ScrollSource = Window | HTMLElement;
+
+function readMetrics(target: ScrollSource) {
+  if (target instanceof Window) {
+    const max = Math.max(
+      0,
+      document.documentElement.scrollHeight - window.innerHeight,
+    );
+    return { y: window.scrollY, max };
+  }
+  return {
+    y: target.scrollTop,
+    max: Math.max(0, target.scrollHeight - target.clientHeight),
+  };
 }
 
-function resolveTop(target: ScrollTarget, offset = 0): number {
+function resolveTop(
+  target: ScrollTarget,
+  source: ScrollSource,
+  offset = 0,
+): number {
   if (typeof target === "number") return target + offset;
+  if (source instanceof Window) {
+    const el =
+      typeof target === "string" ? document.querySelector(target) : target;
+    if (!el) return window.scrollY;
+    return el.getBoundingClientRect().top + window.scrollY + offset;
+  }
   const el =
-    typeof target === "string" ? document.querySelector(target) : target;
-  if (!el) return window.scrollY;
-  return el.getBoundingClientRect().top + window.scrollY + offset;
+    typeof target === "string" ? source.querySelector(target) : target;
+  if (!(el instanceof HTMLElement)) return source.scrollTop;
+  return el.offsetTop + offset;
 }
 
 /** Pushes Lenis' live scroll state into the shared motion values. */
@@ -96,20 +117,22 @@ function LenisBridge({
   return null;
 }
 
-/** Native scroll listener used on the reduced-motion path and the no-provider fallback. */
+/** Native scroll listener for the reduced-motion path and the no-provider fallback. */
 function useNativeScrollSync(
   enabled: boolean,
+  getTarget: () => ScrollSource | null,
   scrollY: MotionValue<number>,
   progress: MotionValue<number>,
   velocity: MotionValue<number>,
 ) {
   useEffect(() => {
     if (!enabled) return;
-    let lastY = window.scrollY;
+    const target = getTarget();
+    if (!target) return;
+    let lastY = readMetrics(target).y;
     let lastT = performance.now();
     const onScroll = () => {
-      const y = window.scrollY;
-      const max = maxScroll();
+      const { y, max } = readMetrics(target);
       const now = performance.now();
       const dt = now - lastT || 16;
       scrollY.set(y);
@@ -119,13 +142,14 @@ function useNativeScrollSync(
       lastT = now;
     };
     onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, [enabled, scrollY, progress, velocity]);
+    target.addEventListener("scroll", onScroll, { passive: true });
+    return () => target.removeEventListener("scroll", onScroll);
+  }, [enabled, getTarget, scrollY, progress, velocity]);
 }
 
 export function SmoothScroll({
   children,
+  root = true,
   lerp = 0.1,
   duration = 1.2,
   orientation = "vertical",
@@ -138,6 +162,12 @@ export function SmoothScroll({
   const progress = useMotionValue(0);
   const velocity = useMotionValue(0);
   const lenisRef = useRef<Lenis | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const nativeSource = useCallback(
+    (): ScrollSource | null => (root ? window : containerRef.current),
+    [root],
+  );
 
   const scrollTo = useCallback(
     (target: ScrollTarget, options?: ScrollToOptions) => {
@@ -150,17 +180,17 @@ export function SmoothScroll({
         });
         return;
       }
-      window.scrollTo({
-        top: resolveTop(target, options?.offset),
-        behavior: reduce || options?.immediate ? "auto" : "smooth",
-      });
+      const source = nativeSource();
+      const behavior = reduce || options?.immediate ? "auto" : "smooth";
+      const top = resolveTop(target, source ?? window, options?.offset);
+      (source ?? window).scrollTo({ top, behavior });
     },
-    [reduce],
+    [reduce, nativeSource],
   );
 
-  // Reduced-motion path drives the native listener directly; the Lenis path
-  // leaves it disabled and lets LenisBridge feed the values instead.
-  useNativeScrollSync(!!reduce, scrollY, progress, velocity);
+  // Reduced motion drives the native listener; the Lenis path leaves it
+  // disabled and lets LenisBridge feed the values instead.
+  useNativeScrollSync(!!reduce, nativeSource, scrollY, progress, velocity);
 
   const api = useMemo<SmoothScrollApi>(
     () => ({ lenis: lenisRef.current, scrollY, progress, velocity, scrollTo }),
@@ -170,7 +200,9 @@ export function SmoothScroll({
   if (reduce) {
     return (
       <SmoothScrollContext.Provider value={api}>
-        <div className={className}>{children}</div>
+        <div ref={containerRef} className={className}>
+          {children}
+        </div>
       </SmoothScrollContext.Provider>
     );
   }
@@ -178,7 +210,7 @@ export function SmoothScroll({
   return (
     <SmoothScrollContext.Provider value={api}>
       <ReactLenis
-        root
+        root={root}
         className={className}
         options={{
           lerp,
@@ -213,11 +245,12 @@ export function useSmoothScroll(): SmoothScrollApi {
   const progress = useMotionValue(0);
   const velocity = useMotionValue(0);
 
-  useNativeScrollSync(ctx === null, scrollY, progress, velocity);
+  const windowSource = useCallback((): ScrollSource => window, []);
+  useNativeScrollSync(ctx === null, windowSource, scrollY, progress, velocity);
 
   const scrollTo = useCallback((target: ScrollTarget, options?: ScrollToOptions) => {
     window.scrollTo({
-      top: resolveTop(target, options?.offset),
+      top: resolveTop(target, window, options?.offset),
       behavior: options?.immediate ? "auto" : "smooth",
     });
   }, []);

--- a/components/motion/smooth-scroll.tsx
+++ b/components/motion/smooth-scroll.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import type Lenis from "lenis";
+import { ReactLenis, useLenis } from "lenis/react";
+import { type MotionValue, useMotionValue, useReducedMotion } from "motion/react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+
+// Lenis' own expo-out curve — the canonical smooth-scroll easing. Kept as a
+// named local fn (not a lib/ease token) because tokens are bezier control
+// points for the motion lib, while Lenis needs a (t) => number easing fn.
+const EASE_SCROLL = (t: number) => Math.min(1, 1.001 - 2 ** (-10 * t));
+
+export type ScrollTarget = number | string | HTMLElement;
+
+export type ScrollToOptions = {
+  offset?: number;
+  immediate?: boolean;
+  duration?: number;
+};
+
+export type SmoothScrollApi = {
+  /** Underlying Lenis instance, or null on the reduced-motion / native path. */
+  lenis: Lenis | null;
+  /** Current scroll offset in px. */
+  scrollY: MotionValue<number>;
+  /** Scroll position as 0..1 of the scrollable height. */
+  progress: MotionValue<number>;
+  /** Signed scroll velocity (px/frame); drives velocity-based effects. */
+  velocity: MotionValue<number>;
+  /** Programmatic smooth scroll. Respects reduced motion (jumps instantly). */
+  scrollTo: (target: ScrollTarget, options?: ScrollToOptions) => void;
+};
+
+const SmoothScrollContext = createContext<SmoothScrollApi | null>(null);
+
+export interface SmoothScrollProps {
+  children: ReactNode;
+  /** Smoothing factor; lower is smoother and heavier. */
+  lerp?: number;
+  /** Wheel / programmatic ease duration in seconds. */
+  duration?: number;
+  orientation?: "vertical" | "horizontal";
+  /** Wheel scroll speed multiplier. */
+  wheelMultiplier?: number;
+  /** Smooth touch scrolling. Off by default — native momentum is good on mobile. */
+  touch?: boolean;
+  className?: string;
+}
+
+function maxScroll() {
+  return Math.max(
+    0,
+    document.documentElement.scrollHeight - window.innerHeight,
+  );
+}
+
+function resolveTop(target: ScrollTarget, offset = 0): number {
+  if (typeof target === "number") return target + offset;
+  const el =
+    typeof target === "string" ? document.querySelector(target) : target;
+  if (!el) return window.scrollY;
+  return el.getBoundingClientRect().top + window.scrollY + offset;
+}
+
+/** Pushes Lenis' live scroll state into the shared motion values. */
+function LenisBridge({
+  scrollY,
+  progress,
+  velocity,
+  lenisRef,
+}: {
+  scrollY: MotionValue<number>;
+  progress: MotionValue<number>;
+  velocity: MotionValue<number>;
+  lenisRef: { current: Lenis | null };
+}) {
+  const lenis = useLenis((instance) => {
+    scrollY.set(instance.scroll);
+    progress.set(instance.progress);
+    velocity.set(instance.velocity);
+  });
+  useEffect(() => {
+    lenisRef.current = lenis ?? null;
+    return () => {
+      lenisRef.current = null;
+    };
+  }, [lenis, lenisRef]);
+  return null;
+}
+
+/** Native scroll listener used on the reduced-motion path and the no-provider fallback. */
+function useNativeScrollSync(
+  enabled: boolean,
+  scrollY: MotionValue<number>,
+  progress: MotionValue<number>,
+  velocity: MotionValue<number>,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    let lastY = window.scrollY;
+    let lastT = performance.now();
+    const onScroll = () => {
+      const y = window.scrollY;
+      const max = maxScroll();
+      const now = performance.now();
+      const dt = now - lastT || 16;
+      scrollY.set(y);
+      progress.set(max > 0 ? y / max : 0);
+      velocity.set(((y - lastY) / dt) * 16);
+      lastY = y;
+      lastT = now;
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [enabled, scrollY, progress, velocity]);
+}
+
+export function SmoothScroll({
+  children,
+  lerp = 0.1,
+  duration = 1.2,
+  orientation = "vertical",
+  wheelMultiplier = 1,
+  touch = false,
+  className,
+}: SmoothScrollProps) {
+  const reduce = useReducedMotion();
+  const scrollY = useMotionValue(0);
+  const progress = useMotionValue(0);
+  const velocity = useMotionValue(0);
+  const lenisRef = useRef<Lenis | null>(null);
+
+  const scrollTo = useCallback(
+    (target: ScrollTarget, options?: ScrollToOptions) => {
+      const lenis = lenisRef.current;
+      if (lenis && !reduce) {
+        lenis.scrollTo(target, {
+          offset: options?.offset,
+          duration: options?.duration,
+          immediate: options?.immediate,
+        });
+        return;
+      }
+      window.scrollTo({
+        top: resolveTop(target, options?.offset),
+        behavior: reduce || options?.immediate ? "auto" : "smooth",
+      });
+    },
+    [reduce],
+  );
+
+  // Reduced-motion path drives the native listener directly; the Lenis path
+  // leaves it disabled and lets LenisBridge feed the values instead.
+  useNativeScrollSync(!!reduce, scrollY, progress, velocity);
+
+  const api = useMemo<SmoothScrollApi>(
+    () => ({ lenis: lenisRef.current, scrollY, progress, velocity, scrollTo }),
+    [scrollY, progress, velocity, scrollTo],
+  );
+
+  if (reduce) {
+    return (
+      <SmoothScrollContext.Provider value={api}>
+        <div className={className}>{children}</div>
+      </SmoothScrollContext.Provider>
+    );
+  }
+
+  return (
+    <SmoothScrollContext.Provider value={api}>
+      <ReactLenis
+        root
+        className={className}
+        options={{
+          lerp,
+          duration,
+          orientation,
+          wheelMultiplier,
+          smoothWheel: true,
+          syncTouch: touch,
+          easing: EASE_SCROLL,
+        }}
+      >
+        <LenisBridge
+          scrollY={scrollY}
+          progress={progress}
+          velocity={velocity}
+          lenisRef={lenisRef}
+        />
+        {children}
+      </ReactLenis>
+    </SmoothScrollContext.Provider>
+  );
+}
+
+/**
+ * Read the page's smooth-scroll state. Inside <SmoothScroll> it returns the
+ * shared motion values; outside it falls back to a native window scroll
+ * listener so scroll-driven components still work without the provider.
+ */
+export function useSmoothScroll(): SmoothScrollApi {
+  const ctx = useContext(SmoothScrollContext);
+  const scrollY = useMotionValue(0);
+  const progress = useMotionValue(0);
+  const velocity = useMotionValue(0);
+
+  useNativeScrollSync(ctx === null, scrollY, progress, velocity);
+
+  const scrollTo = useCallback((target: ScrollTarget, options?: ScrollToOptions) => {
+    window.scrollTo({
+      top: resolveTop(target, options?.offset),
+      behavior: options?.immediate ? "auto" : "smooth",
+    });
+  }, []);
+
+  const fallback = useMemo<SmoothScrollApi>(
+    () => ({ lenis: null, scrollY, progress, velocity, scrollTo }),
+    [scrollY, progress, velocity, scrollTo],
+  );
+
+  return ctx ?? fallback;
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -146,6 +146,9 @@ export const previews: Record<string, ComponentType> = {
   "motion/theme-toggle": dynamic(() =>
     import("./motion/theme-toggle.preview").then((m) => m.ThemeTogglePreview),
   ),
+  "motion/smooth-scroll": dynamic(() =>
+    import("./motion/smooth-scroll.preview").then((m) => m.SmoothScrollPreview),
+  ),
 };
 
 export function getPreview(category: string, slug: string) {

--- a/components/previews/motion/smooth-scroll.preview.tsx
+++ b/components/previews/motion/smooth-scroll.preview.tsx
@@ -20,7 +20,7 @@ export function SmoothScrollPreview() {
   });
 
   return (
-    <div className="relative w-full max-w-sm overflow-hidden rounded-2xl border border-border bg-card">
+    <div className="relative w-full max-w-lg overflow-hidden rounded-2xl border border-border bg-card">
       <motion.div
         className="absolute inset-x-0 top-0 z-10 h-0.5 origin-left bg-foreground"
         style={{ scaleX: progress }}

--- a/components/previews/motion/smooth-scroll.preview.tsx
+++ b/components/previews/motion/smooth-scroll.preview.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { ArrowUp } from "lucide-react";
+import { motion, useScroll, useSpring } from "motion/react";
+import { useRef } from "react";
+
+// The real <SmoothScroll> is a page-level provider (root mode) shown in the
+// Usage tab. A boxed preview can't hijack the page, so this demos the feel:
+// a contained scroller with a spring-smoothed progress bar and scroll-to-top,
+// the same scroll-driven UI <SmoothScroll> + useSmoothScroll unlock.
+const SECTIONS = Array.from({ length: 16 }, (_, i) => i + 1);
+
+export function SmoothScrollPreview() {
+  const ref = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ container: ref });
+  const progress = useSpring(scrollYProgress, {
+    stiffness: 120,
+    damping: 28,
+    mass: 0.6,
+  });
+
+  return (
+    <div className="relative w-full max-w-sm overflow-hidden rounded-2xl border border-border bg-card">
+      <motion.div
+        className="absolute inset-x-0 top-0 z-10 h-0.5 origin-left bg-foreground"
+        style={{ scaleX: progress }}
+      />
+      <div ref={ref} className="h-64 overflow-y-auto scrollbar-hide">
+        <div className="space-y-3 p-4">
+          {SECTIONS.map((n) => (
+            <div
+              key={`section-${n}`}
+              className="rounded-lg bg-muted/60 px-3 py-4 text-sm text-muted-foreground"
+            >
+              Section {n}
+            </div>
+          ))}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => ref.current?.scrollTo({ top: 0, behavior: "smooth" })}
+        className="absolute bottom-3 right-3 z-10 grid size-9 place-items-center rounded-full border border-border bg-background/80 text-foreground backdrop-blur transition-colors hover:bg-background"
+        aria-label="Scroll to top"
+      >
+        <ArrowUp className="size-4" />
+      </button>
+    </div>
+  );
+}

--- a/components/previews/motion/smooth-scroll.preview.tsx
+++ b/components/previews/motion/smooth-scroll.preview.tsx
@@ -1,50 +1,45 @@
 "use client";
 
 import { ArrowUp } from "lucide-react";
-import { motion, useScroll, useSpring } from "motion/react";
-import { useRef } from "react";
 
-// The real <SmoothScroll> is a page-level provider (root mode) shown in the
-// Usage tab. A boxed preview can't hijack the page, so this demos the feel:
-// a contained scroller with a spring-smoothed progress bar and scroll-to-top,
-// the same scroll-driven UI <SmoothScroll> + useSmoothScroll unlock.
+import { SmoothScroll, useSmoothScroll } from "@/components/motion/smooth-scroll";
+
+// In production <SmoothScroll> wraps the page (root). Here it runs in contained
+// mode (root={false}) so the box itself smooth-scrolls — the same engine, and
+// the button uses the useSmoothScroll() hook to glide back to the top.
 const SECTIONS = Array.from({ length: 16 }, (_, i) => i + 1);
 
-export function SmoothScrollPreview() {
-  const ref = useRef<HTMLDivElement>(null);
-  const { scrollYProgress } = useScroll({ container: ref });
-  const progress = useSpring(scrollYProgress, {
-    stiffness: 120,
-    damping: 28,
-    mass: 0.6,
-  });
-
+function ScrollTopButton() {
+  const { scrollTo } = useSmoothScroll();
   return (
-    <div className="relative w-full max-w-lg overflow-hidden rounded-2xl border border-border bg-card">
-      <motion.div
-        className="absolute inset-x-0 top-0 z-10 h-0.5 origin-left bg-foreground"
-        style={{ scaleX: progress }}
-      />
-      <div ref={ref} className="h-64 overflow-y-auto scrollbar-hide">
-        <div className="space-y-3 p-4">
-          {SECTIONS.map((n) => (
-            <div
-              key={`section-${n}`}
-              className="rounded-lg bg-muted/60 px-3 py-4 text-sm text-muted-foreground"
-            >
-              Section {n}
-            </div>
-          ))}
-        </div>
+    <button
+      type="button"
+      onClick={() => scrollTo(0)}
+      className="sticky bottom-3 left-[calc(100%-3rem)] z-10 grid size-9 place-items-center rounded-full border border-border bg-background/80 text-foreground backdrop-blur transition-colors hover:bg-background"
+      aria-label="Scroll to top"
+    >
+      <ArrowUp className="size-4" />
+    </button>
+  );
+}
+
+export function SmoothScrollPreview() {
+  return (
+    <SmoothScroll
+      root={false}
+      className="h-64 w-full max-w-lg overflow-y-auto scrollbar-hide rounded-2xl border border-border bg-card"
+    >
+      <div className="space-y-3 p-4">
+        {SECTIONS.map((n) => (
+          <div
+            key={`section-${n}`}
+            className="rounded-lg bg-muted/60 px-3 py-4 text-sm text-muted-foreground"
+          >
+            Section {n}
+          </div>
+        ))}
       </div>
-      <button
-        type="button"
-        onClick={() => ref.current?.scrollTo({ top: 0, behavior: "smooth" })}
-        className="absolute bottom-3 right-3 z-10 grid size-9 place-items-center rounded-full border border-border bg-background/80 text-foreground backdrop-blur transition-colors hover:bg-background"
-        aria-label="Scroll to top"
-      >
-        <ArrowUp className="size-4" />
-      </button>
-    </div>
+      <ScrollTopButton />
+    </SmoothScroll>
   );
 }

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -282,6 +282,14 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/drawer.tsx",
         badge: "new",
       },
+      {
+        slug: "smooth-scroll",
+        name: "Smooth Scroll",
+        description: "Page-level smooth-scroll provider over Lenis with a useSmoothScroll hook exposing scroll offset, progress and velocity. Reduced-motion safe.",
+        file: "components/motion/smooth-scroll.tsx",
+        badge: "new",
+        keywords: ["smooth scroll", "lenis", "scroll progress", "momentum scroll", "scroll velocity"],
+      },
     ],
   },
   {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@vercel/speed-insights": "^1.1.0",
     "clsx": "^2.1.1",
     "geist": "^1.7.2",
+    "lenis": "^1.3.23",
     "lucide-react": "^1.16.0",
     "motion": "^11.15.0",
     "next": "^15.1.4",

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -6,6 +6,7 @@ import type { ReactElement } from "react";
 import { AnimatedBadge } from "@/components/motion/animated-badge";
 import { Button } from "@/components/motion/button";
 import { Switch } from "@/components/motion/switch";
+import { SmoothScroll } from "@/components/motion/smooth-scroll";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/motion/tabs";
 import { TextReveal } from "@/components/motion/text-reveal";
 import { Tooltip } from "@/components/motion/tooltip";
@@ -25,6 +26,17 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
     ),
   ],
   ["AnimatedBadge", () => <AnimatedBadge status="success">Live</AnimatedBadge>],
+  [
+    "SmoothScroll",
+    () => (
+      <SmoothScroll>
+        <main>
+          <h1>Page</h1>
+          <p>Scrollable content.</p>
+        </main>
+      </SmoothScroll>
+    ),
+  ],
   ["TextReveal", () => <TextReveal text="Ship it" />],
   [
     "Tooltip",

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,7 +7,9 @@ GlobalRegistrator.register();
 if (typeof window.matchMedia !== "function") {
   window.matchMedia = (query: string) =>
     ({
-      matches: false,
+      // Render the reduced-motion path in tests: deterministic, no JS springs
+      // or scroll engines to settle, so axe sees stable markup.
+      matches: query.includes("prefers-reduced-motion"),
       media: query,
       onchange: null,
       addListener: () => {},


### PR DESCRIPTION
First piece of a planned **scroll category**. The engine others hook into.

## What
- `<SmoothScroll>` — page-level provider wrapping `lenis/react` (root mode). Curated prop surface (`lerp`, `duration`, `orientation`, `wheelMultiplier`, `touch`), easing via a named expo-out curve.
- `useSmoothScroll()` — the stable interface: `scrollY`, `progress`, `velocity` as motion values + `scrollTo`. Used outside the provider it falls back to a native window scroll listener, so scroll-driven components work either way.

## Behavior
- **Reduced motion** → Lenis is not mounted at all; native scroll + listener feed the same motion values. `scrollTo` jumps instantly.
- Keyboard/focus scrolling untouched (Lenis virtualizes wheel/touch only).

## Registry
- New `smooth-scroll` motion entry. Shadcn item auto-declares `dependencies: ["lenis", "motion"]` — `npx shadcn add @beui/smooth-scroll` installs Lenis.
- Preview is a contained demo (root provider can't live-mount in a docs card); real usage wraps the page, shown in the Usage tab.

## Tests
- Added to the axe a11y suite. Test setup now matches `prefers-reduced-motion`, so SmoothScroll exercises the deterministic native path (no rAF/Lenis to settle in happy-dom).

## Follow-ups (separate PRs)
scroll-progress, parallax, scroll-to, scroll-reveal — all consume `useSmoothScroll`.

## Verify
- `bun run check` clean
- `bun test` → 8/8