### PR TITLE
feat: optional ripple animation on Button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | slug | file | what it does |
 |---|---|---|
 | `tilt-card` | `components/motion/tilt-card.tsx` | 3D perspective tilt on hover with cursor-tracked glare |
-| `button` | `components/motion/button/` | Spring-pressed `Button`, `StatefulButton` (idle/loading/success/error), `MagneticButton` |
+| `button` | `components/motion/button/` | Spring-pressed `Button` (optional `ripple` prop for a Material-style press ripple), `StatefulButton` (idle/loading/success/error), `MagneticButton` |
 | `marquee` | `components/motion/marquee.tsx` | Infinite horizontal or vertical scroll, pause-on-hover |
 | `tabs` | `components/motion/tabs.tsx` | Pill, segment or underline tabs with spring layoutId indicator |
 | `switch` | `components/motion/switch.tsx` | Toggle with spring-driven thumb and press feedback |

--- a/components/motion/button/base.tsx
+++ b/components/motion/button/base.tsx
@@ -1,7 +1,19 @@
 "use client";
 
-import { AnimatePresence, motion, useReducedMotion, type HTMLMotionProps } from "motion/react";
-import { forwardRef, type PointerEvent, type ReactNode, useCallback, useRef, useState } from "react";
+import {
+  AnimatePresence,
+  motion,
+  useReducedMotion,
+  type HTMLMotionProps,
+} from "motion/react";
+import {
+  forwardRef,
+  type PointerEvent,
+  type ReactNode,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import { EASE_OUT, SPRING_PRESS } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
@@ -9,7 +21,10 @@ import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "outline";
 export type ButtonSize = "sm" | "md" | "lg" | "icon";
 
-export interface ButtonProps extends Omit<HTMLMotionProps<"button">, "children"> {
+export interface ButtonProps extends Omit<
+  HTMLMotionProps<"button">,
+  "children"
+> {
   variant?: ButtonVariant;
   size?: ButtonSize;
   pressScale?: number;
@@ -22,10 +37,10 @@ type Ripple = { id: number; x: number; y: number; size: number };
 
 const VARIANT_CLASS: Record<ButtonVariant, string> = {
   primary: "bg-primary text-primary-foreground hover:bg-primary/90",
-  secondary:
-    "border border-border bg-card text-foreground hover:border-border",
+  secondary: "border border-border bg-card text-foreground hover:border-border",
   ghost: "text-muted-foreground hover:text-foreground hover:bg-primary/5",
-  outline: "border border-border bg-transparent text-foreground hover:bg-primary/5",
+  outline:
+    "border border-border bg-transparent text-foreground hover:bg-primary/5",
 };
 
 const SIZE_CLASS: Record<ButtonSize, string> = {
@@ -35,91 +50,93 @@ const SIZE_CLASS: Record<ButtonSize, string> = {
   icon: "h-8 w-8 rounded-lg",
 };
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  {
-    variant = "primary",
-    size = "md",
-    pressScale = 0.93,
-    ripple = false,
-    className,
-    children,
-    onPointerDown,
-    ...rest
-  },
-  ref,
-) {
-  const reduce = useReducedMotion();
-  const canHover = useHoverCapable();
-  const [ripples, setRipples] = useState<Ripple[]>([]);
-  const nextId = useRef(0);
-
-  const handlePointerDown = useCallback(
-    (event: PointerEvent<HTMLButtonElement>) => {
-      if (ripple && !reduce) {
-        const rect = event.currentTarget.getBoundingClientRect();
-        const size = Math.max(rect.width, rect.height) * 2;
-        setRipples((prev) => [
-          ...prev,
-          {
-            id: nextId.current++,
-            x: event.clientX - rect.left,
-            y: event.clientY - rect.top,
-            size,
-          },
-        ]);
-      }
-      onPointerDown?.(event);
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(
+    {
+      variant = "primary",
+      size = "md",
+      pressScale = 0.93,
+      ripple = false,
+      className,
+      children,
+      onPointerDown,
+      ...rest
     },
-    [ripple, reduce, onPointerDown],
-  );
+    ref,
+  ) {
+    const reduce = useReducedMotion();
+    const canHover = useHoverCapable();
+    const [ripples, setRipples] = useState<Ripple[]>([]);
+    const nextId = useRef(0);
 
-  return (
-    <motion.button
-      ref={ref}
-      type="button"
-      whileTap={reduce ? undefined : { scale: pressScale }}
-      whileHover={reduce || !canHover ? undefined : { scale: 1.02 }}
-      transition={SPRING_PRESS}
-      onPointerDown={handlePointerDown}
-      className={cn(
-        "inline-flex items-center justify-center font-medium select-none",
-        "transition-colors",
-        "disabled:pointer-events-none disabled:opacity-50",
-        ripple && "relative overflow-hidden",
-        VARIANT_CLASS[variant],
-        SIZE_CLASS[size],
-        className,
-      )}
-      {...rest}
-    >
-      {ripple && !reduce ? (
-        <span className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
-          <AnimatePresence>
-            {ripples.map((r) => (
-              <motion.span
-                key={r.id}
-                className="absolute rounded-full bg-current"
-                style={{
-                  left: r.x,
-                  top: r.y,
-                  width: r.size,
-                  height: r.size,
-                  x: "-50%",
-                  y: "-50%",
-                }}
-                initial={{ scale: 0, opacity: 0.3 }}
-                animate={{ scale: 1, opacity: 0 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.9, ease: EASE_OUT }}
-                onAnimationComplete={() =>
-                  setRipples((prev) => prev.filter((x) => x.id !== r.id))
-                }
-              />
-            ))}
-          </AnimatePresence>
-        </span>
-      ) : null}
-      {children}
-    </motion.button>
-  );
-});
+    const handlePointerDown = useCallback(
+      (event: PointerEvent<HTMLButtonElement>) => {
+        if (ripple && !reduce) {
+          const rect = event.currentTarget.getBoundingClientRect();
+          const size = Math.max(rect.width, rect.height) * 2;
+          setRipples((prev) => [
+            ...prev,
+            {
+              id: nextId.current++,
+              x: event.clientX - rect.left,
+              y: event.clientY - rect.top,
+              size,
+            },
+          ]);
+        }
+        onPointerDown?.(event);
+      },
+      [ripple, reduce, onPointerDown],
+    );
+
+    return (
+      <motion.button
+        ref={ref}
+        type="button"
+        whileTap={reduce ? undefined : { scale: pressScale }}
+        whileHover={reduce || !canHover ? undefined : { scale: 1.02 }}
+        transition={SPRING_PRESS}
+        onPointerDown={handlePointerDown}
+        className={cn(
+          "inline-flex items-center justify-center font-medium select-none",
+          "transition-colors",
+          "disabled:pointer-events-none disabled:opacity-50",
+          ripple && "relative overflow-hidden",
+          VARIANT_CLASS[variant],
+          SIZE_CLASS[size],
+          className,
+        )}
+        {...rest}
+      >
+        {ripple && !reduce ? (
+          <span className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
+            <AnimatePresence>
+              {ripples.map((r) => (
+                <motion.span
+                  key={r.id}
+                  className="absolute rounded-full bg-current"
+                  style={{
+                    left: r.x,
+                    top: r.y,
+                    width: r.size,
+                    height: r.size,
+                    x: "-50%",
+                    y: "-50%",
+                  }}
+                  initial={{ scale: 0, opacity: 0.3 }}
+                  animate={{ scale: 1, opacity: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 1.6, ease: EASE_OUT }}
+                  onAnimationComplete={() =>
+                    setRipples((prev) => prev.filter((x) => x.id !== r.id))
+                  }
+                />
+              ))}
+            </AnimatePresence>
+          </span>
+        ) : null}
+        {children}
+      </motion.button>
+    );
+  },
+);

--- a/components/motion/button/base.tsx
+++ b/components/motion/button/base.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { motion, useReducedMotion, type HTMLMotionProps } from "motion/react";
-import { forwardRef, type ReactNode } from "react";
-import { SPRING_PRESS } from "@/lib/ease";
+import { AnimatePresence, motion, useReducedMotion, type HTMLMotionProps } from "motion/react";
+import { forwardRef, type PointerEvent, type ReactNode, useCallback, useRef, useState } from "react";
+import { EASE_OUT, SPRING_PRESS } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
 
@@ -13,8 +13,12 @@ export interface ButtonProps extends Omit<HTMLMotionProps<"button">, "children">
   variant?: ButtonVariant;
   size?: ButtonSize;
   pressScale?: number;
+  /** Spawn a Material-style ripple from the press point. Off by default. */
+  ripple?: boolean;
   children?: ReactNode;
 }
+
+type Ripple = { id: number; x: number; y: number; size: number };
 
 const VARIANT_CLASS: Record<ButtonVariant, string> = {
   primary: "bg-primary text-primary-foreground hover:bg-primary/90",
@@ -32,11 +36,43 @@ const SIZE_CLASS: Record<ButtonSize, string> = {
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { variant = "primary", size = "md", pressScale = 0.93, className, children, ...rest },
+  {
+    variant = "primary",
+    size = "md",
+    pressScale = 0.93,
+    ripple = false,
+    className,
+    children,
+    onPointerDown,
+    ...rest
+  },
   ref,
 ) {
   const reduce = useReducedMotion();
   const canHover = useHoverCapable();
+  const [ripples, setRipples] = useState<Ripple[]>([]);
+  const nextId = useRef(0);
+
+  const handlePointerDown = useCallback(
+    (event: PointerEvent<HTMLButtonElement>) => {
+      if (ripple && !reduce) {
+        const rect = event.currentTarget.getBoundingClientRect();
+        const size = Math.max(rect.width, rect.height) * 2;
+        setRipples((prev) => [
+          ...prev,
+          {
+            id: nextId.current++,
+            x: event.clientX - rect.left,
+            y: event.clientY - rect.top,
+            size,
+          },
+        ]);
+      }
+      onPointerDown?.(event);
+    },
+    [ripple, reduce, onPointerDown],
+  );
+
   return (
     <motion.button
       ref={ref}
@@ -44,16 +80,45 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
       whileTap={reduce ? undefined : { scale: pressScale }}
       whileHover={reduce || !canHover ? undefined : { scale: 1.02 }}
       transition={SPRING_PRESS}
+      onPointerDown={handlePointerDown}
       className={cn(
         "inline-flex items-center justify-center font-medium select-none",
         "transition-colors",
         "disabled:pointer-events-none disabled:opacity-50",
+        ripple && "relative overflow-hidden",
         VARIANT_CLASS[variant],
         SIZE_CLASS[size],
         className,
       )}
       {...rest}
     >
+      {ripple && !reduce ? (
+        <span className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
+          <AnimatePresence>
+            {ripples.map((r) => (
+              <motion.span
+                key={r.id}
+                className="absolute rounded-full bg-current"
+                style={{
+                  left: r.x,
+                  top: r.y,
+                  width: r.size,
+                  height: r.size,
+                  x: "-50%",
+                  y: "-50%",
+                }}
+                initial={{ scale: 0, opacity: 0.3 }}
+                animate={{ scale: 1, opacity: 0 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.6, ease: EASE_OUT }}
+                onAnimationComplete={() =>
+                  setRipples((prev) => prev.filter((x) => x.id !== r.id))
+                }
+              />
+            ))}
+          </AnimatePresence>
+        </span>
+      ) : null}
       {children}
     </motion.button>
   );

--- a/components/motion/button/base.tsx
+++ b/components/motion/button/base.tsx
@@ -110,7 +110,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
                 initial={{ scale: 0, opacity: 0.3 }}
                 animate={{ scale: 1, opacity: 0 }}
                 exit={{ opacity: 0 }}
-                transition={{ duration: 0.6, ease: EASE_OUT }}
+                transition={{ duration: 0.9, ease: EASE_OUT }}
                 onAnimationComplete={() =>
                   setRipples((prev) => prev.filter((x) => x.id !== r.id))
                 }

--- a/components/previews/motion/button-base.preview.tsx
+++ b/components/previews/motion/button-base.preview.tsx
@@ -26,6 +26,10 @@ export function ButtonBasePreview() {
           <Trash2 className="h-4 w-4" />
         </Button>
       </div>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Button variant="primary" size="md" ripple>Ripple</Button>
+        <Button variant="outline" size="md" ripple>Tap me</Button>
+      </div>
     </div>
   );
 }

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -23,6 +23,7 @@ afterEach(cleanup);
 const cases: Array<[name: string, render: () => ReactElement]> = [
   ["Button", () => <Button>Subscribe</Button>],
   ["Button disabled", () => <Button disabled>Subscribe</Button>],
+  ["Button ripple", () => <Button ripple>Subscribe</Button>],
   [
     "Switch",
     () => (


### PR DESCRIPTION
Requested via feedback — an optional ripple variant for buttons.

## What
- New opt-in `ripple` prop on `Button`. A Material-style ripple spawns from the exact press point (pointerdown, so mouse + touch), clipped to the button shape via `rounded-[inherit]`, drawn with `currentColor`.
- Off by default; existing buttons unchanged.
- Reduced motion skips the ripple entirely.
- Ripples self-clean on animation complete (no leak).

## Tests
- Ripple Button added to the axe a11y suite. `bun run check` clean, `bun test` 14/14.

Shown in the button-base preview (Ripple / Tap me).