### PR TITLE
feat: range slider (stepped ticks + ring thumb)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `marquee` | `components/motion/marquee.tsx` | Infinite horizontal or vertical scroll, pause-on-hover |
 | `tabs` | `components/motion/tabs.tsx` | Pill, segment or underline tabs with spring layoutId indicator |
 | `switch` | `components/motion/switch.tsx` | Toggle with spring-driven thumb and press feedback |
+| `slider` | `components/motion/slider.tsx` | Range slider with stepped tick dots and a spring ring thumb that grows on grab; drag + keyboard, controlled/uncontrolled |
 | `bottom-sheet` | `components/motion/bottom-sheet.tsx` | Draggable bottom sheet with snap points, inertia and glass surface |
 | `shared-layout-bg` | `components/motion/shared-layout-bg.tsx` | Pill that glides between hovered items via shared layout |
 | `dock` | `components/motion/dock.tsx` | macOS-style dock with grouped actions and gliding active pill |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `marquee` | `components/motion/marquee.tsx` | Infinite horizontal or vertical scroll, pause-on-hover |
 | `tabs` | `components/motion/tabs.tsx` | Pill, segment or underline tabs with spring layoutId indicator |
 | `switch` | `components/motion/switch.tsx` | Toggle with spring-driven thumb and press feedback |
-| `slider` | `components/motion/slider.tsx` | Pill-track range slider with tick dots and a vertical-bar thumb; a magnifier lens ring blooms around the thumb on grab (`lens` prop). Drag + keyboard, controlled/uncontrolled |
+| `slider` | `components/motion/slider.tsx` | Range slider with tick dots and a bouncy vertical-bar thumb; track fills dark while dragging, light at rest. Drag + keyboard, controlled/uncontrolled |
 | `bottom-sheet` | `components/motion/bottom-sheet.tsx` | Draggable bottom sheet with snap points, inertia and glass surface |
 | `shared-layout-bg` | `components/motion/shared-layout-bg.tsx` | Pill that glides between hovered items via shared layout |
 | `dock` | `components/motion/dock.tsx` | macOS-style dock with grouped actions and gliding active pill |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `marquee` | `components/motion/marquee.tsx` | Infinite horizontal or vertical scroll, pause-on-hover |
 | `tabs` | `components/motion/tabs.tsx` | Pill, segment or underline tabs with spring layoutId indicator |
 | `switch` | `components/motion/switch.tsx` | Toggle with spring-driven thumb and press feedback |
-| `slider` | `components/motion/slider.tsx` | Range slider with stepped tick dots and a spring ring thumb that grows on grab; drag + keyboard, controlled/uncontrolled |
+| `slider` | `components/motion/slider.tsx` | Pill-track range slider with tick dots and a vertical-bar thumb; a magnifier lens ring blooms around the thumb on grab (`lens` prop). Drag + keyboard, controlled/uncontrolled |
 | `bottom-sheet` | `components/motion/bottom-sheet.tsx` | Draggable bottom sheet with snap points, inertia and glass surface |
 | `shared-layout-bg` | `components/motion/shared-layout-bg.tsx` | Pill that glides between hovered items via shared layout |
 | `dock` | `components/motion/dock.tsx` | macOS-style dock with grouped actions and gliding active pill |

