### PR TITLE
fix: allow /api/og in robots (Twitter card image)

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -7,8 +7,11 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: "/",
-        // Machine endpoints: image generation and raw source text.
+        // Allow the OG image route so social crawlers (Twitter/X, etc.) can
+        // fetch link-preview images; the more specific allow overrides the
+        // /api/ disallow below.
+        allow: ["/", "/api/og"],
+        // Machine endpoints: raw source text and the rest of /api/.
         // Agents fetch these directly; they are not search content.
         disallow: ["/api/", "/r/*/raw"],
       },


### PR DESCRIPTION
## Bug
No image on Twitter/X link previews for beui.dev.

## Cause
`robots.txt` had `Disallow: /api/`. Every page's `twitter:image` (and component/category/docs OG images) points to `/api/og` — under `/api/` — so Twitterbot was blocked from fetching the image. Other platforms worked because the homepage `og:image` resolves to the allowed `/opengraph-image` file route.

## Fix
Allow `/api/og` specifically (more specific rule wins); the rest of `/api/` stays disallowed.

## Note
After deploy, X may still show the stale (imageless) card from its cache. Re-share the link (or append a one-off `?v=1`) to force a fresh crawl.