### PR TITLE
fix: refine component interactions and surfaces

### DIFF
--- a/components/motion/bottom-sheet.tsx
+++ b/components/motion/bottom-sheet.tsx
@@ -159,7 +159,7 @@ export function BottomSheet({
             style={heightStyle}
             className={cn(
               "pointer-events-auto absolute bottom-0 left-0 right-0 mx-auto flex max-w-2xl flex-col overflow-hidden rounded-t-3xl will-change-transform",
-              "border border-border bg-card shadow-xl",
+              "border border-border bg-background shadow-xl",
               className,
             )}
             role="dialog"

--- a/components/motion/feedback-widget.tsx
+++ b/components/motion/feedback-widget.tsx
@@ -17,13 +17,16 @@ type Status = "idle" | "open" | "sending" | "sent" | "error";
 
 const SUCCESS_DURATION_MS = 1600;
 
-// Folder-open feel for the morph: a touch of overshoot, no wobble.
-const MORPH = {
-  type: "spring",
-  stiffness: 320,
-  damping: 34,
-  mass: 0.9,
-} as const;
+// The trigger grows into the panel with a slight overshoot on open, then uses
+// a calmer curve on close so dismissing feels faster and less prominent.
+const MORPH_OPEN_EASE = [0.34, 1.25, 0.64, 1] as const;
+const MORPH_CLOSE_EASE = [0.22, 1, 0.36, 1] as const;
+const MORPH_OPEN_DURATION = 0.4;
+const MORPH_CLOSE_DURATION = 0.28;
+const MORPH_FADE_DURATION = 0.22;
+const MORPH_SLIDE = 40;
+const MORPH_SCALE = 0.97;
+const MORPH_BLUR = "blur(2px)";
 
 // Celebration sprinkles that burst from the success icon.
 const SPRINKLES = Array.from({ length: 8 }, (_, i) => {
@@ -90,8 +93,17 @@ export function FeedbackWidget({
   );
 
   useEffect(() => {
-    if (status === "open") textareaRef.current?.focus();
-  }, [status]);
+    if (status !== "open") return;
+
+    // Match the wallet account switcher's staged interaction: focusing while
+    // the surface is still expanding makes the caret and focus state appear
+    // inside a scaled panel. Arm the field once the open morph has settled.
+    const timer = window.setTimeout(
+      () => textareaRef.current?.focus(),
+      reduce ? 0 : MORPH_OPEN_DURATION * 1000,
+    );
+    return () => window.clearTimeout(timer);
+  }, [status, reduce]);
 
   // Dismiss on escape or outside click while open (but not mid-send).
   useEffect(() => {
@@ -135,7 +147,43 @@ export function FeedbackWidget({
   };
 
   const left = position === "bottom-left";
-  const morph = reduce ? { duration: 0.15 } : MORPH;
+  const contentOffset = left ? -MORPH_SLIDE : MORPH_SLIDE;
+  const surfaceTransition = reduce
+    ? { duration: 0 }
+    : {
+        layout: {
+          duration: open ? MORPH_OPEN_DURATION : MORPH_CLOSE_DURATION,
+          ease: open ? MORPH_OPEN_EASE : MORPH_CLOSE_EASE,
+        },
+        borderRadius: {
+          duration: open ? MORPH_OPEN_DURATION : MORPH_CLOSE_DURATION,
+          ease: open ? MORPH_OPEN_EASE : MORPH_CLOSE_EASE,
+        },
+      };
+  const contentTransition = reduce
+    ? { duration: 0 }
+    : {
+        opacity: {
+          duration: MORPH_FADE_DURATION,
+          ease: MORPH_CLOSE_EASE,
+        },
+        x: {
+          duration: MORPH_OPEN_DURATION,
+          ease: MORPH_CLOSE_EASE,
+        },
+        scale: {
+          duration: MORPH_OPEN_DURATION,
+          ease: MORPH_CLOSE_EASE,
+        },
+        filter: {
+          duration: MORPH_FADE_DURATION,
+          ease: MORPH_CLOSE_EASE,
+        },
+        rotate: {
+          duration: MORPH_OPEN_DURATION,
+          ease: MORPH_CLOSE_EASE,
+        },
+      };
   const viewInitial = reduce
     ? { opacity: 0 }
     : { opacity: 0, y: 8, filter: "blur(4px)" };
@@ -171,12 +219,12 @@ export function FeedbackWidget({
         className,
       )}
     >
-      {/* One persistent shell owns the surface in every state. Swapping two
-          shared-layout elements here makes their backgrounds crossfade. */}
+      {/* One persistent shell grows out of the corner trigger. The shell and
+          its contents use separate timing so the surface leads the reveal. */}
       <motion.div
         layout
-        animate={{ borderRadius: open ? 26 : 24 }}
-        transition={morph}
+        animate={{ borderRadius: open ? 20 : 40 }}
+        transition={surfaceTransition}
         style={{ transformOrigin: left ? "bottom left" : "bottom right" }}
         className={cn(
           "pointer-events-auto absolute bottom-0 overflow-hidden border border-border bg-background text-foreground shadow-lg",
@@ -188,10 +236,28 @@ export function FeedbackWidget({
           {open ? (
             <motion.div
               key="panel"
-              initial={false}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.14, ease: EASE_OUT }}
+              initial={
+                reduce
+                  ? { opacity: 0 }
+                  : {
+                      opacity: 0,
+                      x: contentOffset,
+                      scale: MORPH_SCALE,
+                      filter: MORPH_BLUR,
+                    }
+              }
+              animate={{ opacity: 1, x: 0, scale: 1, filter: "blur(0px)" }}
+              exit={
+                reduce
+                  ? { opacity: 0 }
+                  : {
+                      opacity: 0,
+                      x: contentOffset,
+                      scale: MORPH_SCALE,
+                      filter: MORPH_BLUR,
+                    }
+              }
+              transition={contentTransition}
             >
               <motion.div layout="position">
                 <AnimatePresence mode="popLayout" initial={false} propagate>
@@ -354,9 +420,27 @@ export function FeedbackWidget({
           ) : (
             <motion.button
               key="trigger"
-              layout
               type="button"
-              transition={morph}
+              initial={
+                reduce
+                  ? { opacity: 0 }
+                  : {
+                      opacity: 0,
+                      x: -contentOffset,
+                      filter: MORPH_BLUR,
+                    }
+              }
+              animate={{ opacity: 1, x: 0, filter: "blur(0px)" }}
+              exit={
+                reduce
+                  ? { opacity: 0 }
+                  : {
+                      opacity: 0,
+                      x: -contentOffset,
+                      filter: MORPH_BLUR,
+                    }
+              }
+              transition={contentTransition}
               onClick={() => {
                 clearCloseTimer();
                 setStatus("open");
@@ -364,10 +448,18 @@ export function FeedbackWidget({
               aria-label={title}
               aria-haspopup="dialog"
               whileTap={reduce ? undefined : { scale: 0.92 }}
-              className="absolute inset-0 flex items-center justify-center bg-transparent text-foreground"
+              className={cn(
+                "absolute bottom-0 flex h-12 w-12 items-center justify-center bg-transparent text-foreground",
+                left ? "left-0" : "right-0",
+              )}
             >
               <motion.span
-                layout
+                initial={
+                  reduce ? false : { rotate: 45, scale: MORPH_SCALE }
+                }
+                animate={{ rotate: 0, scale: 1 }}
+                exit={{ rotate: 45, scale: MORPH_SCALE }}
+                transition={contentTransition}
                 className="grid h-5 w-5 shrink-0 place-items-center [&>svg]:h-full [&>svg]:w-full"
               >
                 {icon ?? <MessageSquare className="h-5 w-5" />}

--- a/components/motion/input.tsx
+++ b/components/motion/input.tsx
@@ -9,21 +9,12 @@ import {
 import {
   useEffect,
   useId,
-  useLayoutEffect,
   useRef,
   useState,
   type InputHTMLAttributes,
   type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
-
-// Caret glide — snappy enough to feel attached to the keystroke, soft enough to read.
-const CARET_SPRING = {
-  type: "spring",
-  stiffness: 700,
-  damping: 40,
-  mass: 0.5,
-} as const;
 
 // Horizontal padding inside the field, in px. Wider when an icon occupies the edge.
 const EDGE_PAD = 14;
@@ -60,9 +51,6 @@ export function Input({
   type,
   ...rest
 }: InputProps) {
-  // Password masks characters as dots, so a plain-text mirror can't measure the
-  // caret position. Use the native caret there; the gliding caret is for text.
-  const customCaret = type !== "password";
   const reactId = useId();
   const id = idProp ?? reactId;
   const reduce = useReducedMotion();
@@ -72,32 +60,16 @@ export function Input({
   const value = controlled ? (valueProp ?? "") : internal;
 
   const [focused, setFocused] = useState(false);
-  const [caretIndex, setCaretIndex] = useState<number | null>(null);
-  const [caretX, setCaretX] = useState(0);
-  const [scrollLeft, setScrollLeft] = useState(0);
 
   const fieldRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const mirrorRef = useRef<HTMLSpanElement>(null);
 
   const hasError = Boolean(error);
   const errorMessage = typeof error === "string" ? error : null;
-  const index = caretIndex ?? value.length;
 
   // Right edge shows the success check, otherwise the caller's right icon.
   const rightSlot = success ? null : rightIcon;
   const leftPad = leftIcon ? ICON_PAD : EDGE_PAD;
   const rightPad = rightSlot || success ? ICON_PAD : EDGE_PAD;
-
-  // Measure text width up to the caret, and read the input's scroll so the
-  // caret stays aligned once the value overflows and the field scrolls.
-  useLayoutEffect(() => {
-    if (mirrorRef.current) {
-      mirrorRef.current.textContent = value.slice(0, index);
-      setCaretX(mirrorRef.current.offsetWidth);
-    }
-    if (inputRef.current) setScrollLeft(inputRef.current.scrollLeft);
-  }, [value, index]);
 
   // Shake the field when an error appears.
   useEffect(() => {
@@ -151,7 +123,6 @@ export function Input({
         ) : null}
 
         <input
-          ref={inputRef}
           id={id}
           type={type}
           value={value}
@@ -159,64 +130,16 @@ export function Input({
           aria-invalid={hasError || undefined}
           aria-describedby={errorMessage ? `${id}-error` : undefined}
           style={{ paddingLeft: leftPad, paddingRight: rightPad }}
-          onChange={(e) => {
-            handleChange(e.target.value);
-            setCaretIndex(e.target.selectionStart);
-          }}
-          onFocus={(e) => {
-            setFocused(true);
-            setCaretIndex(e.target.selectionStart);
-          }}
+          onChange={(e) => handleChange(e.target.value)}
+          onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
-          onSelect={(e) => setCaretIndex(e.currentTarget.selectionStart)}
-          onScroll={(e) => setScrollLeft(e.currentTarget.scrollLeft)}
           className={cn(
-            "peer h-full w-full bg-transparent text-base leading-6 text-foreground outline-none",
-            customCaret ? "caret-transparent" : "caret-foreground",
+            "peer h-full w-full bg-transparent text-base leading-6 text-foreground caret-foreground outline-none",
             "placeholder:text-muted-foreground/60",
             disabled && "cursor-not-allowed",
           )}
           {...rest}
         />
-
-        {customCaret ? (
-          <>
-            {/* Hidden mirror measures caret x for the value up to the caret index. */}
-            <span
-              ref={mirrorRef}
-              aria-hidden
-              style={{ left: leftPad }}
-              className="pointer-events-none invisible absolute top-1/2 -translate-y-1/2 whitespace-pre text-base leading-6"
-            />
-
-            {/* Custom caret glides between positions and blinks while focused. */}
-            <motion.span
-              aria-hidden
-              initial={false}
-              style={{ left: leftPad }}
-              animate={{
-                x: caretX - scrollLeft,
-                opacity: focused && !disabled ? [1, 1, 0, 0] : 0,
-              }}
-              transition={{
-                x: reduce ? { duration: 0 } : CARET_SPRING,
-                opacity: focused
-                  ? {
-                      duration: 1,
-                      repeat: Infinity,
-                      times: [0, 0.5, 0.5, 1],
-                      ease: "linear",
-                    }
-                  : { duration: 0.1 },
-              }}
-              className={cn(
-                "pointer-events-none absolute top-1/2 h-5 w-px -translate-y-1/2 rounded-full bg-foreground",
-                hasError && "bg-destructive",
-                success && "bg-(--color-success)",
-              )}
-            />
-          </>
-        ) : null}
 
         {success ? (
           <motion.svg

--- a/components/motion/input.tsx
+++ b/components/motion/input.tsx
@@ -7,6 +7,7 @@ import {
   useReducedMotion,
 } from "motion/react";
 import {
+  forwardRef,
   useEffect,
   useId,
   useRef,
@@ -16,9 +17,16 @@ import {
 } from "react";
 import { cn } from "@/lib/utils";
 
-// Horizontal padding inside the field, in px. Wider when an icon occupies the edge.
-const EDGE_PAD = 14;
-const ICON_PAD = 40;
+export type InputClassNames = {
+  root?: string;
+  label?: string;
+  field?: string;
+  input?: string;
+  leftIcon?: string;
+  rightIcon?: string;
+  successIcon?: string;
+  errorMessage?: string;
+};
 
 export interface InputProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
@@ -34,23 +42,30 @@ export interface InputProps extends Omit<
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
   className?: string;
+  classNames?: InputClassNames;
 }
 
-export function Input({
-  label,
-  value: valueProp,
-  defaultValue,
-  onChange,
-  error,
-  success,
-  leftIcon,
-  rightIcon,
-  className,
-  disabled,
-  id: idProp,
-  type,
-  ...rest
-}: InputProps) {
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  {
+    label,
+    value: valueProp,
+    defaultValue,
+    onChange,
+    onFocus,
+    onBlur,
+    error,
+    success,
+    leftIcon,
+    rightIcon,
+    className,
+    classNames,
+    disabled,
+    id: idProp,
+    type,
+    ...rest
+  },
+  ref,
+) {
   const reactId = useId();
   const id = idProp ?? reactId;
   const reduce = useReducedMotion();
@@ -68,8 +83,6 @@ export function Input({
 
   // Right edge shows the success check, otherwise the caller's right icon.
   const rightSlot = success ? null : rightIcon;
-  const leftPad = leftIcon ? ICON_PAD : EDGE_PAD;
-  const rightPad = rightSlot || success ? ICON_PAD : EDGE_PAD;
 
   // Shake the field when an error appears.
   useEffect(() => {
@@ -87,11 +100,16 @@ export function Input({
   };
 
   return (
-    <div className={cn("flex flex-col gap-1.5", className)}>
+    <div
+      className={cn("flex flex-col gap-1.5", className, classNames?.root)}
+    >
       {label ? (
         <label
           htmlFor={id}
-          className="px-1 text-sm font-medium text-foreground"
+          className={cn(
+            "px-1 text-sm font-medium text-foreground",
+            classNames?.label,
+          )}
         >
           {label}
         </label>
@@ -114,38 +132,56 @@ export function Input({
           focused && !hasError && "border-foreground/40 ring-2 ring-ring/40",
           hasError && "border-destructive ring-2 ring-destructive/25",
           disabled && "opacity-60",
+          classNames?.field,
         )}
       >
         {leftIcon ? (
-          <span className="pointer-events-none absolute left-3 top-1/2 flex -translate-y-1/2 items-center text-muted-foreground [&_svg]:h-4 [&_svg]:w-4">
+          <span
+            className={cn(
+              "pointer-events-none absolute left-3 top-1/2 flex -translate-y-1/2 items-center text-muted-foreground [&_svg]:h-4 [&_svg]:w-4",
+              classNames?.leftIcon,
+            )}
+          >
             {leftIcon}
           </span>
         ) : null}
 
         <input
+          ref={ref}
           id={id}
           type={type}
           value={value}
           disabled={disabled}
           aria-invalid={hasError || undefined}
           aria-describedby={errorMessage ? `${id}-error` : undefined}
-          style={{ paddingLeft: leftPad, paddingRight: rightPad }}
+          {...rest}
           onChange={(e) => handleChange(e.target.value)}
-          onFocus={() => setFocused(true)}
-          onBlur={() => setFocused(false)}
+          onFocus={(event) => {
+            setFocused(true);
+            onFocus?.(event);
+          }}
+          onBlur={(event) => {
+            setFocused(false);
+            onBlur?.(event);
+          }}
           className={cn(
             "peer h-full w-full bg-transparent text-base leading-6 text-foreground caret-foreground outline-none",
             "placeholder:text-muted-foreground/60",
+            leftIcon ? "pl-10" : "pl-3.5",
+            rightSlot || success ? "pr-10" : "pr-3.5",
             disabled && "cursor-not-allowed",
+            classNames?.input,
           )}
-          {...rest}
         />
 
         {success ? (
           <motion.svg
             viewBox="0 0 24 24"
             fill="none"
-            className="absolute right-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-(--color-success)"
+            className={cn(
+              "absolute right-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-(--color-success)",
+              classNames?.successIcon,
+            )}
           >
             <motion.path
               d="M5 12.5l4.5 4.5L19 7.5"
@@ -159,7 +195,12 @@ export function Input({
             />
           </motion.svg>
         ) : rightSlot ? (
-          <span className="absolute right-3 top-1/2 flex -translate-y-1/2 items-center text-muted-foreground [&_svg]:h-4 [&_svg]:w-4">
+          <span
+            className={cn(
+              "absolute right-3 top-1/2 flex -translate-y-1/2 items-center text-muted-foreground [&_svg]:h-4 [&_svg]:w-4",
+              classNames?.rightIcon,
+            )}
+          >
             {rightSlot}
           </span>
         ) : null}
@@ -182,7 +223,10 @@ export function Input({
                 : { opacity: 0, y: -4, filter: "blur(4px)" }
             }
             transition={{ duration: 0.2 }}
-            className="px-1 text-xs text-destructive"
+            className={cn(
+              "px-1 text-xs text-destructive",
+              classNames?.errorMessage,
+            )}
           >
             {errorMessage}
           </motion.p>
@@ -190,4 +234,4 @@ export function Input({
       </AnimatePresence>
     </div>
   );
-}
+});

--- a/components/motion/morphing-modal.tsx
+++ b/components/motion/morphing-modal.tsx
@@ -80,7 +80,7 @@ export function MorphingModal({
               }}
               transition={SPRING_PANEL}
               className={cn(
-                "pointer-events-auto relative w-full max-w-sm overflow-hidden rounded-3xl border border-border bg-card shadow-2xl will-change-transform",
+                "pointer-events-auto relative w-full max-w-sm overflow-hidden rounded-3xl border border-border bg-background shadow-2xl will-change-transform",
                 className,
               )}
             >

--- a/components/motion/tabs.tsx
+++ b/components/motion/tabs.tsx
@@ -98,6 +98,7 @@ export function TabsTrigger({
 }) {
   const { value: current, setValue, layoutId, variant } = useTabs();
   const active = current === value;
+  const usesDefaultIndicator = indicatorClassName === undefined;
 
   if (variant === "underline") {
     return (
@@ -126,8 +127,9 @@ export function TabsTrigger({
     );
   }
 
-  // Pill + Segment use the same trick: a max-contrast pill slides via layoutId,
-  // text uses `mix-blend-exclusion` so it inverts dynamically against the moving bg.
+  // The default max-contrast pill uses exclusion so labels invert exactly as
+  // the indicator passes beneath them. Custom indicators retain explicit text
+  // colors because their background may not be suitable for blending.
   const radius = variant === "pill" ? "rounded-full" : "rounded-md";
 
   return (
@@ -149,8 +151,17 @@ export function TabsTrigger({
         aria-selected={active}
         onClick={() => setValue(value)}
         className={cn(
-          "relative z-10 inline-flex items-center justify-center whitespace-nowrap bg-transparent px-3.5 py-1.5 text-sm font-medium transition-colors outline-none",
-          active ? "text-primary-foreground" : "text-muted-foreground hover:text-foreground",
+          "relative z-10 inline-flex items-center justify-center whitespace-nowrap bg-transparent px-3.5 py-1.5 text-sm font-medium outline-none",
+          usesDefaultIndicator
+            ? "text-white mix-blend-exclusion transition-opacity"
+            : "transition-colors",
+          usesDefaultIndicator
+            ? active
+              ? "opacity-100"
+              : "opacity-70 hover:opacity-100"
+            : active
+              ? "text-primary-foreground"
+              : "text-muted-foreground hover:text-foreground",
           radius,
           className,
         )}

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -106,7 +106,7 @@ export const registry: CategoryEntry[] = [
       {
         slug: "input",
         name: "Input",
-        description: "Text input with label, left/right icons, a gliding caret, error shake and success check draw.",
+        description: "Text input with label, left/right icons, error shake and success check draw.",
         file: "components/motion/input.tsx",
         keywords: [
           "react animated input",

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -6,6 +6,7 @@ import type { ReactElement } from "react";
 import { AnimatedBadge } from "@/components/motion/animated-badge";
 import { Button } from "@/components/motion/button";
 import { Checkbox } from "@/components/motion/checkbox";
+import { Input } from "@/components/motion/input";
 import { BloomMenu } from "@/components/motion/bloom-menu";
 import { RadioGroup, RadioGroupItem } from "@/components/motion/radio";
 import { Switch } from "@/components/motion/switch";
@@ -63,6 +64,7 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
     "Checkbox",
     () => <Checkbox checked={false} onCheckedChange={() => {}} label="Accept terms" />,
   ],
+  ["Input", () => <Input label="Email" type="email" />],
   [
     "RadioGroup",
     () => (

--- a/tests/input.test.tsx
+++ b/tests/input.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { createRef } from "react";
+import { Input } from "@/components/motion/input";
+
+afterEach(cleanup);
+
+describe("Input", () => {
+  test("exposes its input ref and configurable slots", () => {
+    const ref = createRef<HTMLInputElement>();
+    const { getByLabelText, container } = render(
+      <Input
+        ref={ref}
+        label="Email"
+        className="root-class"
+        classNames={{
+          field: "field-class",
+          input: "h-14 px-6",
+          label: "label-class",
+        }}
+      />,
+    );
+
+    const input = getByLabelText("Email") as HTMLInputElement;
+    const field = input.parentElement;
+
+    expect(ref.current).toBe(input);
+    expect(container.firstElementChild?.classList).toContain("root-class");
+    expect(field?.classList).toContain("field-class");
+    expect(input.classList).toContain("h-14");
+    expect(input.classList).toContain("px-6");
+    expect(container.querySelector("label")?.classList).toContain("label-class");
+  });
+
+  test("composes native focus events with internal state", () => {
+    const onFocus = mock(() => {});
+    const onBlur = mock(() => {});
+    const { getByLabelText } = render(
+      <Input label="Name" onFocus={onFocus} onBlur={onBlur} />,
+    );
+    const input = getByLabelText("Name") as HTMLInputElement;
+    const field = input.parentElement;
+
+    fireEvent.focus(input);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(field?.dataset.state).toBe("focused");
+
+    fireEvent.blur(input);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+    expect(field?.dataset.state).toBe("idle");
+  });
+
+  test("keeps the string value change callback", () => {
+    const onChange = mock(() => {});
+    const { getByLabelText } = render(
+      <Input label="Query" onChange={onChange} />,
+    );
+
+    fireEvent.change(getByLabelText("Query"), {
+      target: { value: "beUI" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("beUI");
+  });
+});


### PR DESCRIPTION
## Summary
- synchronize tab label contrast with the moving indicator
- replace the animated input caret with the native caret and expose configurable input slots
- use background surfaces for the bottom sheet and morphing modal
- refine the feedback widget opening and closing morph with staged focus and reduced-motion support

## Validation
- `bun run typecheck`
- `bun run lint` (passes with one pre-existing non-null assertion warning)
- `bun run check:registry`
- `bun test` (22 passing)