### PR TITLE
feat: redesign landing page

### DIFF
--- a/app/components/[category]/page.tsx
+++ b/app/components/[category]/page.tsx
@@ -109,7 +109,7 @@ export default async function CategoryPage({
 
       {newComponents.length ? (
         <section className="mt-10">
-          <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
+          <p className="font-display text-xs font-medium uppercase text-muted-foreground">
             New
           </p>
           <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
@@ -128,7 +128,7 @@ export default async function CategoryPage({
       ) : null}
 
       <section className="mt-10">
-        <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
+        <p className="font-display text-xs font-medium uppercase text-muted-foreground">
           All {cat.name}
         </p>
         <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/app/docs/motion-patterns/motion-patterns.tsx
+++ b/app/docs/motion-patterns/motion-patterns.tsx
@@ -130,7 +130,7 @@ export function MotionPatterns() {
                   {pattern.spec}
                 </span>
               </div>
-              <h2 className="mt-4 font-pixel text-base uppercase text-foreground">
+              <h2 className="mt-4 font-display text-base uppercase text-foreground">
                 {pattern.title}
               </h2>
               <p className="mt-1 text-sm leading-5 text-muted-foreground">
@@ -167,7 +167,7 @@ function PatternDetails({ pattern }: { pattern: Pattern }) {
     <div className="space-y-3 pt-2">
       <section className="rounded-2xl border border-border bg-background p-4">
         <div className="flex items-center justify-between gap-3">
-          <h3 className="font-pixel text-sm uppercase text-foreground">
+          <h3 className="font-display text-sm uppercase text-foreground">
             Live example
           </h3>
           <span className="rounded-full border border-border bg-card px-2.5 py-1 font-mono text-[11px] text-muted-foreground">
@@ -178,7 +178,7 @@ function PatternDetails({ pattern }: { pattern: Pattern }) {
       </section>
 
       <section className="rounded-2xl border border-border bg-background p-4">
-        <h3 className="font-pixel text-sm uppercase text-foreground">
+        <h3 className="font-display text-sm uppercase text-foreground">
           Simple guide
         </h3>
         <div className="mt-3 grid gap-3">
@@ -199,7 +199,7 @@ function PatternDetails({ pattern }: { pattern: Pattern }) {
       </section>
 
       <section className="rounded-2xl border border-border bg-background p-4">
-        <h3 className="font-pixel text-sm uppercase text-foreground">
+        <h3 className="font-display text-sm uppercase text-foreground">
           Pseudo code
         </h3>
         <pre className="mt-3 overflow-x-auto rounded-xl border border-border bg-card p-3 text-xs leading-6 text-foreground">
@@ -244,7 +244,7 @@ function LiveExample({ pattern }: { pattern: Pattern }) {
           transition={{ duration: 0.52, ease: EASE_OUT }}
           className="w-56 rounded-2xl bg-card p-4"
         >
-          <p className="font-pixel text-sm uppercase text-foreground">New card</p>
+          <p className="font-display text-sm uppercase text-foreground">New card</p>
           <p className="mt-2 text-sm text-muted-foreground">Soft reveal with lift.</p>
         </motion.div>
       </DemoFrame>

--- a/app/docs/motion-patterns/page.tsx
+++ b/app/docs/motion-patterns/page.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
 export default function MotionPatternsPage() {
   return (
     <div className="max-w-4xl">
-      <h1 className="font-pixel text-4xl uppercase tracking-tight text-foreground">
+      <h1 className="font-display text-4xl uppercase tracking-tight text-foreground">
         Motion Patterns
       </h1>
       <p className="mt-3 max-w-2xl text-muted-foreground">

--- a/app/globals.css
+++ b/app/globals.css
@@ -88,9 +88,9 @@
 
     --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
     --font-mono: var(--font-mono), ui-monospace, monospace;
-    --font-pixel:
-        var(--font-geist-pixel-square), var(--font-mono), ui-monospace,
-        monospace;
+    --font-display:
+        var(--font-bricolage), var(--font-inter), ui-sans-serif, system-ui,
+        sans-serif;
 }
 
 @theme {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { Inter, JetBrains_Mono } from "next/font/google";
-import { GeistPixelSquare } from "geist/font/pixel";
+import { Bricolage_Grotesque, Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { GoogleAnalytics } from "@/components/app/analytics/google-analytics";
 import { ThemeProvider } from "@/components/app/chrome/theme-provider";
@@ -20,7 +19,10 @@ import { cn } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
-const pixel = GeistPixelSquare;
+const display = Bricolage_Grotesque({
+  subsets: ["latin"],
+  variable: "--font-bricolage",
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -100,7 +102,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const googleAnalyticsId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 
   return (
-    <html lang="en" suppressHydrationWarning className={cn(inter.variable, mono.variable, pixel.variable)}>
+    <html lang="en" suppressHydrationWarning className={cn(inter.variable, mono.variable, display.variable)}>
       <head>
         <link rel="icon" type="image/png" href="/beui-mark.png" />
         <link rel="alternate" type="text/plain" title="llms.txt" href="/llms.txt" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,10 @@ import { ArrowRight } from "lucide-react";
 import { registry } from "@/lib/registry";
 import { Hero } from "@/components/app/landing/hero";
 import { InstallCommand } from "@/components/app/docs/install-command";
-import { LandingComponentCard } from "@/components/app/landing/landing-component-card";
+import {
+  type CardVariant,
+  LandingComponentCard,
+} from "@/components/app/landing/landing-component-card";
 import { SiteFooter } from "@/components/app/chrome/site-footer";
 import { Testimonials } from "@/components/app/landing/testimonials";
 import { WorkCta } from "@/components/app/landing/work-cta";
@@ -35,6 +38,48 @@ const CURATED: { category: string; slug: string }[] = [
   { category: "blocks", slug: "bloom-menu" },
 ];
 
+// Grid of live-preview cards. The first tile is promoted to a large "feature"
+// showcase once there are enough cards to keep the bento balanced.
+const BENTO_CLASS =
+  "grid grid-cols-1 gap-4 [grid-auto-rows:19rem] sm:grid-cols-2 sm:grid-flow-dense lg:grid-cols-3 xl:grid-cols-4";
+
+function bentoVariant(index: number, total: number): CardVariant {
+  if (index === 0 && total >= 3) return "feature";
+  return "default";
+}
+
+function SectionHeader({
+  eyebrow,
+  title,
+  href,
+}: {
+  eyebrow: string;
+  title: string;
+  href?: string;
+}) {
+  return (
+    <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+      <div>
+        <p className="text-[0.7rem] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+          {eyebrow}
+        </p>
+        <h2 className="mt-3 font-display text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
+          {title}
+        </h2>
+      </div>
+      {href ? (
+        <Link
+          href={href}
+          className="group inline-flex items-center self-start text-sm font-medium text-muted-foreground transition-colors hover:text-foreground md:self-auto"
+        >
+          Browse all
+          <ArrowRight className="ml-1 h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
 export default function Home() {
   const curatedComponents = CURATED.flatMap(({ category, slug }) => {
     const cat = registry.find((c) => c.slug === category);
@@ -55,7 +100,7 @@ export default function Home() {
 
   return (
     <div className="relative">
-      <section className="relative isolate overflow-hidden px-4 pb-16 pt-20 md:pt-28">
+      <section className="relative isolate overflow-hidden px-4 pb-20 pt-20 md:pt-28">
         <Hero />
       </section>
 
@@ -67,52 +112,34 @@ export default function Home() {
       </section>
 
       {newComponents.length ? (
-        <section className="mx-auto max-w-7xl px-4 pb-16">
-          <div className="mb-8 flex flex-col gap-4 border-t border-border pt-12 md:flex-row md:items-center md:justify-between">
-            <div>
-              <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
-                New
-              </p>
-              <h2 className="mt-2 font-pixel text-3xl font-medium leading-tight text-foreground md:text-4xl">
-                Recently launched.
-              </h2>
-            </div>
-          </div>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-            {newComponents.map(({ category, component }) => (
+        <section className="mx-auto max-w-7xl border-t border-border px-4 pb-16 pt-14">
+          <SectionHeader eyebrow="New" title="Recently launched" />
+          <div className={BENTO_CLASS}>
+            {newComponents.map(({ category, component }, i) => (
               <LandingComponentCard
                 key={`${category}-${component.slug}`}
                 component={component}
                 category={category}
+                variant={bentoVariant(i, newComponents.length)}
               />
             ))}
           </div>
         </section>
       ) : null}
 
-      <section className="mx-auto max-w-7xl px-4 pb-16">
-        <div className="mb-8 flex flex-col gap-4 border-t border-border pt-12 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
-              Components
-            </p>
-            <h2 className="mt-2 font-pixel text-3xl font-medium leading-tight text-foreground md:text-4xl">
-              Motion primitives.
-            </h2>
-          </div>
-          <Link
-            href="/components/motion"
-            className="inline-flex items-center self-start text-sm font-medium text-muted-foreground hover:text-foreground md:self-center"
-          >
-            Browse all <ArrowRight className="ml-1 h-3.5 w-3.5" />
-          </Link>
-        </div>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-          {curatedComponents.map(({ category, component }) => (
+      <section className="mx-auto max-w-7xl border-t border-border px-4 pb-16 pt-14">
+        <SectionHeader
+          eyebrow="Components"
+          title="Motion primitives"
+          href="/components/motion"
+        />
+        <div className={BENTO_CLASS}>
+          {curatedComponents.map(({ category, component }, i) => (
             <LandingComponentCard
               key={`${category}-${component.slug}`}
               component={component}
               category={category}
+              variant={bentoVariant(i, curatedComponents.length)}
             />
           ))}
         </div>

--- a/components/app/chrome/site-footer.tsx
+++ b/components/app/chrome/site-footer.tsx
@@ -18,7 +18,7 @@ export function SiteFooter() {
         <div className="grid grid-cols-2 gap-10 md:grid-cols-[1.5fr_1fr_1fr_1fr]">
           {/* Brand */}
           <div className="col-span-2 md:col-span-1">
-            <p className="font-pixel text-lg font-medium text-foreground">beUI</p>
+            <p className="font-display text-lg font-medium text-foreground">beUI</p>
             <p className="mt-2 max-w-[220px] text-sm leading-6 text-muted-foreground">
               The motion toolkit for React & Next.js. Copy-paste via shadcn registry.
             </p>

--- a/components/app/docs/component-card.tsx
+++ b/components/app/docs/component-card.tsx
@@ -20,7 +20,7 @@ export function ComponentCard({
       className="group/card relative flex h-40 flex-col overflow-hidden rounded-3xl bg-card transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
-        <h3 className="truncate font-pixel text-base font-medium text-foreground">
+        <h3 className="truncate font-display text-base font-medium text-foreground">
           {name}
         </h3>
         {badge === "new" ? <NewBadge /> : null}

--- a/components/app/landing/hero.tsx
+++ b/components/app/landing/hero.tsx
@@ -42,7 +42,7 @@ export function Hero() {
         text={HEADLINE}
         delay={START}
         stagger={STAGGER}
-        className="mx-auto font-pixel text-5xl font-medium leading-[0.9] text-foreground sm:text-6xl md:text-7xl"
+        className="mx-auto font-display text-5xl font-semibold leading-[0.92] tracking-tight text-foreground sm:text-6xl md:text-7xl"
       />
 
       <motion.p

--- a/components/app/landing/landing-component-card.tsx
+++ b/components/app/landing/landing-component-card.tsx
@@ -1,25 +1,38 @@
 "use client";
 
 import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
 import { useState } from "react";
 import type { ComponentEntry } from "@/lib/registry";
 import { NewBadge } from "@/components/app/docs/new-badge";
 import { PreviewFit } from "@/components/app/landing/preview-fit";
 import { getPreview } from "@/components/previews";
+import { cn } from "@/lib/utils";
+
+export type CardVariant = "default" | "wide" | "feature";
+
+const VARIANT_SPAN: Record<CardVariant, string> = {
+  default: "",
+  wide: "sm:col-span-2",
+  feature: "sm:col-span-2 sm:row-span-2",
+};
 
 export function LandingComponentCard({
   component,
   category = "motion",
+  variant = "default",
 }: {
   component: ComponentEntry;
   category?: string;
+  variant?: CardVariant;
 }) {
   const Preview = getPreview(category, component.slug);
   const [hover, setHover] = useState(false);
+  const feature = variant === "feature";
 
   return (
     <article
-      className="group/card relative h-72"
+      className={cn("group/card relative h-full", VARIANT_SPAN[variant])}
       onPointerEnter={() => setHover(true)}
       onPointerLeave={() => setHover(false)}
       onFocus={() => setHover(true)}
@@ -30,28 +43,30 @@ export function LandingComponentCard({
         aria-label={`View ${component.name}`}
         className="absolute inset-0 z-20 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       />
-      <div className="relative flex h-full flex-col overflow-hidden rounded-3xl bg-card transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint]">
-        <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
-          <h3 className="truncate font-pixel text-base font-medium text-foreground">
-            {component.name}
-          </h3>
-          {component.badge === "new" ? <NewBadge /> : null}
-        </div>
-
-        <PreviewFit
-          hover={hover}
-          overlay={
-            <div className="pointer-events-none absolute inset-0 rounded-3xl bg-transparent backdrop-blur-0 transition-[background-color,backdrop-filter] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:bg-card/55 group-hover/card:backdrop-blur-md group-focus-within/card:bg-card/55 group-focus-within/card:backdrop-blur-md">
-              <div className="absolute inset-x-0 bottom-0 translate-y-full px-4 py-3 transition-transform duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-y-0 group-focus-within/card:translate-y-0">
-                <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-                  {component.description}
-                </p>
-              </div>
-            </div>
-          }
-        >
+      <div className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-border bg-card transition-colors duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] contain-[paint] group-hover/card:border-border-strong">
+        <PreviewFit hover={hover} maxScale={feature ? 1 : 0.82}>
           {Preview ? <Preview /> : null}
         </PreviewFit>
+
+        <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3.5">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <h3
+                className={cn(
+                  "truncate font-display font-semibold tracking-tight text-foreground",
+                  feature ? "text-lg" : "text-[0.95rem]",
+                )}
+              >
+                {component.name}
+              </h3>
+              {component.badge === "new" ? <NewBadge /> : null}
+            </div>
+            <p className="mt-0.5 line-clamp-1 text-xs leading-relaxed text-muted-foreground">
+              {component.description}
+            </p>
+          </div>
+          <ArrowUpRight className="h-4 w-4 shrink-0 -translate-x-1 text-muted-foreground opacity-0 transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover/card:translate-x-0 group-hover/card:opacity-100" />
+        </div>
       </div>
     </article>
   );

--- a/components/app/landing/preview-fit.tsx
+++ b/components/app/landing/preview-fit.tsx
@@ -2,11 +2,10 @@
 
 import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
 
-// Matches the original flat scale so normal-size previews look unchanged;
-// only previews bigger than the card shrink further to actually fit — no
-// clipping, and the card itself stays a fixed, modest size.
-const BASE_SCALE = 0.8;
-const HOVER_SCALE = 0.84;
+// Cap so a preview never renders larger than intended; only previews bigger
+// than the card shrink further to actually fit — no clipping. `maxScale`
+// per-card lets feature tiles show their preview larger than grid tiles.
+const HOVER_LIFT = 1.05;
 const MIN_SCALE = 0.22;
 
 // A real desktop width for the preview to render at before it gets scaled
@@ -29,10 +28,12 @@ export function PreviewFit({
   children,
   hover,
   overlay,
+  maxScale = 0.82,
 }: {
   children: ReactNode;
   hover: boolean;
   overlay?: ReactNode;
+  maxScale?: number;
 }) {
   const outerRef = useRef<HTMLDivElement>(null);
   const stageRef = useRef<HTMLDivElement>(null);
@@ -66,12 +67,12 @@ export function PreviewFit({
     return () => ro.disconnect();
   }, []);
 
-  const scale = Math.min(BASE_SCALE, fitScale) * (hover ? HOVER_SCALE / BASE_SCALE : 1);
+  const scale = Math.min(maxScale, fitScale) * (hover ? HOVER_LIFT : 1);
 
   return (
     <div
       ref={outerRef}
-      className="relative mx-2 mb-2 flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-3xl bg-background p-3 contain-[paint]"
+      className="relative m-2 mb-0 flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-[1.25rem] bg-background p-3 contain-[paint]"
     >
       <div
         ref={stageRef}

--- a/components/app/landing/testimonials.tsx
+++ b/components/app/landing/testimonials.tsx
@@ -48,12 +48,12 @@ export async function Testimonials() {
 
   return (
     <section className="pb-16">
-      <div className="mx-auto mb-8 max-w-7xl border-t border-border px-4 pt-12">
-        <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
+      <div className="mx-auto mb-8 max-w-7xl border-t border-border px-4 pt-14">
+        <p className="text-[0.7rem] font-medium uppercase tracking-[0.22em] text-muted-foreground">
           Testimonials
         </p>
-        <h2 className="mt-2 font-pixel text-3xl font-medium leading-tight text-foreground md:text-4xl">
-          Loved by builders.
+        <h2 className="mt-3 font-display text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
+          Loved by builders
         </h2>
       </div>
 

--- a/components/app/landing/work-cta.tsx
+++ b/components/app/landing/work-cta.tsx
@@ -1,130 +1,45 @@
-"use client";
-
-import { ArrowUpRight, Mail, TrendingUp } from "lucide-react";
-import { motion, useReducedMotion } from "motion/react";
+import { ArrowUpRight, Mail } from "lucide-react";
 import { PressLink } from "@/components/app/press-link";
-import { EASE_IN_OUT } from "@/lib/ease";
 
 const CAL_URL = "https://cal.com/saurra3h/30min";
 const EMAIL = "saurabh10102@gmail.com";
 
 export function WorkCta() {
   return (
-    <section className="px-4 pb-24">
-      <div className="mx-auto max-w-7xl">
-        <div className="relative overflow-hidden rounded-[28px] border border-border px-8 py-16 shadow-[inset_0_1px_0_rgba(255,255,255,0.03),inset_0_-30px_44px_-32px_rgba(0,0,0,0.12)] md:px-16 md:py-20">
-          <div className="relative grid items-center gap-12 md:grid-cols-2">
-            {/* left: copy + actions */}
-            <div className="flex flex-col items-start text-left">
-              <span className="inline-flex items-center rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
-                Contact us
-              </span>
+    <section className="px-4 py-24 md:py-36">
+      <div className="mx-auto flex max-w-2xl flex-col items-center text-center">
+        <p className="text-[0.7rem] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+          Work with me
+        </p>
 
-              <h2 className="mt-6 font-pixel text-3xl font-semibold text-foreground md:text-5xl md:leading-[1.15]">
-                Want components built for your product?
-              </h2>
-              <p className="mt-5 max-w-md text-base leading-7 text-muted-foreground">
-                Custom motion components and frontend systems, built to spec.
-                Book a call or drop a line, whichever's easier.
-              </p>
+        <h2 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground md:text-5xl md:leading-[1.1]">
+          Need components built for your product?
+        </h2>
+        <p className="mt-5 max-w-md text-base leading-7 text-muted-foreground">
+          Custom motion components and frontend systems, built to spec. Book a
+          call or drop a line, whichever's easier.
+        </p>
 
-              <div className="mt-8 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
-                <PressLink
-                  href={CAL_URL}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="group inline-flex items-center justify-center gap-2 rounded-full bg-primary px-7 py-3.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
-                >
-                  Book a call
-                  <ArrowUpRight className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
-                </PressLink>
+        <div className="mt-8 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+          <PressLink
+            href={CAL_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="group inline-flex items-center justify-center gap-2 rounded-full bg-primary px-7 py-3.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Book a call
+            <ArrowUpRight className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+          </PressLink>
 
-                <PressLink
-                  href={`mailto:${EMAIL}`}
-                  className="group inline-flex items-center justify-center gap-2 rounded-full border border-border bg-transparent px-7 py-3.5 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
-                >
-                  <Mail className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5" />
-                  Email me
-                </PressLink>
-              </div>
-            </div>
-
-            {/* right: floating component-preview stack */}
-            <CtaVisual />
-          </div>
+          <PressLink
+            href={`mailto:${EMAIL}`}
+            className="group inline-flex items-center justify-center gap-2 rounded-full border border-border bg-background px-7 py-3.5 text-sm font-semibold text-foreground transition-colors hover:border-border-strong hover:bg-muted"
+          >
+            <Mail className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5" />
+            Email me
+          </PressLink>
         </div>
       </div>
     </section>
-  );
-}
-
-function CtaVisual() {
-  const reduce = useReducedMotion();
-
-  const float = (range: number, duration: number) =>
-    reduce
-      ? undefined
-      : {
-          y: [-range, range, -range],
-          transition: { duration, ease: EASE_IN_OUT, repeat: Infinity },
-        };
-
-  return (
-    <div aria-hidden className="relative hidden h-72 select-none md:block">
-      {/* back: switch row */}
-      <motion.div
-        animate={float(6, 6)}
-        className="absolute right-6 top-2 w-56 rotate-[6deg] rounded-2xl border border-border bg-background p-4 shadow-sm"
-      >
-        <div className="flex items-center justify-between">
-          <div className="space-y-1.5">
-            <div className="h-2 w-20 rounded-full bg-foreground/15" />
-            <div className="h-2 w-12 rounded-full bg-foreground/10" />
-          </div>
-          <div className="flex h-6 w-10 items-center rounded-full bg-foreground/15 p-0.5">
-            <div className="ml-auto h-5 w-5 rounded-full bg-foreground" />
-          </div>
-        </div>
-      </motion.div>
-
-      {/* mid: stat / number card */}
-      <motion.div
-        animate={float(8, 7)}
-        className="absolute left-2 top-16 w-52 -rotate-3 rounded-2xl border border-border bg-background p-4 shadow-md"
-      >
-        <div className="flex items-center justify-between">
-          <div className="h-2 w-16 rounded-full bg-foreground/10" />
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground">
-            <TrendingUp className="h-3 w-3" />
-            +24%
-          </span>
-        </div>
-        <div className="mt-3 font-pixel text-2xl font-semibold text-foreground">
-          48,210
-        </div>
-        <div className="mt-3 flex items-end gap-1">
-          {[5, 8, 6, 10, 7, 12, 9].map((h, i) => (
-            <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: static decorative bars
-              key={i}
-              style={{ height: h * 4 }}
-              className="w-2 rounded-sm bg-foreground/15"
-            />
-          ))}
-        </div>
-      </motion.div>
-
-      {/* front: button pill card */}
-      <motion.div
-        animate={float(7, 5.5)}
-        className="absolute right-2 bottom-2 w-48 rotate-2 rounded-2xl border border-border bg-background p-4 shadow-lg"
-      >
-        <div className="h-2 w-24 rounded-full bg-foreground/10" />
-        <div className="mt-4 inline-flex w-full items-center justify-center gap-1.5 rounded-full bg-primary px-4 py-2.5 text-xs font-semibold text-primary-foreground">
-          Get started
-          <ArrowUpRight className="h-3.5 w-3.5" />
-        </div>
-      </motion.div>
-    </div>
   );
 }

--- a/components/app/playground/playground.tsx
+++ b/components/app/playground/playground.tsx
@@ -121,7 +121,7 @@ export function Playground() {
   return (
     <div className="mx-auto max-w-7xl px-4 pb-24 pt-10 md:pt-12">
       <header className="mb-8">
-        <h1 className="font-pixel text-3xl font-semibold text-foreground md:text-4xl">
+        <h1 className="font-display text-3xl font-semibold text-foreground md:text-4xl">
           Playground
         </h1>
         <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">

--- a/components/app/preferences/preferences-panel.tsx
+++ b/components/app/preferences/preferences-panel.tsx
@@ -54,7 +54,7 @@ export function PreferencesPanel() {
       </div>
 
       <section>
-        <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
+        <p className="font-display text-xs font-medium uppercase text-muted-foreground">
           Theme
         </p>
         <div className="mt-3 flex flex-wrap items-center gap-2.5">
@@ -94,7 +94,7 @@ export function PreferencesPanel() {
       </section>
 
       <section>
-        <p className="font-pixel text-xs font-medium uppercase text-muted-foreground">
+        <p className="font-display text-xs font-medium uppercase text-muted-foreground">
           Icons
         </p>
         <div className="mt-3 flex flex-col gap-2">


### PR DESCRIPTION
Landing redesign — drops the pixel font, refreshes the grids and CTA.

## Type
- Removed `GeistPixelSquare` entirely; every `font-pixel` (14 files) now `font-display` → **Bricolage Grotesque**, wired through a single `--font-display` token so the display face is a one-line swap.

## Layout
- Component grids are now **bento**: the first tile promotes to a 2×2 feature showcase (`grid-auto-rows` + `grid-flow-dense`), rest uniform.
- Refined section headers (tracked eyebrow + display title).

## Cards
- Bordered card, hover tightens the border only (no lift, no shadow).
- Name + one-line description in a footer bar; arrow slides in on hover.

## Contact CTA
- Simplified to centered text: eyebrow, heading, subcopy, two buttons.
- Removed the floating illustration and the container bg/border; added vertical breathing room.

Typecheck, lint (one pre-existing warning), and registry check pass.