### PR TITLE
feat: adopt motion-toolkit tagline and Framer Motion branding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-beUI is a React, TypeScript, Motion and Tailwind CSS component library.
+beUI is a React, TypeScript, Framer Motion and Tailwind CSS component library.
 
 ## Before You Open a PR
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">beUI v2</h1>
 
 <p align="center">
-  Motion components for React. Copy the source, own the code.
+  The motion toolkit for React & Next.js. Copy the source, own the code.
 </p>
 
 <p align="center">

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -17,7 +17,7 @@ export async function GET(request: Request) {
   const description =
     component?.description ??
     category?.description ??
-    "Production-ready motion components for React. Copy the source, own the code.";
+    "The motion toolkit for React & Next.js. Built on Framer Motion and Tailwind.";
   const label = component
     ? "Component"
     : category

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   applicationName: SITE_NAME,
   title: {
-    default: "beUI · Production-ready motion components for React & Next.js",
+    default: "beUI · The motion toolkit for React & Next.js",
     template: "%s · beUI",
   },
   description: SITE_DESCRIPTION,
@@ -44,7 +44,7 @@ export const metadata: Metadata = {
     },
   },
   openGraph: {
-    title: "beUI · Production-ready motion components for React & Next.js",
+    title: "beUI · The motion toolkit for React & Next.js",
     description: SITE_DESCRIPTION,
     type: "website",
     url: "/",
@@ -55,13 +55,13 @@ export const metadata: Metadata = {
         url: "/api/og",
         width: 1200,
         height: 630,
-        alt: "beUI · Production-ready motion components for React & Next.js",
+        alt: "beUI · The motion toolkit for React & Next.js",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "beUI · Production-ready motion components for React & Next.js",
+    title: "beUI · The motion toolkit for React & Next.js",
     description: SITE_DESCRIPTION,
     images: ["/api/og"],
   },

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "next/og";
 import { OG_SIZE, ogImage } from "@/lib/og";
 
 export const runtime = "edge";
-export const alt = "beUI · Motion components for React";
+export const alt = "beUI · The motion toolkit for React & Next.js";
 export const size = OG_SIZE;
 export const contentType = "image/png";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,7 +41,7 @@ export default function Home() {
 
       <section className="mx-auto max-w-2xl px-4 pb-24">
         <p className="mb-5 text-center text-sm text-muted-foreground">
-          Built on Motion. Distributed via shadcn.
+          Built on Framer Motion. Distributed via shadcn.
         </p>
         <InstallCommand />
       </section>

--- a/components/app/hero.tsx
+++ b/components/app/hero.tsx
@@ -42,7 +42,7 @@ export function Hero() {
         text={HEADLINE}
         delay={START}
         stagger={STAGGER}
-        className="mx-auto font-pixel text-5xl font-medium leading-[0.9] text-foreground sm:text-6xl md:text-7xl"
+        className="mx-auto font-pixel text-6xl font-medium leading-[0.9] text-foreground sm:text-6xl md:text-7xl"
       />
 
       <motion.p
@@ -51,7 +51,8 @@ export function Hero() {
         transition={{ duration: 0.5, ease: EASE_OUT, delay: subDelay }}
         className="mx-auto mt-6 max-w-md text-pretty text-base leading-7 text-muted-foreground"
       >
-        Copy-paste animated components built on Framer Motion and Tailwind. Free and open source.
+        Copy-paste animated components built on Framer Motion and Tailwind. Free
+        and open source.
       </motion.p>
 
       <motion.div

--- a/components/app/hero.tsx
+++ b/components/app/hero.tsx
@@ -7,7 +7,7 @@ import { GithubIcon } from "@/components/app/icons";
 import { PressLink } from "@/components/app/press-link";
 import { TextReveal } from "@/components/motion/text-reveal";
 
-const HEADLINE = ["Motion", "components", "for React."];
+const HEADLINE = ["The motion toolkit", "for React", "& Next.js"];
 const HEADLINE_WORDS = HEADLINE.reduce((n, l) => n + l.split(" ").length, 0);
 const STAGGER = 0.09;
 const START = 0.12;
@@ -49,9 +49,9 @@ export function Hero() {
         initial={{ opacity: 0, y: 10, filter: "blur(6px)" }}
         animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
         transition={{ duration: 0.5, ease: EASE_OUT, delay: subDelay }}
-        className="mx-auto mt-6 max-w-sm text-pretty text-base leading-7 text-muted-foreground"
+        className="mx-auto mt-6 max-w-md text-pretty text-base leading-7 text-muted-foreground"
       >
-        Copy-ready components with clean motion.
+        Copy-paste animated components built on Framer Motion and Tailwind. Free and open source.
       </motion.p>
 
       <motion.div

--- a/components/app/hero.tsx
+++ b/components/app/hero.tsx
@@ -42,7 +42,7 @@ export function Hero() {
         text={HEADLINE}
         delay={START}
         stagger={STAGGER}
-        className="mx-auto font-pixel text-6xl font-medium leading-[0.9] text-foreground sm:text-6xl md:text-7xl"
+        className="mx-auto font-pixel text-5xl font-medium leading-[0.9] text-foreground sm:text-6xl md:text-7xl"
       />
 
       <motion.p

--- a/components/app/hero.tsx
+++ b/components/app/hero.tsx
@@ -7,7 +7,7 @@ import { GithubIcon } from "@/components/app/icons";
 import { PressLink } from "@/components/app/press-link";
 import { TextReveal } from "@/components/motion/text-reveal";
 
-const HEADLINE = ["The motion toolkit", "for React", "& Next.js"];
+const HEADLINE = ["The motion toolkit", "for React & Next.js"];
 const HEADLINE_WORDS = HEADLINE.reduce((n, l) => n + l.split(" ").length, 0);
 const STAGGER = 0.09;
 const START = 0.12;

--- a/components/app/site-footer.tsx
+++ b/components/app/site-footer.tsx
@@ -15,7 +15,7 @@ export function SiteFooter() {
           <div className="col-span-2 md:col-span-1">
             <p className="font-pixel text-lg font-medium text-foreground">beUI</p>
             <p className="mt-2 max-w-[220px] text-sm leading-6 text-muted-foreground">
-              Motion components for React. Copy-paste via shadcn registry.
+              The motion toolkit for React & Next.js. Copy-paste via shadcn registry.
             </p>
             <p className="mt-5 text-xs text-muted-foreground">
               Created by{" "}

--- a/lib/og.tsx
+++ b/lib/og.tsx
@@ -20,7 +20,7 @@ type OgOptions = {
 // Satori-safe styles only (flexbox; every multi-child node sets display:flex).
 export function ogImage({
   title = "beUI",
-  description = "Production-ready motion components for React. Copy the source, own the code.",
+  description = "The motion toolkit for React & Next.js. Built on Framer Motion and Tailwind.",
   label = "Motion components",
   command = "npx shadcn add @beui/...",
 }: OgOptions = {}): ReactElement {

--- a/lib/registry-server.ts
+++ b/lib/registry-server.ts
@@ -347,7 +347,7 @@ export async function buildShadcnRegistry(): Promise<ShadcnRegistry> {
 export async function buildIndex() {
   return {
     name: "beUI",
-    description: "Bespoke motion components for React.",
+    description: "The motion toolkit for React and Next.js.",
     site: SITE_URL,
     endpoints: {
       llms: `${SITE_URL}/llms.txt`,

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -5,11 +5,13 @@ import {
   allComponents,
   registry,
 } from "@/lib/registry";
+import { SITE_URL } from "@/lib/site";
 
-export const SITE = "https://beui.dev";
+export const SITE = SITE_URL;
 export const SITE_NAME = "beUI";
+export const SITE_TAGLINE = "The motion toolkit for React & Next.js";
 export const SITE_DESCRIPTION =
-  "Free, open-source, shadcn-compatible motion components for React and Next.js. Built on Motion and Tailwind CSS. Copy-paste the source or install with the shadcn CLI.";
+  "The motion toolkit for React and Next.js. Free, open-source, shadcn-compatible components built on Framer Motion and Tailwind CSS. Copy-paste the source or install with the shadcn CLI.";
 export const AUTHOR = "Saurabh";
 
 const abs = (path: string) => (path.startsWith("http") ? path : `${SITE}${path}`);
@@ -88,6 +90,7 @@ export function siteJsonLd(): JsonLdSchema[] {
       "@id": `${SITE}/#org`,
       name: SITE_NAME,
       url: SITE,
+      slogan: SITE_TAGLINE,
       logo: abs("/beui-mark.png"),
     },
     {
@@ -95,6 +98,8 @@ export function siteJsonLd(): JsonLdSchema[] {
       "@type": "SoftwareApplication",
       "@id": `${SITE}/#app`,
       name: SITE_NAME,
+      alternateName: "beUI motion toolkit",
+      slogan: SITE_TAGLINE,
       description: SITE_DESCRIPTION,
       url: SITE,
       applicationCategory: "DeveloperApplication",


### PR DESCRIPTION
## What

Locks in one positioning line and makes the library name consistent.

**Tagline:** `The motion toolkit for React & Next.js`
**Library name:** referred to as **Framer Motion** in user-facing copy (was "Motion").

## Changes

- `lib/seo.ts` — new `SITE_TAGLINE`; `SITE_DESCRIPTION` rewritten ("built on Framer Motion and Tailwind"); `SITE` now points at the env-driven `SITE_URL`; `Organization.slogan` + `SoftwareApplication.slogan`/`alternateName` added to JSON-LD.
- `app/layout.tsx` — `title.default`, OG, Twitter, OG-alt all use the tagline.
- `components/app/hero.tsx` — H1 = tagline; subhead = "Copy-paste animated components built on Framer Motion and Tailwind. Free and open source."
- `app/page.tsx` — "Built on Framer Motion."
- `app/opengraph-image.tsx`, `lib/og.tsx`, `app/api/og/route.tsx` — social card copy.
- `components/app/site-footer.tsx`, `README.md`, `CONTRIBUTING.md` — tagline / Framer Motion.
- `lib/registry-server.ts` — registry index + `llms.txt` header description = tagline.

## Verification

- `bun run typecheck` clean
- `bun run lint` clean (one pre-existing warning, unrelated)
- grep confirms no remaining "built on Motion" library refs

## Not in this PR (follow-ups discussed)

SEO Phase 2: per-component content depth (overview / when-to-use / props table / accessibility), FAQ schema, sitemap `lastModified` from file mtime.