--- a/components/motion/slider.tsx
+++ b/components/motion/slider.tsx
@@ -6,6 +6,7 @@ import {
   useMotionValue,
   useReducedMotion,
   useSpring,
+  useTransform,
 } from "motion/react";
 import {
   type KeyboardEvent,
@@ -66,7 +67,11 @@ export function Slider({
     target.set(percent);
   }, [percent, target]);
   const smooth = useSpring(target, SPRING_GLIDE);
-  const left = useMotionTemplate`${reduce ? target : smooth}%`;
+  const pos = reduce ? target : smooth;
+  const left = useMotionTemplate`${pos}%`;
+  // Self-offset the thumb from 0% (flush left) to -100% (flush right) of its
+  // own width so it stays fully inside the track at both ends — no clip, no gap.
+  const thumbX = useTransform(pos, (p) => `${-p}%`);
 
   const steps = Math.floor((max - min) / step);
   const ticks =
@@ -137,25 +142,25 @@ export function Slider({
 
   return (
     <div
+      ref={trackRef}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={endDrag}
       onPointerCancel={endDrag}
       className={cn(
-        "relative flex h-10 w-full touch-none select-none items-center rounded-lg bg-muted",
+        "relative flex h-10 w-full touch-none select-none items-center overflow-hidden rounded-lg bg-muted",
         disabled ? "pointer-events-none opacity-50" : "cursor-grab active:cursor-grabbing",
         className,
       )}
     >
-      {/* inset travel region so the thumb never clips at either end */}
-      <div ref={trackRef} className="relative mx-2 h-full flex-1">
-        {/* fill — consistent resting tone, drag or not */}
-        <motion.div
-          className="absolute inset-y-0 left-0 rounded-full bg-foreground/15"
-          style={{ width: left }}
-        />
+      {/* fill — runs from the left edge to the thumb, consistent tone */}
+      <motion.div
+        className="absolute inset-y-0 left-0 bg-foreground/15"
+        style={{ width: left }}
+      />
 
-        {/* ticks */}
+      {/* ticks — slight inset so the end dots don't clip */}
+      <div className="pointer-events-none absolute inset-x-2 inset-y-0">
         {ticks.map((t) => {
           const tp = ((t - min) / (max - min)) * 100;
           return (
@@ -166,23 +171,23 @@ export function Slider({
             />
           );
         })}
-
-        {/* vertical bar thumb */}
-        <motion.div
-          role="slider"
-          tabIndex={disabled ? -1 : 0}
-          aria-label={ariaLabel}
-          aria-valuemin={min}
-          aria-valuemax={max}
-          aria-valuenow={current}
-          aria-disabled={disabled || undefined}
-          onKeyDown={onKeyDown}
-          animate={reduce ? undefined : { scaleY: active ? 1.35 : 1 }}
-          transition={SPRING_BOUNCY}
-          className="absolute top-1/2 h-5 w-1.5 rounded-sm bg-foreground shadow-sm outline-none ring-foreground/30 focus-visible:ring-4"
-          style={{ left, x: "-50%", y: "-50%" }}
-        />
       </div>
+
+      {/* vertical bar thumb — contained at both ends via thumbX */}
+      <motion.div
+        role="slider"
+        tabIndex={disabled ? -1 : 0}
+        aria-label={ariaLabel}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={current}
+        aria-disabled={disabled || undefined}
+        onKeyDown={onKeyDown}
+        animate={reduce ? undefined : { scaleY: active ? 1.35 : 1 }}
+        transition={SPRING_BOUNCY}
+        className="absolute top-1/2 h-5 w-1.5 rounded-sm bg-foreground shadow-sm outline-none ring-foreground/30 focus-visible:ring-4"
+        style={{ left, x: thumbX, y: "-50%" }}
+      />
     </div>
   );
 }

--- a/components/motion/slider.tsx
+++ b/components/motion/slider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 import {
   type KeyboardEvent,
   type PointerEvent,
@@ -9,8 +9,10 @@ import {
   useState,
 } from "react";
 
-import { SPRING_PRESS } from "@/lib/ease";
 import { cn } from "@/lib/utils";
+
+// Bouncy thumb feedback — low damping for a playful overshoot on grab.
+const SPRING_BOUNCY = { type: "spring", stiffness: 500, damping: 14, mass: 0.7 } as const;
 
 export interface SliderProps {
   value?: number;
@@ -21,8 +23,6 @@ export interface SliderProps {
   step?: number;
   /** Render a tick dot at each step. */
   showTicks?: boolean;
-  /** Bloom a magnifier lens ring around the thumb while dragging. */
-  lens?: boolean;
   disabled?: boolean;
   className?: string;
   "aria-label"?: string;
@@ -38,7 +38,6 @@ export function Slider({
   max = 100,
   step = 1,
   showTicks = true,
-  lens = true,
   disabled = false,
   className,
   "aria-label": ariaLabel,
@@ -126,38 +125,35 @@ export function Slider({
       onPointerUp={endDrag}
       onPointerCancel={endDrag}
       className={cn(
-        "relative flex h-10 w-full touch-none select-none items-center rounded-full bg-muted",
+        "relative flex h-10 w-full touch-none select-none items-center overflow-hidden rounded-lg bg-muted",
         disabled ? "pointer-events-none opacity-50" : "cursor-grab active:cursor-grabbing",
         className,
       )}
     >
+      {/* fill — dark while dragging, light at rest */}
+      <div
+        className={cn(
+          "absolute inset-y-0 left-0 transition-colors duration-200",
+          active ? "bg-foreground" : "bg-foreground/15",
+        )}
+        style={{ width: `${percent}%` }}
+      />
+
       {/* ticks */}
       {ticks.map((t) => {
         const tp = ((t - min) / (max - min)) * 100;
+        const filled = t <= current;
         return (
           <span
             key={t}
-            className="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground/25"
+            className={cn(
+              "absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors",
+              filled && active ? "bg-background/60" : "bg-foreground/25",
+            )}
             style={{ left: `${tp}%` }}
           />
         );
       })}
-
-      {/* lens ring */}
-      {lens && !reduce ? (
-        <AnimatePresence>
-          {active ? (
-            <motion.span
-              className="pointer-events-none absolute top-1/2 size-16 -translate-x-1/2 -translate-y-1/2 rounded-full border border-foreground/40 bg-background/5 backdrop-blur-[1px]"
-              style={{ left: `${percent}%` }}
-              initial={{ scale: 0, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0, opacity: 0 }}
-              transition={SPRING_PRESS}
-            />
-          ) : null}
-        </AnimatePresence>
-      ) : null}
 
       {/* vertical bar thumb */}
       <motion.div
@@ -169,9 +165,9 @@ export function Slider({
         aria-valuenow={current}
         aria-disabled={disabled || undefined}
         onKeyDown={onKeyDown}
-        animate={reduce ? undefined : { scaleY: active ? 1.3 : 1 }}
-        transition={SPRING_PRESS}
-        className="absolute h-5 w-1.5 -translate-x-1/2 rounded-full bg-foreground shadow-sm outline-none ring-foreground/30 focus-visible:ring-4"
+        animate={reduce ? undefined : { scaleY: active ? 1.35 : 1 }}
+        transition={SPRING_BOUNCY}
+        className="absolute h-5 w-1.5 -translate-x-1/2 rounded-sm bg-foreground shadow-sm outline-none ring-foreground/30 focus-visible:ring-4"
         style={{ left: `${percent}%` }}
       />
     </div>

--- a/components/motion/slider.tsx
+++ b/components/motion/slider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useReducedMotion } from "motion/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   type KeyboardEvent,
   type PointerEvent,
@@ -21,6 +21,8 @@ export interface SliderProps {
   step?: number;
   /** Render a tick dot at each step. */
   showTicks?: boolean;
+  /** Bloom a magnifier lens ring around the thumb while dragging. */
+  lens?: boolean;
   disabled?: boolean;
   className?: string;
   "aria-label"?: string;
@@ -36,6 +38,7 @@ export function Slider({
   max = 100,
   step = 1,
   showTicks = true,
+  lens = true,
   disabled = false,
   className,
   "aria-label": ariaLabel,
@@ -123,35 +126,40 @@ export function Slider({
       onPointerUp={endDrag}
       onPointerCancel={endDrag}
       className={cn(
-        "relative flex h-10 w-full items-center touch-none select-none",
-        disabled && "pointer-events-none opacity-50",
+        "relative flex h-10 w-full touch-none select-none items-center rounded-full bg-muted",
+        disabled ? "pointer-events-none opacity-50" : "cursor-grab active:cursor-grabbing",
         className,
       )}
     >
-      {/* rail */}
-      <div className="relative h-1.5 w-full rounded-full bg-muted">
-        {/* fill */}
-        <div
-          className="absolute inset-y-0 left-0 rounded-full bg-foreground"
-          style={{ width: `${percent}%` }}
-        />
-        {/* ticks */}
-        {ticks.map((t) => {
-          const tp = ((t - min) / (max - min)) * 100;
-          return (
-            <span
-              key={t}
-              className={cn(
-                "absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full",
-                t <= current ? "bg-background/70" : "bg-foreground/25",
-              )}
-              style={{ left: `${tp}%` }}
-            />
-          );
-        })}
-      </div>
+      {/* ticks */}
+      {ticks.map((t) => {
+        const tp = ((t - min) / (max - min)) * 100;
+        return (
+          <span
+            key={t}
+            className="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground/25"
+            style={{ left: `${tp}%` }}
+          />
+        );
+      })}
 
-      {/* thumb */}
+      {/* lens ring */}
+      {lens && !reduce ? (
+        <AnimatePresence>
+          {active ? (
+            <motion.span
+              className="pointer-events-none absolute top-1/2 size-16 -translate-x-1/2 -translate-y-1/2 rounded-full border border-foreground/40 bg-background/5 backdrop-blur-[1px]"
+              style={{ left: `${percent}%` }}
+              initial={{ scale: 0, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0, opacity: 0 }}
+              transition={SPRING_PRESS}
+            />
+          ) : null}
+        </AnimatePresence>
+      ) : null}
+
+      {/* vertical bar thumb */}
       <motion.div
         role="slider"
         tabIndex={disabled ? -1 : 0}
@@ -161,9 +169,9 @@ export function Slider({
         aria-valuenow={current}
         aria-disabled={disabled || undefined}
         onKeyDown={onKeyDown}
-        animate={reduce ? undefined : { scale: active ? 1.25 : 1 }}
+        animate={reduce ? undefined : { scaleY: active ? 1.3 : 1 }}
         transition={SPRING_PRESS}
-        className="absolute size-5 -translate-x-1/2 rounded-full border-2 border-foreground bg-background shadow-md outline-none ring-foreground/30 focus-visible:ring-4"
+        className="absolute h-5 w-1.5 -translate-x-1/2 rounded-full bg-foreground shadow-sm outline-none ring-foreground/30 focus-visible:ring-4"
         style={{ left: `${percent}%` }}
       />
     </div>

--- a/components/motion/slider.tsx
+++ b/components/motion/slider.tsx
@@ -1,17 +1,27 @@
 "use client";
 
-import { motion, useReducedMotion } from "motion/react";
+import {
+  motion,
+  useMotionTemplate,
+  useMotionValue,
+  useReducedMotion,
+  useSpring,
+} from "motion/react";
 import {
   type KeyboardEvent,
   type PointerEvent,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react";
 
 import { cn } from "@/lib/utils";
 
-// Bouncy thumb feedback — low damping for a playful overshoot on grab.
+// Smooth glide for the thumb/fill — critically damped, no overshoot, so the
+// handle follows the pointer butterily and eases between snapped steps.
+const SPRING_GLIDE = { stiffness: 700, damping: 50, mass: 0.5 } as const;
+// Bouncy grab feedback for the thumb scale only.
 const SPRING_BOUNCY = { type: "spring", stiffness: 500, damping: 14, mass: 0.7 } as const;
 
 export interface SliderProps {
@@ -49,6 +59,14 @@ export function Slider({
   const controlled = value !== undefined;
   const current = clamp(controlled ? value : internal, min, max);
   const percent = ((current - min) / (max - min)) * 100;
+
+  // Spring-smoothed position drives both the thumb and the fill.
+  const target = useMotionValue(percent);
+  useEffect(() => {
+    target.set(percent);
+  }, [percent, target]);
+  const smooth = useSpring(target, SPRING_GLIDE);
+  const left = useMotionTemplate`${reduce ? target : smooth}%`;
 
   const steps = Math.floor((max - min) / step);
   const ticks =
@@ -130,26 +148,19 @@ export function Slider({
         className,
       )}
     >
-      {/* fill — dark while dragging, light at rest */}
-      <div
-        className={cn(
-          "absolute inset-y-0 left-0 transition-colors duration-200",
-          active ? "bg-foreground" : "bg-foreground/15",
-        )}
-        style={{ width: `${percent}%` }}
+      {/* fill — consistent resting tone, drag or not */}
+      <motion.div
+        className="absolute inset-y-0 left-0 bg-foreground/15"
+        style={{ width: left }}
       />
 
       {/* ticks */}
       {ticks.map((t) => {
         const tp = ((t - min) / (max - min)) * 100;
-        const filled = t <= current;
         return (
           <span
             key={t}
-            className={cn(
-              "absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors",
-              filled && active ? "bg-background/60" : "bg-foreground/25",
-            )}
+            className="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground/25"
             style={{ left: `${tp}%` }}
           />
         );
@@ -167,8 +178,8 @@ export function Slider({
         onKeyDown={onKeyDown}
         animate={reduce ? undefined : { scaleY: active ? 1.35 : 1 }}
         transition={SPRING_BOUNCY}
-        className="absolute h-5 w-1.5 -translate-x-1/2 rounded-sm bg-foreground shadow-sm outline-none ring-foreground/30 focus-visible:ring-4"
-        style={{ left: `${percent}%` }}
+        className="absolute top-1/2 h-5 w-1.5 rounded-sm bg-foreground shadow-sm outline-none ring-foreground/30 focus-visible:ring-4"
+        style={{ left, x: "-50%", y: "-50%" }}
       />
     </div>
   );

--- a/components/motion/slider.tsx
+++ b/components/motion/slider.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import {
+  type KeyboardEvent,
+  type PointerEvent,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
+
+import { SPRING_PRESS } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+export interface SliderProps {
+  value?: number;
+  defaultValue?: number;
+  onValueChange?: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  /** Render a tick dot at each step. */
+  showTicks?: boolean;
+  disabled?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
+
+export function Slider({
+  value,
+  defaultValue = 0,
+  onValueChange,
+  min = 0,
+  max = 100,
+  step = 1,
+  showTicks = true,
+  disabled = false,
+  className,
+  "aria-label": ariaLabel,
+}: SliderProps) {
+  const reduce = useReducedMotion();
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [internal, setInternal] = useState(defaultValue);
+  const [active, setActive] = useState(false);
+  const controlled = value !== undefined;
+  const current = clamp(controlled ? value : internal, min, max);
+  const percent = ((current - min) / (max - min)) * 100;
+
+  const steps = Math.floor((max - min) / step);
+  const ticks =
+    showTicks && steps > 0 && steps <= 50
+      ? Array.from({ length: steps + 1 }, (_, i) => min + i * step)
+      : [];
+
+  const commit = useCallback(
+    (next: number) => {
+      const snapped = clamp(Math.round((next - min) / step) * step + min, min, max);
+      if (!controlled) setInternal(snapped);
+      onValueChange?.(snapped);
+    },
+    [controlled, onValueChange, min, max, step],
+  );
+
+  const valueFromX = useCallback(
+    (clientX: number) => {
+      const rect = trackRef.current?.getBoundingClientRect();
+      if (!rect) return current;
+      const ratio = clamp((clientX - rect.left) / rect.width, 0, 1);
+      return min + ratio * (max - min);
+    },
+    [current, min, max],
+  );
+
+  const onPointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setActive(true);
+      commit(valueFromX(event.clientX));
+    },
+    [disabled, commit, valueFromX],
+  );
+
+  const onPointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!active || disabled) return;
+      commit(valueFromX(event.clientX));
+    },
+    [active, disabled, commit, valueFromX],
+  );
+
+  const endDrag = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    setActive(false);
+  }, []);
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      const map: Record<string, number> = {
+        ArrowRight: current + step,
+        ArrowUp: current + step,
+        ArrowLeft: current - step,
+        ArrowDown: current - step,
+        Home: min,
+        End: max,
+      };
+      if (event.key in map) {
+        event.preventDefault();
+        commit(map[event.key]);
+      }
+    },
+    [disabled, current, step, min, max, commit],
+  );
+
+  return (
+    <div
+      ref={trackRef}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      className={cn(
+        "relative flex h-10 w-full items-center touch-none select-none",
+        disabled && "pointer-events-none opacity-50",
+        className,
+      )}
+    >
+      {/* rail */}
+      <div className="relative h-1.5 w-full rounded-full bg-muted">
+        {/* fill */}
+        <div
+          className="absolute inset-y-0 left-0 rounded-full bg-foreground"
+          style={{ width: `${percent}%` }}
+        />
+        {/* ticks */}
+        {ticks.map((t) => {
+          const tp = ((t - min) / (max - min)) * 100;
+          return (
+            <span
+              key={t}
+              className={cn(
+                "absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full",
+                t <= current ? "bg-background/70" : "bg-foreground/25",
+              )}
+              style={{ left: `${tp}%` }}
+            />
+          );
+        })}
+      </div>
+
+      {/* thumb */}
+      <motion.div
+        role="slider"
+        tabIndex={disabled ? -1 : 0}
+        aria-label={ariaLabel}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={current}
+        aria-disabled={disabled || undefined}
+        onKeyDown={onKeyDown}
+        animate={reduce ? undefined : { scale: active ? 1.25 : 1 }}
+        transition={SPRING_PRESS}
+        className="absolute size-5 -translate-x-1/2 rounded-full border-2 border-foreground bg-background shadow-md outline-none ring-foreground/30 focus-visible:ring-4"
+        style={{ left: `${percent}%` }}
+      />
+    </div>
+  );
+}

--- a/components/motion/slider.tsx
+++ b/components/motion/slider.tsx
@@ -137,50 +137,52 @@ export function Slider({
 
   return (
     <div
-      ref={trackRef}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={endDrag}
       onPointerCancel={endDrag}
       className={cn(
-        "relative flex h-10 w-full touch-none select-none items-center overflow-hidden rounded-lg bg-muted",
+        "relative flex h-10 w-full touch-none select-none items-center rounded-lg bg-muted",
         disabled ? "pointer-events-none opacity-50" : "cursor-grab active:cursor-grabbing",
         className,
       )}
     >
-      {/* fill — consistent resting tone, drag or not */}
-      <motion.div
-        className="absolute inset-y-0 left-0 bg-foreground/15"
-        style={{ width: left }}
-      />
+      {/* inset travel region so the thumb never clips at either end */}
+      <div ref={trackRef} className="relative mx-2 h-full flex-1">
+        {/* fill — consistent resting tone, drag or not */}
+        <motion.div
+          className="absolute inset-y-0 left-0 rounded-full bg-foreground/15"
+          style={{ width: left }}
+        />
 
-      {/* ticks */}
-      {ticks.map((t) => {
-        const tp = ((t - min) / (max - min)) * 100;
-        return (
-          <span
-            key={t}
-            className="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground/25"
-            style={{ left: `${tp}%` }}
-          />
-        );
-      })}
+        {/* ticks */}
+        {ticks.map((t) => {
+          const tp = ((t - min) / (max - min)) * 100;
+          return (
+            <span
+              key={t}
+              className="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground/25"
+              style={{ left: `${tp}%` }}
+            />
+          );
+        })}
 
-      {/* vertical bar thumb */}
-      <motion.div
-        role="slider"
-        tabIndex={disabled ? -1 : 0}
-        aria-label={ariaLabel}
-        aria-valuemin={min}
-        aria-valuemax={max}
-        aria-valuenow={current}
-        aria-disabled={disabled || undefined}
-        onKeyDown={onKeyDown}
-        animate={reduce ? undefined : { scaleY: active ? 1.35 : 1 }}
-        transition={SPRING_BOUNCY}
-        className="absolute top-1/2 h-5 w-1.5 rounded-sm bg-foreground shadow-sm outline-none ring-foreground/30 focus-visible:ring-4"
-        style={{ left, x: "-50%", y: "-50%" }}
-      />
+        {/* vertical bar thumb */}
+        <motion.div
+          role="slider"
+          tabIndex={disabled ? -1 : 0}
+          aria-label={ariaLabel}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={current}
+          aria-disabled={disabled || undefined}
+          onKeyDown={onKeyDown}
+          animate={reduce ? undefined : { scaleY: active ? 1.35 : 1 }}
+          transition={SPRING_BOUNCY}
+          className="absolute top-1/2 h-5 w-1.5 rounded-sm bg-foreground shadow-sm outline-none ring-foreground/30 focus-visible:ring-4"
+          style={{ left, x: "-50%", y: "-50%" }}
+        />
+      </div>
     </div>
   );
 }

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -161,6 +161,9 @@ export const previews: Record<string, ComponentType> = {
   "motion/scroll-reveal": dynamic(() =>
     import("./motion/scroll-reveal.preview").then((m) => m.ScrollRevealPreview),
   ),
+  "motion/slider": dynamic(() =>
+    import("./motion/slider.preview").then((m) => m.SliderPreview),
+  ),
 };
 
 export function getPreview(category: string, slug: string) {

--- a/components/previews/motion/slider.preview.tsx
+++ b/components/previews/motion/slider.preview.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+
+import { Slider } from "@/components/motion/slider";
+
+export function SliderPreview() {
+  const [value, setValue] = useState(40);
+
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>Volume</span>
+          <span className="tabular-nums text-foreground">{value}</span>
+        </div>
+        <Slider value={value} onValueChange={setValue} aria-label="Volume" />
+      </div>
+
+      <Slider
+        defaultValue={6}
+        min={0}
+        max={10}
+        step={1}
+        aria-label="Rating out of ten"
+      />
+    </div>
+  );
+}

--- a/components/previews/motion/slider.preview.tsx
+++ b/components/previews/motion/slider.preview.tsx
@@ -8,22 +8,12 @@ export function SliderPreview() {
   const [value, setValue] = useState(40);
 
   return (
-    <div className="flex w-full max-w-sm flex-col gap-8">
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center justify-between text-sm text-muted-foreground">
-          <span>Volume</span>
-          <span className="tabular-nums text-foreground">{value}</span>
-        </div>
-        <Slider value={value} onValueChange={setValue} aria-label="Volume" />
+    <div className="flex w-full max-w-sm flex-col gap-3">
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>Drag the handle</span>
+        <span className="tabular-nums text-foreground">{value}</span>
       </div>
-
-      <Slider
-        defaultValue={6}
-        min={0}
-        max={10}
-        step={1}
-        aria-label="Rating out of ten"
-      />
+      <Slider value={value} onValueChange={setValue} step={5} aria-label="Value" />
     </div>
   );
 }

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -353,7 +353,7 @@ export const registry: CategoryEntry[] = [
       {
         slug: "slider",
         name: "Slider",
-        description: "Pill-track range slider with tick dots and a vertical bar thumb; a magnifier lens ring blooms around the thumb on grab. Drag and keyboard control, reduced-motion safe.",
+        description: "Range slider with tick dots and a bouncy vertical-bar thumb; the track fills dark while dragging and stays light at rest. Drag and keyboard control, reduced-motion safe.",
         file: "components/motion/slider.tsx",
         badge: "new",
         keywords: ["slider", "range slider", "range input", "stepped slider", "ticks"],

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -350,6 +350,14 @@ export const registry: CategoryEntry[] = [
           },
         ],
       },
+      {
+        slug: "slider",
+        name: "Slider",
+        description: "Range slider with stepped tick dots, a spring ring thumb that grows on grab, drag and keyboard control. Reduced-motion safe.",
+        file: "components/motion/slider.tsx",
+        badge: "new",
+        keywords: ["slider", "range slider", "range input", "stepped slider", "ticks"],
+      },
     ],
   },
   {

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -353,7 +353,7 @@ export const registry: CategoryEntry[] = [
       {
         slug: "slider",
         name: "Slider",
-        description: "Range slider with stepped tick dots, a spring ring thumb that grows on grab, drag and keyboard control. Reduced-motion safe.",
+        description: "Pill-track range slider with tick dots and a vertical bar thumb; a magnifier lens ring blooms around the thumb on grab. Drag and keyboard control, reduced-motion safe.",
         file: "components/motion/slider.tsx",
         badge: "new",
         keywords: ["slider", "range slider", "range input", "stepped slider", "ticks"],

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -10,6 +10,7 @@ import { Parallax } from "@/components/motion/parallax";
 import { ScrollProgress } from "@/components/motion/scroll-progress";
 import { ScrollReveal } from "@/components/motion/scroll-reveal";
 import { ScrollTo } from "@/components/motion/scroll-to";
+import { Slider } from "@/components/motion/slider";
 import { SmoothScroll } from "@/components/motion/smooth-scroll";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/motion/tabs";
 import { TextReveal } from "@/components/motion/text-reveal";
@@ -53,6 +54,7 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
     ),
   ],
   ["ScrollTo", () => <ScrollTo to="#top">Back to top</ScrollTo>],
+  ["Slider", () => <Slider defaultValue={40} aria-label="Volume" />],
   [
     "ScrollReveal",
     () => (


### PR DESCRIPTION
The dotted rail with a ring thumb — built as a range Slider.

## What
- `<Slider>` — stepped range slider. Tick dots at each step, a spring ring thumb that scales up on grab, pointer drag with snap-to-step, click-to-set on the track.
- Controlled + uncontrolled (`value`/`defaultValue`/`onValueChange`), `min`/`max`/`step`, `showTicks`, `disabled`.
- Keyboard: arrows step, Home/End jump to bounds; `role="slider"` with aria-valuemin/max/now.
- Reduced motion drops the thumb spring/scale.

## Tests
- Added to the axe a11y suite. `bun run check` clean, `bun test` 15/15.