### PR TITLE
fix: clean up search indexing routes

### DIFF
--- a/app/r/[slug]/raw/route.ts
+++ b/app/r/[slug]/raw/route.ts
@@ -24,6 +24,7 @@ export async function GET(
         "cache-control": "public, max-age=300, s-maxage=3600",
         "access-control-allow-origin": "*",
         "access-control-allow-methods": "GET, OPTIONS",
+        "x-robots-tag": "noindex",
         "link": `</r/${slug}>; rel="alternate"; type="application/json"`,
       },
     });

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -10,9 +10,9 @@ export default function robots(): MetadataRoute.Robots {
         // fetch link-preview images; the more specific allow overrides the
         // /api/ disallow below.
         allow: ["/", "/api/og"],
-        // Machine endpoints: raw source text and the rest of /api/.
-        // Agents fetch these directly; they are not search content.
-        disallow: ["/api/", "/r/*/raw"],
+        // API endpoints do not need crawler traffic. Raw registry source stays
+        // crawlable so bots can read its X-Robots-Tag: noindex directive.
+        disallow: ["/api/"],
       },
     ],
     sitemap: `${SITE}/sitemap.xml`,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,21 +1,111 @@
-// Components that moved from the motion category to blocks. Old page URLs
-// stay alive; install slugs were never category-scoped so /r/* is untouched.
-const MOVED_TO_BLOCKS = [
+// Block source files still live under components/motion. Keep inferred and
+// historical motion-category URLs pointed at their public block docs pages.
+const BLOCK_COMPONENTS = [
   "swap",
   "dynamic-island",
   "command-palette",
   "expandable-action-bar",
+  "overflow-actions",
+  "expandable-tabs",
+  "swipeable-list",
+  "file-upload",
+  "prediction-market",
+  "wallet-card",
+  "otp-input",
+  "bloom-menu",
+  "feedback-widget",
+  "not-found",
+];
+
+// Old variant and source-file URLs surfaced by crawlers before the catalog was
+// consolidated. Send them to the component page that owns the implementation.
+const LEGACY_COMPONENT_REDIRECTS = [
+  ["/components/motion/base", "/components/motion/button"],
+  ["/components/motion/button-base", "/components/motion/button"],
+  ["/components/motion/stateful", "/components/motion/button"],
+  ["/components/motion/button-stateful", "/components/motion/button"],
+  ["/components/motion/magnetic", "/components/motion/button"],
+  ["/components/motion/button-magnetic", "/components/motion/button"],
+  ["/components/motion/select-morph", "/components/motion/select"],
+  ["/components/motion/text-reveal", "/components/motion/text-animation"],
+  ["/components/motion/text-shimmer", "/components/motion/text-animation"],
+  ["/components/motion/text-cascade", "/components/motion/text-animation"],
+  ["/components/motion/number-ticker", "/components/motion/number"],
+  ["/components/motion/animated-number", "/components/motion/number"],
+  ["/components/motion/action-swap-cascade", "/components/motion/action-swap"],
+  ["/components/motion/action-swap-blur", "/components/motion/action-swap"],
+  ["/components/motion/action-swap-roll", "/components/motion/action-swap"],
+  ["/components/motion/smooth-scroll", "/components/motion/scroll-animation"],
+  ["/components/motion/scroll-progress", "/components/motion/scroll-animation"],
+  ["/components/motion/parallax", "/components/motion/scroll-animation"],
+  ["/components/motion/scroll-to", "/components/motion/scroll-animation"],
+  ["/components/motion/scroll-reveal", "/components/motion/scroll-animation"],
+  ["/components/motion/table-editable", "/components/motion/table"],
+  ["/components/motion/table-async", "/components/motion/table"],
+  ["/components/motion/editable-cell", "/components/motion/table"],
+  ["/components/motion/row-handle", "/components/motion/table"],
+  ["/components/motion/skeleton-rows", "/components/motion/table"],
+  ["/components/motion/table-header", "/components/motion/table"],
+  ["/components/motion/table-menu", "/components/motion/table"],
+  ["/components/motion/use-column-reorder", "/components/motion/table"],
+  ["/components/motion/use-column-resize", "/components/motion/table"],
+  ["/components/motion/use-column-sort", "/components/motion/table"],
+  ["/components/motion/use-row-selection", "/components/motion/table"],
+  ["/components/motion/create-menu", "/components/blocks/bloom-menu"],
+  ["/components/blocks/create-menu", "/components/blocks/bloom-menu"],
+  ["/components/blocks/constants", "/components/blocks/swap"],
+  ["/components/blocks/controls", "/components/blocks/swap"],
+  ["/components/blocks/data", "/components/blocks/swap"],
+  ["/components/blocks/field", "/components/blocks/swap"],
+  ["/components/blocks/quote-row", "/components/blocks/swap"],
+  ["/components/blocks/token-badges", "/components/blocks/swap"],
+  ["/components/blocks/token-picker", "/components/blocks/swap"],
+  ["/components/blocks/account-avatar", "/components/blocks/wallet-card"],
+  ["/components/blocks/account-switcher", "/components/blocks/wallet-card"],
+  ["/components/blocks/actions", "/components/blocks/wallet-card"],
+  ["/components/blocks/balance-delta", "/components/blocks/wallet-card"],
+  ["/components/blocks/copy-button", "/components/blocks/wallet-card"],
+  ["/components/blocks/search-bar", "/components/blocks/wallet-card"],
+  ["/components/blocks/use-dismiss", "/components/blocks/wallet-card"],
+  ["/components/blocks/glitch", "/components/blocks/not-found"],
+  ["/components/blocks/not-found-glitch", "/components/blocks/not-found"],
+  ["/components/blocks/magnetic", "/components/blocks/not-found"],
+  ["/components/blocks/not-found-magnetic", "/components/blocks/not-found"],
+  ["/components/blocks/spotlight", "/components/blocks/not-found"],
+  ["/components/blocks/not-found-spotlight", "/components/blocks/not-found"],
+  ["/components/blocks/stacked", "/components/blocks/not-found"],
+  ["/components/blocks/not-found-stacked", "/components/blocks/not-found"],
+  ["/components/blocks/terminal", "/components/blocks/not-found"],
+  ["/components/blocks/not-found-terminal", "/components/blocks/not-found"],
+  ["/components/blocks/shared", "/components/blocks/not-found"],
 ];
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   async redirects() {
-    return MOVED_TO_BLOCKS.map((slug) => ({
-      source: `/components/motion/${slug}`,
-      destination: `/components/blocks/${slug}`,
-      permanent: true,
-    }));
+    return [
+      ...BLOCK_COMPONENTS.map((slug) => ({
+        source: `/components/motion/${slug}`,
+        destination: `/components/blocks/${slug}`,
+        permanent: true,
+      })),
+      ...["swap", "wallet-card", "not-found"].map((slug) => ({
+        source: `/components/motion/${slug}/:internal(.+)`,
+        destination: `/components/blocks/${slug}`,
+        permanent: true,
+      })),
+      ...LEGACY_COMPONENT_REDIRECTS.map(([source, destination]) => ({
+        source,
+        destination,
+        permanent: true,
+      })),
+      {
+        source: "/components/:category/:slug/:internal(.+)",
+        destination: "/components/:category/:slug",
+        permanent: true,
+      },
+    ];
   },
   outputFileTracingIncludes: {
     "/components/*": [


### PR DESCRIPTION
## Summary
- allow crawlers to access raw registry source while returning `X-Robots-Tag: noindex`
- redirect legacy component variants and renamed pages to their canonical docs pages
- redirect inferred nested source-file URLs to the component page that owns them
- preserve `/api/og` crawling because those image resources are intentionally referenced by page metadata

## Validation
- `bun run check`
- `bun test` (22 passing)
- verified 76 redirect rules have no duplicates, valid-page collisions, or invalid destinations
- verified raw route returns `200`, `text/plain`, and `X-Robots-Tag: noindex`