### PR TITLE
feat: work-with-me CTA before footer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { Hero } from "@/components/app/hero";
 import { InstallCommand } from "@/components/app/install-command";
 import { LandingComponentCard } from "@/components/app/landing-component-card";
 import { SiteFooter } from "@/components/app/site-footer";
+import { WorkCta } from "@/components/app/work-cta";
 
 const CURATED: { category: string; slug: string }[] = [
   { category: "motion", slug: "button" },
@@ -96,6 +97,8 @@ export default function Home() {
           ))}
         </div>
       </section>
+
+      <WorkCta />
 
       <SiteFooter />
     </div>

--- a/components/app/work-cta.tsx
+++ b/components/app/work-cta.tsx
@@ -1,0 +1,33 @@
+import { ArrowUpRight } from "lucide-react";
+import { PressLink } from "@/components/app/press-link";
+
+const CAL_URL = "https://cal.com/saurra3h/30min";
+
+export function WorkCta() {
+  return (
+    <section className="px-4 pb-16">
+      <div className="mx-auto max-w-7xl">
+        <div className="flex flex-col items-start gap-6 rounded-2xl border border-border bg-card px-8 py-12 md:flex-row md:items-center md:justify-between md:px-12">
+          <div className="max-w-xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
+              Want components built for your product?
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground md:text-base">
+              Custom motion components and frontend systems, built to spec. Book a
+              call to talk it through.
+            </p>
+          </div>
+          <PressLink
+            href={CAL_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex shrink-0 items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground"
+          >
+            Book a call
+            <ArrowUpRight className="h-4 w-4" />
+          </PressLink>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/app/work-cta.tsx
+++ b/components/app/work-cta.tsx
@@ -7,25 +7,25 @@ export function WorkCta() {
   return (
     <section className="px-4 pb-24">
       <div className="mx-auto max-w-7xl">
-        <div className="relative overflow-hidden rounded-[28px] border border-border bg-card px-8 py-16 md:px-16 md:py-20">
-          {/* concentric-ring depth, theme-derived */}
+        <div className="relative overflow-hidden rounded-[28px] bg-card px-8 py-20 md:px-16 md:py-24">
+          {/* concentric-ring depth behind the content, theme-derived */}
           <div
             aria-hidden
-            className="pointer-events-none absolute -top-32 -right-28 hidden md:block"
+            className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
           >
-            <div className="size-[460px] rounded-full border border-foreground/[0.06]">
-              <div className="absolute inset-14 rounded-full border border-foreground/[0.05]">
-                <div className="absolute inset-14 rounded-full border border-foreground/[0.04]" />
+            <div className="size-[520px] rounded-full border border-foreground/[0.05]">
+              <div className="absolute inset-16 rounded-full border border-foreground/[0.04]">
+                <div className="absolute inset-16 rounded-full border border-foreground/[0.03]" />
               </div>
             </div>
           </div>
 
-          <div className="relative flex flex-col items-start gap-10 md:flex-row md:items-end md:justify-between">
+          <div className="relative flex flex-col items-center gap-8 text-center">
             <div className="max-w-xl">
               <h2 className="font-pixel text-2xl font-medium text-foreground md:text-[2rem] md:leading-[1.15]">
                 Want components built for your product?
               </h2>
-              <p className="mt-5 max-w-md text-base leading-7 text-muted-foreground">
+              <p className="mx-auto mt-5 max-w-md text-base leading-7 text-muted-foreground">
                 Custom motion components and frontend systems, built to spec. Book a
                 call and let's talk it through.
               </p>
@@ -35,7 +35,7 @@ export function WorkCta() {
               href={CAL_URL}
               target="_blank"
               rel="noreferrer noopener"
-              className="group inline-flex shrink-0 items-center gap-2 rounded-full bg-primary px-7 py-3.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+              className="group inline-flex items-center gap-2 rounded-full bg-primary px-7 py-3.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
             >
               Book a call
               <ArrowUpRight className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />

--- a/components/app/work-cta.tsx
+++ b/components/app/work-cta.tsx
@@ -7,27 +7,15 @@ export function WorkCta() {
   return (
     <section className="px-4 pb-24">
       <div className="mx-auto max-w-7xl">
-        <div className="relative overflow-hidden rounded-[28px] bg-card px-8 py-20 md:px-16 md:py-24">
-          {/* concentric-ring depth behind the content, theme-derived */}
-          <div
-            aria-hidden
-            className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
-          >
-            <div className="size-[520px] rounded-full border border-foreground/[0.05]">
-              <div className="absolute inset-16 rounded-full border border-foreground/[0.04]">
-                <div className="absolute inset-16 rounded-full border border-foreground/[0.03]" />
-              </div>
-            </div>
-          </div>
-
+        <div className="relative overflow-hidden rounded-[28px] bg-card px-8 py-20 shadow-[inset_0_1px_1px_rgba(255,255,255,0.06),inset_0_-24px_48px_-24px_rgba(0,0,0,0.28)] md:px-16 md:py-24">
           <div className="relative flex flex-col items-center gap-8 text-center">
             <div className="max-w-xl">
               <h2 className="font-pixel text-2xl font-medium text-foreground md:text-[2rem] md:leading-[1.15]">
                 Want components built for your product?
               </h2>
               <p className="mx-auto mt-5 max-w-md text-base leading-7 text-muted-foreground">
-                Custom motion components and frontend systems, built to spec. Book a
-                call and let's talk it through.
+                Custom motion components and frontend systems, built to spec.
+                Book a call and let's talk it through.
               </p>
             </div>
 

--- a/components/app/work-cta.tsx
+++ b/components/app/work-cta.tsx
@@ -7,25 +7,25 @@ export function WorkCta() {
   return (
     <section className="px-4 pb-24">
       <div className="mx-auto max-w-7xl">
-        <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-[#0a0a0a] px-8 py-16 md:px-16 md:py-20">
-          {/* concentric-ring depth, monochrome */}
+        <div className="relative overflow-hidden rounded-[28px] border border-border bg-card px-8 py-16 md:px-16 md:py-20">
+          {/* concentric-ring depth, theme-derived */}
           <div
             aria-hidden
             className="pointer-events-none absolute -top-32 -right-28 hidden md:block"
           >
-            <div className="size-[460px] rounded-full border border-white/[0.06]">
-              <div className="absolute inset-14 rounded-full border border-white/[0.05]">
-                <div className="absolute inset-14 rounded-full border border-white/[0.04]" />
+            <div className="size-[460px] rounded-full border border-foreground/[0.06]">
+              <div className="absolute inset-14 rounded-full border border-foreground/[0.05]">
+                <div className="absolute inset-14 rounded-full border border-foreground/[0.04]" />
               </div>
             </div>
           </div>
 
           <div className="relative flex flex-col items-start gap-10 md:flex-row md:items-end md:justify-between">
             <div className="max-w-xl">
-              <h2 className="font-pixel text-2xl font-medium text-white md:text-[2rem] md:leading-[1.15]">
+              <h2 className="font-pixel text-2xl font-medium text-foreground md:text-[2rem] md:leading-[1.15]">
                 Want components built for your product?
               </h2>
-              <p className="mt-5 max-w-md text-base leading-7 text-white/55">
+              <p className="mt-5 max-w-md text-base leading-7 text-muted-foreground">
                 Custom motion components and frontend systems, built to spec. Book a
                 call and let's talk it through.
               </p>
@@ -35,7 +35,7 @@ export function WorkCta() {
               href={CAL_URL}
               target="_blank"
               rel="noreferrer noopener"
-              className="group inline-flex shrink-0 items-center gap-2 rounded-full bg-white px-7 py-3.5 text-sm font-semibold text-black transition-colors hover:bg-white/90"
+              className="group inline-flex shrink-0 items-center gap-2 rounded-full bg-primary px-7 py-3.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
             >
               Book a call
               <ArrowUpRight className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />

--- a/components/app/work-cta.tsx
+++ b/components/app/work-cta.tsx
@@ -7,7 +7,7 @@ export function WorkCta() {
   return (
     <section className="px-4 pb-24">
       <div className="mx-auto max-w-7xl">
-        <div className="relative overflow-hidden rounded-[28px] bg-card px-8 py-20 shadow-[inset_0_1px_1px_rgba(255,255,255,0.06),inset_0_-24px_48px_-24px_rgba(0,0,0,0.28)] md:px-16 md:py-24">
+        <div className="relative overflow-hidden rounded-[28px] bg-card px-8 py-20 shadow-[inset_0_1px_0_rgba(255,255,255,0.03),inset_0_-30px_44px_-32px_rgba(0,0,0,0.12)] md:px-16 md:py-24">
           <div className="relative flex flex-col items-center gap-8 text-center">
             <div className="max-w-xl">
               <h2 className="font-pixel text-2xl font-medium text-foreground md:text-[2rem] md:leading-[1.15]">

--- a/components/app/work-cta.tsx
+++ b/components/app/work-cta.tsx
@@ -7,7 +7,7 @@ export function WorkCta() {
   return (
     <section className="px-4 pb-24">
       <div className="mx-auto max-w-7xl">
-        <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-[#0a0a0a] px-8 py-16 shadow-2xl md:px-16 md:py-20">
+        <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-[#0a0a0a] px-8 py-16 md:px-16 md:py-20">
           {/* concentric-ring depth, monochrome */}
           <div
             aria-hidden
@@ -22,10 +22,7 @@ export function WorkCta() {
 
           <div className="relative flex flex-col items-start gap-10 md:flex-row md:items-end md:justify-between">
             <div className="max-w-xl">
-              <p className="text-xs font-medium uppercase tracking-[0.22em] text-white/40">
-                Work with me
-              </p>
-              <h2 className="mt-5 text-3xl font-semibold tracking-tight text-white md:text-[2.6rem] md:leading-[1.05]">
+              <h2 className="font-pixel text-2xl font-medium text-white md:text-[2rem] md:leading-[1.15]">
                 Want components built for your product?
               </h2>
               <p className="mt-5 max-w-md text-base leading-7 text-white/55">
@@ -38,7 +35,7 @@ export function WorkCta() {
               href={CAL_URL}
               target="_blank"
               rel="noreferrer noopener"
-              className="group inline-flex shrink-0 items-center gap-2 rounded-full bg-white px-7 py-3.5 text-sm font-semibold text-black shadow-lg transition-colors hover:bg-white/90"
+              className="group inline-flex shrink-0 items-center gap-2 rounded-full bg-white px-7 py-3.5 text-sm font-semibold text-black transition-colors hover:bg-white/90"
             >
               Book a call
               <ArrowUpRight className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />

--- a/components/app/work-cta.tsx
+++ b/components/app/work-cta.tsx
@@ -5,27 +5,45 @@ const CAL_URL = "https://cal.com/saurra3h/30min";
 
 export function WorkCta() {
   return (
-    <section className="px-4 pb-16">
+    <section className="px-4 pb-24">
       <div className="mx-auto max-w-7xl">
-        <div className="flex flex-col items-start gap-6 rounded-2xl border border-border bg-card px-8 py-12 md:flex-row md:items-center md:justify-between md:px-12">
-          <div className="max-w-xl">
-            <h2 className="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
-              Want components built for your product?
-            </h2>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground md:text-base">
-              Custom motion components and frontend systems, built to spec. Book a
-              call to talk it through.
-            </p>
-          </div>
-          <PressLink
-            href={CAL_URL}
-            target="_blank"
-            rel="noreferrer noopener"
-            className="inline-flex shrink-0 items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground"
+        <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-[#0a0a0a] px-8 py-16 shadow-2xl md:px-16 md:py-20">
+          {/* concentric-ring depth, monochrome */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -top-32 -right-28 hidden md:block"
           >
-            Book a call
-            <ArrowUpRight className="h-4 w-4" />
-          </PressLink>
+            <div className="size-[460px] rounded-full border border-white/[0.06]">
+              <div className="absolute inset-14 rounded-full border border-white/[0.05]">
+                <div className="absolute inset-14 rounded-full border border-white/[0.04]" />
+              </div>
+            </div>
+          </div>
+
+          <div className="relative flex flex-col items-start gap-10 md:flex-row md:items-end md:justify-between">
+            <div className="max-w-xl">
+              <p className="text-xs font-medium uppercase tracking-[0.22em] text-white/40">
+                Work with me
+              </p>
+              <h2 className="mt-5 text-3xl font-semibold tracking-tight text-white md:text-[2.6rem] md:leading-[1.05]">
+                Want components built for your product?
+              </h2>
+              <p className="mt-5 max-w-md text-base leading-7 text-white/55">
+                Custom motion components and frontend systems, built to spec. Book a
+                call and let's talk it through.
+              </p>
+            </div>
+
+            <PressLink
+              href={CAL_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="group inline-flex shrink-0 items-center gap-2 rounded-full bg-white px-7 py-3.5 text-sm font-semibold text-black shadow-lg transition-colors hover:bg-white/90"
+            >
+              Book a call
+              <ArrowUpRight className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+            </PressLink>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
A monochrome CTA band before the homepage footer to monetize the traffic (100k views, 350+ stars).

## What
- `WorkCta` section: **"Want components built for your product?"** + "Custom motion components and frontend systems, built to spec. Book a call to talk it through." → `Book a call` (cal.com).
- Service-framed (offering paid project work), not job-seeking — no "open to work / available / hire me" language.
- Monochrome, matches site; `PressLink` for the button.

Pro section ships next week; this is the call CTA before that.