### PR TITLE
fix: full-row click target for checkbox and radio

### DIFF
--- a/components/motion/checkbox.tsx
+++ b/components/motion/checkbox.tsx
@@ -34,7 +34,14 @@ export function Checkbox({
   const path = indeterminate ? INDETERMINATE_PATH : CHECK_PATH;
 
   return (
-    <span className={cn("inline-flex items-center gap-3", className)}>
+    <label
+      htmlFor={id}
+      className={cn(
+        "inline-flex items-center gap-3",
+        disabled ? "cursor-not-allowed" : "cursor-pointer",
+        className,
+      )}
+    >
       <motion.button
         id={id}
         type="button"
@@ -100,16 +107,10 @@ export function Checkbox({
         </AnimatePresence>
       </motion.button>
       {label ? (
-        <label
-          htmlFor={id}
-          className={cn(
-            "text-sm text-foreground",
-            disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
-          )}
-        >
+        <span className={cn("select-none text-sm text-foreground", disabled && "opacity-60")}>
           {label}
-        </label>
+        </span>
       ) : null}
-    </span>
+    </label>
   );
 }

--- a/components/motion/radio.tsx
+++ b/components/motion/radio.tsx
@@ -94,7 +94,14 @@ export function RadioGroupItem({
   const selected = groupValue === value;
 
   return (
-    <span className={cn("inline-flex items-center gap-3", className)}>
+    <label
+      htmlFor={id}
+      className={cn(
+        "inline-flex items-center gap-3",
+        disabled ? "cursor-not-allowed" : "cursor-pointer",
+        className,
+      )}
+    >
       <motion.button
         id={id}
         type="button"
@@ -123,16 +130,10 @@ export function RadioGroupItem({
         ) : null}
       </motion.button>
       {label ? (
-        <label
-          htmlFor={id}
-          className={cn(
-            "text-sm text-foreground",
-            disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
-          )}
-        >
+        <span className={cn("select-none text-sm text-foreground", disabled && "opacity-60")}>
           {label}
-        </label>
+        </span>
       ) : null}
-    </span>
+    </label>
   );
 }

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -5,6 +5,8 @@ import type { ReactElement } from "react";
 
 import { AnimatedBadge } from "@/components/motion/animated-badge";
 import { Button } from "@/components/motion/button";
+import { Checkbox } from "@/components/motion/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/motion/radio";
 import { Switch } from "@/components/motion/switch";
 import { Parallax } from "@/components/motion/parallax";
 import { ScrollProgress } from "@/components/motion/scroll-progress";
@@ -55,6 +57,19 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
   ],
   ["ScrollTo", () => <ScrollTo to="#top">Back to top</ScrollTo>],
   ["RangeSlider", () => <RangeSlider defaultValue={40} aria-label="Volume" />],
+  [
+    "Checkbox",
+    () => <Checkbox checked={false} onCheckedChange={() => {}} label="Accept terms" />,
+  ],
+  [
+    "RadioGroup",
+    () => (
+      <RadioGroup defaultValue="a">
+        <RadioGroupItem value="a" label="Option A" />
+        <RadioGroupItem value="b" label="Option B" />
+      </RadioGroup>
+    ),
+  ],
   [
     "ScrollReveal",
     () => (


### PR DESCRIPTION
## Bug
Clicking the control or its text toggled, but clicking the **gap between them** did nothing — the row wrapper was a bare `<span>` with no handler.

## Fix
Wrap the whole row in a `<label htmlFor={id}>` (control nested inside). Clicking the control, the gap, or the text now all forward a single toggle to the control. Label text moved to a `<span>`.
- No double-toggle: clicking the control fires once; clicking the label area forwards one click (standard label behavior).
- Applies to `Checkbox` and `RadioGroupItem`.

## Tests
- Added Checkbox + RadioGroup to the axe a11y suite. `bun run check` clean, `bun test` 17/17.