### PR TITLE
feat: track registry installs and copy events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ next-env.d.ts
 
 # editor / local agent config
 .claude/
+.env

--- a/components/app/code-block.tsx
+++ b/components/app/code-block.tsx
@@ -86,11 +86,11 @@ export async function CodeBlock({
             </span>
           </div>
 
-          <CopyButton text={code} />
+          <CopyButton text={code} eventLabel={filename ?? lang} />
         </div>
       ) : (
         <div className="absolute right-3 top-3 z-10">
-          <CopyButton text={code} />
+          <CopyButton text={code} eventLabel={filename ?? lang} />
         </div>
       )}
 

--- a/components/app/copy-button.tsx
+++ b/components/app/copy-button.tsx
@@ -4,14 +4,21 @@ import { Check, Copy } from "lucide-react";
 import { useState } from "react";
 import { ActionSwapCascadeIcon } from "@/components/motion/action-swap-cascade";
 import { Button } from "@/components/motion/button";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 export function CopyButton({
   text,
   className,
+  eventName = "copy_code",
+  eventLabel,
 }: {
   text: string;
   className?: string;
+  /** GA4 event name. Defaults to "copy_code". */
+  eventName?: string;
+  /** What was copied (component slug, filename, install command). */
+  eventLabel?: string;
 }) {
   const [copied, setCopied] = useState(false);
 
@@ -24,6 +31,7 @@ export function CopyButton({
         await navigator.clipboard.writeText(text);
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
+        trackEvent(eventName, { label: eventLabel, chars: text.length });
       }}
       aria-label={copied ? "Copied" : "Copy code"}
       className={cn(

--- a/components/app/install-command.tsx
+++ b/components/app/install-command.tsx
@@ -76,7 +76,11 @@ export function InstallCommand({
           </TabsList>
         </Tabs>
         <div className="ml-auto shrink-0">
-          <CopyButton text={copyValue} />
+          <CopyButton
+            text={copyValue}
+            eventName="copy_install_command"
+            eventLabel={currentSlug}
+          />
         </div>
       </div>
 

--- a/components/app/playground/code-panel.tsx
+++ b/components/app/playground/code-panel.tsx
@@ -51,7 +51,7 @@ export function CodePanel({
       )}
     >
       <div className="absolute right-3 top-3 z-10">
-        <CopyButton text={code} />
+        <CopyButton text={code} eventName="copy_playground" />
       </div>
 
       {html ? (

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,20 @@
+type GtagParams = Record<string, string | number | boolean | undefined>;
+
+declare global {
+  interface Window {
+    gtag?: (
+      command: "event" | "config" | "js",
+      action: string,
+      params?: GtagParams,
+    ) => void;
+  }
+}
+
+/**
+ * Fire a client-side GA4 event. No-ops when gtag is absent (analytics id
+ * unset, ad-blocker, SSR), so callers never need to guard.
+ */
+export function trackEvent(name: string, params?: GtagParams) {
+  if (typeof window === "undefined") return;
+  window.gtag?.("event", name, params);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,75 @@
+import { type NextFetchEvent, type NextRequest, NextResponse } from "next/server";
+
+/**
+ * Registry installs happen via the shadcn CLI fetching `/r/{slug}.json`. That
+ * request is headless (no browser, no gtag), and the route is force-static so
+ * no per-request handler runs. Middleware runs on every request even for
+ * static assets, so we tag installs here and report them to GA4 server-side
+ * via the Measurement Protocol, keeping the route on the CDN.
+ */
+export const config = { matcher: "/r/:path*" };
+
+const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
+const GA_SECRET = process.env.GA_API_SECRET;
+
+export function middleware(req: NextRequest, event: NextFetchEvent) {
+  const pass = NextResponse.next();
+
+  const { pathname } = req.nextUrl;
+  // Only the shadcn item endpoints (`/r/<slug>.json`) are real installs.
+  // Skip the catalog and the raw-source / non-json sub-paths.
+  if (
+    !GA_ID ||
+    !GA_SECRET ||
+    !pathname.endsWith(".json") ||
+    pathname === "/r/registry.json"
+  ) {
+    return pass;
+  }
+
+  const slug = pathname.slice("/r/".length, -".json".length);
+  const ua = req.headers.get("user-agent") ?? "";
+
+  event.waitUntil(reportInstall(slug, ua, req));
+  return pass;
+}
+
+async function reportInstall(slug: string, ua: string, req: NextRequest) {
+  try {
+    const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "";
+    const clientId = await stableId(`${ip}|${ua}`);
+
+    await fetch(
+      `https://www.google-analytics.com/mp/collect?measurement_id=${GA_ID}&api_secret=${GA_SECRET}`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          client_id: clientId,
+          events: [
+            {
+              name: "registry_install",
+              params: {
+                slug,
+                user_agent: ua.slice(0, 100),
+                // shadcn CLI runs on node; helps segment installs from bots/browsers.
+                is_cli: /node|shadcn|bun|undici/i.test(ua),
+              },
+            },
+          ],
+        }),
+      },
+    );
+  } catch {
+    // Analytics is best-effort; never fail the install fetch.
+  }
+}
+
+// GA4 needs a stable-ish client_id. Hash ip+ua so repeat installs from one
+// machine group, without storing anything or setting a cookie.
+async function stableId(seed: string) {
+  const data = new TextEncoder().encode(seed || "anon");
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest).slice(0, 8))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}


### PR DESCRIPTION
## What

GA4 analytics for two actions: **copy-to-clipboard** and **registry installs**.

## Copy events (client-side)

- `lib/analytics.ts` — `trackEvent()` helper + `gtag` window types. No-ops when GA absent (id unset, ad-blocker, SSR), so callers never guard.
- `CopyButton` fires a labeled GA4 event with char count.
- Wired:
  - install command → `copy_install_command` (label = slug)
  - code blocks → `copy_code` (label = filename/lang)
  - playground → `copy_playground`

## Registry installs (server-side)

The real install is `npx shadcn add @beui/x`, which is a headless CLI fetch of `/r/{slug}.json` — no browser, no gtag, and the route is `force-static` (no per-request handler).

- `middleware.ts` runs on `/r/*`, tags `.json` item fetches, and reports them to GA4 via the **Measurement Protocol** (server-side) using `event.waitUntil` so install latency is unaffected. Route stays on the CDN.
- `is_cli` param flags node/bun/shadcn UAs to segment installs from browser/bot noise.
- Stable `client_id` = SHA-256(ip + ua); no cookie, no storage.

## Setup

Requires env var `GA_API_SECRET` (GA4 → Data Streams → Measurement Protocol API secrets). Already added to prod. Without it the middleware no-ops safely.

## Events in GA4

Reports → Engagement → Events: `registry_install`, `copy_install_command`, `copy_code`, `copy_playground`.

## Verification

- `bun run typecheck` clean
- `bun run lint` clean (one pre-existing warning in `install-command.tsx`, unrelated)