### PR TITLE
feat: document MCP server, expand landing, drop stale new badges

### DIFF
--- a/app/docs/ai-agents/page.tsx
+++ b/app/docs/ai-agents/page.tsx
@@ -6,12 +6,12 @@ import { CodeBlock } from "@/components/app/code-block";
 export const metadata: Metadata = {
   title: "AI Agents",
   description:
-    "Endpoints for coding agents to consume beUI components programmatically: llms.txt, JSON registry, and raw source.",
+    "Connect the beUI MCP server, or use the agent-friendly endpoints (llms.txt, JSON registry, raw source) to consume components programmatically.",
   alternates: { canonical: "/docs/ai-agents" },
   openGraph: {
     title: "AI Agents · beUI",
     description:
-      "Endpoints for coding agents to consume beUI components programmatically: llms.txt, JSON registry, and raw source.",
+      "Connect the beUI MCP server, or use the agent-friendly endpoints (llms.txt, JSON registry, raw source) to consume components programmatically.",
     url: "/docs/ai-agents",
     type: "article",
     siteName: "beUI",
@@ -32,6 +32,26 @@ const ENDPOINTS: { label: string; url: string; desc: string }[] = [
   { label: "shadcn item", url: "/r/{slug}.json", desc: "Install item with inline file content and shadcn semantic color classes." },
   { label: "Raw source", url: "/r/{slug}/raw", desc: "Plain text .tsx ready to drop in." },
 ];
+
+const MCP_URL = "https://mcp.beui.dev/mcp";
+
+const MCP_CLI_SNIPPET = `# Claude Code
+claude mcp add --transport http beui https://mcp.beui.dev/mcp
+
+# Codex
+codex mcp add beui --url https://mcp.beui.dev/mcp
+
+# Amp
+amp mcp add beui https://mcp.beui.dev/mcp`;
+
+const MCP_MANUAL_SNIPPET = `{
+  "mcpServers": {
+    "beui": {
+      "type": "http",
+      "url": "https://mcp.beui.dev/mcp"
+    }
+  }
+}`;
 
 const FETCH_SNIPPET = `// 1. Discover what exists
 const idx = await fetch('https://beui.dev/r').then((r) => r.json());
@@ -76,7 +96,25 @@ export default function AIAgentsPage() {
       <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Intro</p>
       <h1 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">For AI agents</h1>
       <p className="mt-3 text-muted-foreground">
-        beUI exposes a static, agent-friendly surface. Coding agents (Cursor, Claude, GPT, custom MCP) can list components, fetch source with all deps, and drop files into the user&apos;s project with one HTTP call.
+        beUI exposes a static, agent-friendly surface. Connect the MCP server below, or hit the raw endpoints directly. Coding agents (Claude, Codex, Cursor, Amp) can list components, fetch source with all deps, and drop files into the user&apos;s project.
+      </p>
+
+      <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">MCP server</h2>
+      <p className="mt-2 text-muted-foreground">
+        The fastest path: connect the beUI MCP server and your agent can list, search and install components directly. Hosted at{" "}
+        <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs text-foreground">{MCP_URL}</code>.
+      </p>
+      <div className="mt-4">
+        <CodeBlock code={MCP_CLI_SNIPPET} lang="bash" filename="terminal" />
+      </div>
+      <p className="mt-4 text-muted-foreground">
+        Any other client: add it manually to your MCP config.
+      </p>
+      <div className="mt-4">
+        <CodeBlock code={MCP_MANUAL_SNIPPET} lang="json" filename="mcp.json" />
+      </div>
+      <p className="mt-4 text-sm text-muted-foreground">
+        Tools: <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">list_components</code>, <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">search_components</code>, <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">get_component</code>, <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">get_install_command</code>.
       </p>
 
       <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">Endpoints</h2>
@@ -127,10 +165,6 @@ export default function AIAgentsPage() {
         <CodeBlock code={ENTRY_SHAPE} lang="json" filename="r/swap.json" />
       </div>
 
-      <h2 className="mt-10 text-xl font-semibold tracking-tight text-foreground">Caching</h2>
-      <p className="mt-2 text-muted-foreground">
-        All routes are pre-rendered at build, served with <code className="rounded bg-foreground/5 px-1.5 py-0.5 font-mono text-xs">cache-control: public, max-age=300, s-maxage=3600</code>.
-      </p>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,20 @@ const CURATED: { category: string; slug: string }[] = [
   { category: "blocks", slug: "command-palette" },
   { category: "blocks", slug: "expandable-action-bar" },
   { category: "blocks", slug: "expandable-tabs" },
+  { category: "motion", slug: "tilt-card" },
+  { category: "motion", slug: "bottom-sheet" },
+  { category: "motion", slug: "switch" },
+  { category: "motion", slug: "tooltip" },
+  { category: "motion", slug: "text-animation" },
+  { category: "motion", slug: "number" },
+  { category: "motion", slug: "bouncy-accordion" },
+  { category: "motion", slug: "range-slider" },
+  { category: "motion", slug: "theme-toggle" },
+  { category: "motion", slug: "drawer" },
+  { category: "blocks", slug: "swap" },
+  { category: "blocks", slug: "otp-input" },
+  { category: "blocks", slug: "swipeable-list" },
+  { category: "blocks", slug: "bloom-menu" },
 ];
 
 export default function Home() {

--- a/components/app/landing-component-card.tsx
+++ b/components/app/landing-component-card.tsx
@@ -33,8 +33,8 @@ export function LandingComponentCard({
           </div>
 
           <div className="pointer-events-none absolute inset-0 rounded-3xl bg-transparent backdrop-blur-0 transition-[background-color,backdrop-filter] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-card/55 group-hover/card:backdrop-blur-md group-focus-within/card:bg-card/55 group-focus-within/card:backdrop-blur-md">
-            <div className="absolute inset-x-0 bottom-0 overflow-hidden rounded-b-3xl px-4 py-3">
-              <p className="line-clamp-2 translate-y-full text-xs leading-relaxed text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-focus-within/card:translate-y-0">
+            <div className="absolute inset-x-0 bottom-0 translate-y-full px-4 py-3 transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-focus-within/card:translate-y-0">
+              <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
                 {component.description}
               </p>
             </div>

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -300,14 +300,12 @@ export const registry: CategoryEntry[] = [
         name: "Bouncy Accordion",
         description: "Single-open accordion with weighted spring layout, icon rows and reduced-motion-safe content reveals.",
         file: "components/motion/bouncy-accordion.tsx",
-        badge: "new",
       },
       {
         slug: "drawer",
         name: "Drawer",
         description: "Side panel that slides in from the left or right with a spring, backdrop blur, body scroll lock and esc-to-close.",
         file: "components/motion/drawer.tsx",
-        badge: "new",
       },
       {
         slug: "scroll-animation",
@@ -320,7 +318,6 @@ export const registry: CategoryEntry[] = [
           "components/motion/scroll-to.tsx",
           "components/motion/scroll-reveal.tsx",
         ],
-        badge: "new",
         keywords: [
           "smooth scroll",
           "lenis",
@@ -421,7 +418,6 @@ export const registry: CategoryEntry[] = [
         name: "Overflow Actions",
         description: "Connected pill rail for primary actions that springs open to reveal extra controls.",
         file: "components/motion/overflow-actions.tsx",
-        badge: "new",
       },
       {
         slug: "expandable-tabs",
@@ -440,14 +436,12 @@ export const registry: CategoryEntry[] = [
         name: "File Upload",
         description: "Drag-and-drop upload queue with progress rows, retry/remove actions and reduced-motion-safe state changes.",
         file: "components/motion/file-upload.tsx",
-        badge: "new",
       },
       {
         slug: "prediction-market",
         name: "Prediction Market",
         description: "Prediction market trade ticket with buy/sell modes, outcome prices, rolling amount entry, quick add chips and trade states.",
         file: "components/motion/prediction-market.tsx",
-        badge: "new",
       },
       {
         slug: "otp-input",
@@ -475,7 +469,6 @@ export const registry: CategoryEntry[] = [
           "components/motion/not-found/stacked.tsx",
           "components/motion/not-found/terminal.tsx",
         ],
-        badge: "new",
         examples: [
           {
             slug: "glitch",


### PR DESCRIPTION
## Changes

### Agents docs
- New **MCP server** section on `/docs/ai-agents` with CLI setup for Claude Code, Codex and Amp, plus a manual `mcp.json` config block, pointing at `https://mcp.beui.dev/mcp`. Lists the 4 tools.
- Removed the Caching section.

### Landing
- "Motion primitives" grid expanded from 10 to 24 curated components (interleaved motion + blocks), leaving the rest for "Browse all".
- **Card fix:** description was leaking before hover, and clamping broke (3rd line) on long text. Vertical padding on a `-webkit-line-clamp` element breaks the clamp — moved padding + slide onto the wrapper and kept the clamp element clean. Now: fully hidden until hover, exactly 2 lines + ellipsis when shown.

### Registry
- Removed the `new` badge from shipped components: overflow-actions, not-found (404), bouncy-accordion, drawer, scroll-animation, file-upload, prediction-market.

## Verification
- `bun run check` (typecheck + lint + registry) green; registry validates 35
- All 24 curated slugs resolve