### PR TITLE
feat: stamp component source with docs-page signature

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -20,6 +20,7 @@ import { NewBadge } from "@/components/app/new-badge";
 import { ComponentCard } from "@/components/app/component-card";
 import { JsonLd } from "@/components/app/json-ld";
 import { getPreview, previews } from "@/components/previews";
+import { pageUrlFor, withSignature } from "@/lib/signature";
 import { readSourceFile } from "@/lib/source-files";
 import {
   breadcrumbJsonLd,
@@ -169,7 +170,7 @@ export default async function ComponentPage({
       {comp.examples?.length ? (
         <div className="mt-10 flex flex-col gap-12">
           {comp.examples.map((ex) => (
-            <ExampleBlock key={ex.slug} category={cat.slug} example={ex} />
+            <ExampleBlock key={ex.slug} category={cat.slug} pageSlug={comp.slug} example={ex} />
           ))}
         </div>
       ) : (
@@ -215,9 +216,11 @@ export default async function ComponentPage({
 
 async function ExampleBlock({
   category,
+  pageSlug,
   example,
 }: {
   category: string;
+  pageSlug: string;
   example: ComponentExample;
 }) {
   const Preview = previews[example.previewKey];
@@ -255,7 +258,10 @@ async function ExampleBlock({
           <CodeBlock code={usage} filename={example.previewFile} />
         </TabsContent>
         <TabsContent value="source" className="mt-4">
-          <CodeBlock code={source} filename={example.file} />
+          <CodeBlock
+            code={withSignature(source, example.file, pageUrlFor(category, pageSlug))}
+            filename={example.file}
+          />
         </TabsContent>
       </Tabs>
       {installSlug ? (
@@ -300,7 +306,10 @@ async function DefaultTabs({
         <CodeBlock code={usage} filename={previewFile} />
       </TabsContent>
       <TabsContent value="source" className="mt-4">
-        <CodeBlock code={source} filename={file} />
+        <CodeBlock
+          code={withSignature(source, file, pageUrlFor(category, slug))}
+          filename={file}
+        />
       </TabsContent>
     </Tabs>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ import { KeyboardShortcuts } from "@/components/app/keyboard-shortcuts";
 import { JsonLd } from "@/components/app/json-ld";
 import { getGithubStarCount } from "@/lib/github";
 import { AUTHOR, SITE_DESCRIPTION, SITE_NAME, siteJsonLd } from "@/lib/seo";
+import { SITE_URL } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
@@ -22,7 +23,7 @@ const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
 const pixel = GeistPixelSquare;
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://beui.dev"),
+  metadataBase: new URL(SITE_URL),
   applicationName: SITE_NAME,
   title: {
     default: "beUI · Production-ready motion components for React & Next.js",

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from "next";
-
-const SITE = "https://beui.dev";
+import { SITE_URL as SITE } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,6 @@
 import type { MetadataRoute } from "next";
 import { allComponents, registry } from "@/lib/registry";
-
-const SITE = "https://beui.dev";
+import { SITE_URL as SITE } from "@/lib/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();

--- a/lib/registry-server.ts
+++ b/lib/registry-server.ts
@@ -1,7 +1,7 @@
 import { allComponents, findCategory, registry } from "@/lib/registry";
+import { pageUrlFor, withSignature } from "@/lib/signature";
+import { SITE_URL } from "@/lib/site";
 import { readOptionalSourceFile, readSourceFile, resolveSourceImport, type SourceFile } from "@/lib/source-files";
-
-const SITE_URL = "https://beui.dev";
 
 export type RegistryFile = {
   path: string;
@@ -250,7 +250,8 @@ export async function buildEntry(categorySlug: string, slug: string): Promise<Re
   const previewSource = await readOptionalSourceFile(previewPath);
   const previewGraph = previewSource ? await collectSourceGraph([previewPath]) : null;
   const componentFileSet = new Set(requiredFiles);
-  const files = mergeRegistryFiles(componentGraph.files, previewGraph?.files ?? [], componentFileSet, previewPath);
+  const pageUrl = pageUrlFor(categorySlug, comp.pageSlug);
+  const files = mergeRegistryFiles(componentGraph.files, previewGraph?.files ?? [], componentFileSet, previewPath, pageUrl);
 
   return {
     slug: comp.slug,
@@ -272,6 +273,7 @@ function mergeRegistryFiles(
   previewFiles: SourceFile[],
   componentFileSet: Set<string>,
   previewPath: string,
+  pageUrl: string,
 ) {
   const seen = new Set<string>();
   const files: RegistryFile[] = [];
@@ -279,10 +281,11 @@ function mergeRegistryFiles(
   for (const file of [...componentFiles, ...previewFiles]) {
     if (seen.has(file.path)) continue;
     seen.add(file.path);
+    const isComponent = file.path !== previewPath && componentFileSet.has(file.path);
     files.push({
       path: file.path,
-      type: file.path === previewPath ? "preview" : componentFileSet.has(file.path) ? "component" : "util",
-      content: file.content,
+      type: file.path === previewPath ? "preview" : isComponent ? "component" : "util",
+      content: isComponent ? withSignature(file.content, file.path, pageUrl) : file.content,
     });
   }
 
@@ -299,6 +302,8 @@ export async function buildShadcnItem(
 
   const graph = await collectSourceGraph([comp.file, ...(comp.extraFiles ?? [])]);
   const dependencies = graph.external.filter((dep) => !SHADCN_DEP_SKIP.has(dep));
+  const componentFileSet = new Set([comp.file, ...(comp.extraFiles ?? [])]);
+  const pageUrl = pageUrlFor(comp.categorySlug, comp.pageSlug);
 
   return {
     $schema: "https://ui.shadcn.com/schema/registry-item.json",
@@ -310,7 +315,13 @@ export async function buildShadcnItem(
     dependencies,
     registryDependencies: [],
     files: uniqueByPath(
-      graph.files.map((file) => shadcnFile(file.path, includeContent ? file.content : undefined)),
+      graph.files.map((file) => {
+        if (!includeContent) return shadcnFile(file.path);
+        const content = componentFileSet.has(file.path)
+          ? withSignature(file.content, file.path, pageUrl)
+          : file.content;
+        return shadcnFile(file.path, content);
+      }),
     ),
   };
 }

--- a/lib/signature.ts
+++ b/lib/signature.ts
@@ -1,0 +1,29 @@
+import { SITE_URL } from "@/lib/site";
+
+const CODE_EXT = /\.(tsx?|jsx?|css|mjs|cjs)$/;
+// "use client" / "use server" must stay the first statement; insert the
+// banner right after the directive when present, otherwise at the very top.
+const DIRECTIVE_RE = /^\s*(["']use (?:client|server)["'];?[^\n]*\n)/;
+
+/** Component docs page URL, e.g. https://beui.dev/components/motion/tabs */
+export function pageUrlFor(categorySlug: string, pageSlug: string) {
+  return `${SITE_URL}/components/${categorySlug}/${pageSlug}`;
+}
+
+/**
+ * Prepend a one-line provenance comment pointing at the component's docs page.
+ * Applied to component source files on copy and on registry install so the
+ * origin travels with the code. No-ops for non-code files (json, etc.).
+ */
+export function withSignature(content: string, path: string, pageUrl: string) {
+  if (!CODE_EXT.test(path)) return content;
+  const url = pageUrl.replace(/^https?:\/\//, "");
+  const banner = path.endsWith(".css") ? `/* ${url} */` : `// ${url}`;
+
+  const directive = content.match(DIRECTIVE_RE);
+  if (directive) {
+    const end = directive[0].length;
+    return `${content.slice(0, end)}${banner}\n${content.slice(end)}`;
+  }
+  return `${banner}\n${content}`;
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,4 @@
+/** Canonical site origin. Override per environment via NEXT_PUBLIC_SITE_URL. */
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://beui.dev"
+).replace(/\/$/, "");


### PR DESCRIPTION
## What

Adds a one-line provenance comment to component source — both when copied from the docs and when installed via the registry — so the origin travels with the code:

```tsx
"use client";
// beui.dev/components/motion/tabs
import ...
```

Plus centralizes the site domain behind an env var.

## Signature

- `lib/signature.ts`
  - `withSignature(content, path, pageUrl)` — inserts the banner after any `use client`/`use server` directive, else at the top. Picks `//` vs `/* */` by extension. No-ops non-code files (json, etc.).
  - `pageUrlFor(category, slug)` — the docs page URL.
- Applied to the **component's own source files only** (not shared util/lib deps):
  - **Install** — `buildEntry` + `buildShadcnItem` in `lib/registry-server.ts`
  - **Copy** — source tab on the component page (`ExampleBlock` + `DefaultTabs`). Usage/preview tabs unchanged, matching what installs ship.

## Domain from env

- `lib/site.ts` — `SITE_URL = NEXT_PUBLIC_SITE_URL ?? "https://beui.dev"` (trailing slash stripped).
- Reused in `registry-server`, `robots`, `sitemap`, and layout `metadataBase` (previously hardcoded `https://beui.dev` in each).
- `NEXT_PUBLIC_SITE_URL` is optional; the fallback keeps prod working. Set it for non-prod envs to self-reference.

## Verification

- `bun run typecheck` clean
- `bun run check:registry` validates 35 components
- `bun run lint` clean (one pre-existing warning in `install-command.tsx`, unrelated)