### PR TITLE
feat: add availability scheduler block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `shared-layout-bg` | `components/motion/shared-layout-bg.tsx` | Pill that glides between hovered items via shared layout |
 | `dock` | `components/motion/dock.tsx` | macOS-style dock with grouped actions and gliding active pill |
 | `tooltip` | `components/motion/tooltip.tsx` | Hover/focus tooltip with blur enter/exit and spring spawn |
-| `popover` | `components/motion/popover.tsx` | Composable gooey popover (`Popover`, `PopoverTrigger`, `PopoverContent`); panel oozes out of the trigger via an SVG goo filter (liquid neck that stretches/pinches) with crisp content fading in on top. Inline-anchored, click or hover trigger, controlled/uncontrolled |
+| `popover` | `components/motion/popover.tsx`, `popover-morph.tsx` | Composable popover, two variants. **Gooey** (`Popover`, `PopoverTrigger`, `PopoverContent`, install `@beui/popover`): panel oozes out of the trigger via an SVG goo filter (liquid neck that stretches/pinches) with crisp content fading in on top. **Morph** (`MorphPopover`, `MorphPopoverTrigger`, `MorphPopoverContent`, install `@beui/popover-morph`): panel laid out full size but clipped to the corner nearest the trigger, then unclips as one piece with a drop-shadow that hugs the shape; side/align aware. Both inline-anchored, click trigger, controlled/uncontrolled |
 | `morphing-modal` | `components/motion/morphing-modal.tsx` | Panel that morphs height across inner views with blur cross-fade |
 | `text-reveal` | `components/motion/text-reveal.tsx` | Word or character reveal with spring slide-up and blur |
 | `text-shimmer` | `components/motion/text-shimmer.tsx` | Gradient sweep across text for loading or emphasis |
@@ -78,6 +78,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `prediction-market` | `components/motion/prediction-market.tsx` | Trade ticket with buy/sell modes, outcome prices and rolling amount entry |
 | `otp-input` | `components/motion/otp-input.tsx` | One-time-code input with gliding focus ring, roll-in digits, error shake and success draw |
 | `bloom-menu` | `components/motion/bloom-menu.tsx` | Button that morphs open into a menu and blooms iris-out from center via shared layout + clip-path, with radially staggered items |
+| `availability-scheduler` | `components/motion/availability-scheduler/` | Weekly availability editor (`AvailabilityScheduler`): each day springs between available/unavailable via a shared-layout toggle, time ranges add/remove with blur-slide + layout reflow, times pick from a self-contained scrollable dropdown, and a copy menu clones a day's hours to selected days or every day; controlled/uncontrolled, reduced-motion safe |
 
 ### Site chrome (`components/app/` — not part of the library)
 

--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -268,7 +268,7 @@ async function ExampleBlock({
           <TabsTrigger value="source">Code</TabsTrigger>
         </TabsList>
         <TabsContent value="preview" className="mt-4">
-          <div className="flex min-h-[260px] items-center justify-center rounded-2xl border border-border bg-card py-10">
+          <div className="flex min-h-[260px] items-center justify-center py-10">
             {Preview ? <Preview /> : null}
           </div>
         </TabsContent>

--- a/components/motion/availability-scheduler/copy-menu.tsx
+++ b/components/motion/availability-scheduler/copy-menu.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { Checkbox } from "@/components/motion/checkbox";
+import {
+  MorphPopover,
+  MorphPopoverContent,
+} from "@/components/motion/popover-morph";
+import { Tooltip } from "@/components/motion/tooltip";
+import { SPRING_PRESS } from "@/lib/ease";
+import { IconButton } from "./icon-button";
+import { type DayKey, WEEKDAYS } from "./types";
+
+// Copy this day's hours to other days: a morph popover with a day picker.
+export function CopyMenu({
+  fromLabel,
+  reduce,
+  onApply,
+}: {
+  fromLabel: string;
+  reduce: boolean;
+  onApply: (targets: DayKey[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [picked, setPicked] = useState<Set<DayKey>>(new Set());
+  const others = WEEKDAYS.filter((d) => d.label !== fromLabel);
+
+  const toggle = (k: DayKey) =>
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(k)) next.delete(k);
+      else next.add(k);
+      return next;
+    });
+
+  const apply = (targets: DayKey[]) => {
+    if (!targets.length) return;
+    onApply(targets);
+    setOpen(false);
+    setPicked(new Set());
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1200);
+  };
+
+  return (
+    <MorphPopover open={open} onOpenChange={setOpen}>
+      <Tooltip content="Copy times">
+        <IconButton
+          label={`Copy ${fromLabel} hours to other days`}
+          reduce={reduce}
+          expanded={open}
+          onClick={() => setOpen(!open)}
+        >
+          <AnimatePresence mode="popLayout" initial={false}>
+            {copied ? (
+              <motion.span
+                key="done"
+                initial={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.5 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.5 }}
+                transition={SPRING_PRESS}
+                className="text-foreground"
+              >
+                <Check className="h-4 w-4" />
+              </motion.span>
+            ) : (
+              <motion.span
+                key="copy"
+                initial={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.5 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.5 }}
+                transition={SPRING_PRESS}
+              >
+                <Copy className="h-4 w-4" />
+              </motion.span>
+            )}
+          </AnimatePresence>
+        </IconButton>
+      </Tooltip>
+
+      <MorphPopoverContent align="end" className="w-52 p-2">
+        <p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+          Copy times to
+        </p>
+        <div className="flex flex-col">
+          {others.map((d) => (
+            <Checkbox
+              key={d.key}
+              checked={picked.has(d.key)}
+              onCheckedChange={() => toggle(d.key)}
+              label={d.label}
+              className="w-full flex-row-reverse justify-between rounded-lg px-2 py-1.5 transition-colors hover:bg-muted [&_button]:size-4 [&_button]:rounded-[5px] [&_button]:border [&_button[data-state=unchecked]]:border-border-strong"
+            />
+          ))}
+        </div>
+        <div className="mt-1 flex items-center gap-2 border-t border-border px-1 pt-2">
+          <button
+            type="button"
+            onClick={() => apply(others.map((d) => d.key))}
+            className="flex-1 rounded-lg px-2 py-1.5 text-xs font-medium text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:bg-muted"
+          >
+            Every day
+          </button>
+          <button
+            type="button"
+            onClick={() => apply([...picked])}
+            disabled={picked.size === 0}
+            className="flex-1 rounded-lg bg-primary px-2 py-1.5 text-xs font-semibold text-primary-foreground outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-40"
+          >
+            Apply
+          </button>
+        </div>
+      </MorphPopoverContent>
+    </MorphPopover>
+  );
+}

--- a/components/motion/availability-scheduler/day-row.tsx
+++ b/components/motion/availability-scheduler/day-row.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+import { Plus, X } from "lucide-react";
+import { useRef } from "react";
+import { Switch } from "@/components/motion/switch";
+import { Tooltip } from "@/components/motion/tooltip";
+import { SPRING_LAYOUT } from "@/lib/ease";
+import { CopyMenu } from "./copy-menu";
+import { IconButton } from "./icon-button";
+import { TimeSelect } from "./time-select";
+import {
+  type DayAvailability,
+  type DayKey,
+  type TimeOption,
+  type TimeRange,
+  toMinutes,
+  toValue,
+} from "./types";
+
+export function DayRow({
+  day,
+  label,
+  state,
+  options,
+  reduce,
+  depth,
+  onChange,
+  onCopy,
+}: {
+  day: DayKey;
+  label: string;
+  state: DayAvailability;
+  options: TimeOption[];
+  reduce: boolean;
+  // Higher = painted above later rows, so a downward-opening panel always sits
+  // over the rows below it — during both open and close animations.
+  depth: number;
+  onChange: (next: DayAvailability) => void;
+  onCopy: (targets: DayKey[]) => void;
+}) {
+  const idRef = useRef(0);
+  const nextId = () => `${day}-n${idRef.current++}`;
+
+  const setEnabled = (enabled: boolean) => {
+    if (enabled && state.ranges.length === 0) {
+      onChange({
+        enabled,
+        ranges: [{ id: nextId(), start: "09:00", end: "17:00" }],
+      });
+    } else {
+      onChange({ ...state, enabled });
+    }
+  };
+
+  const updateRange = (id: string, patch: Partial<TimeRange>) => {
+    onChange({
+      ...state,
+      ranges: state.ranges.map((r) => (r.id === id ? { ...r, ...patch } : r)),
+    });
+  };
+
+  const addRange = () => {
+    const last = state.ranges[state.ranges.length - 1];
+    const start = last ? Math.min(toMinutes(last.end) + 60, 24 * 60 - 60) : 540;
+    onChange({
+      enabled: true,
+      ranges: [
+        ...state.ranges,
+        { id: nextId(), start: toValue(start), end: toValue(start + 60) },
+      ],
+    });
+  };
+
+  const removeRange = (id: string) => {
+    const ranges = state.ranges.filter((r) => r.id !== id);
+    // Removing the last slot marks the day unavailable.
+    onChange({ enabled: ranges.length > 0, ranges });
+  };
+
+  return (
+    <motion.div
+      layout={reduce ? false : "position"}
+      transition={SPRING_LAYOUT}
+      style={{ zIndex: depth }}
+      className="relative flex items-start gap-4 py-4"
+    >
+      {/* toggle + label */}
+      <div className="flex w-36 shrink-0 items-center gap-3 pt-1">
+        <Switch checked={state.enabled} onCheckedChange={setEnabled} />
+        <span className="text-sm font-medium text-foreground">{label}</span>
+      </div>
+
+      {/* ranges or unavailable */}
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <AnimatePresence initial={false} mode="popLayout">
+          {state.enabled ? (
+            state.ranges.map((r, i) => (
+              <motion.div
+                key={r.id}
+                layout={reduce ? false : "position"}
+                style={{ zIndex: state.ranges.length - i }}
+                initial={
+                  reduce
+                    ? { opacity: 0 }
+                    : { opacity: 0, y: -6, filter: "blur(4px)" }
+                }
+                animate={
+                  reduce
+                    ? { opacity: 1 }
+                    : { opacity: 1, y: 0, filter: "blur(0px)" }
+                }
+                exit={
+                  reduce
+                    ? { opacity: 0 }
+                    : { opacity: 0, y: -4, filter: "blur(4px)" }
+                }
+                transition={SPRING_LAYOUT}
+                className="relative flex items-center gap-2"
+              >
+                <TimeSelect
+                  value={r.start}
+                  options={options}
+                  onChange={(v) => updateRange(r.id, { start: v })}
+                />
+                <span className="text-muted-foreground">–</span>
+                <TimeSelect
+                  value={r.end}
+                  options={options}
+                  onChange={(v) => updateRange(r.id, { end: v })}
+                />
+                <Tooltip content="Remove">
+                  <IconButton
+                    label="Remove time range"
+                    reduce={reduce}
+                    onClick={() => removeRange(r.id)}
+                  >
+                    <X className="h-4 w-4" />
+                  </IconButton>
+                </Tooltip>
+              </motion.div>
+            ))
+          ) : (
+            <motion.span
+              key="unavailable"
+              layout={reduce ? false : "position"}
+              initial={reduce ? { opacity: 0 } : { opacity: 0, y: -4 }}
+              animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
+              exit={reduce ? { opacity: 0 } : { opacity: 0, y: -4 }}
+              transition={SPRING_LAYOUT}
+              className="py-2 text-sm text-muted-foreground"
+            >
+              Unavailable
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* actions */}
+      <div className="flex shrink-0 items-center gap-1 pt-0.5">
+        <Tooltip content="Add time">
+          <IconButton
+            label={`Add time range to ${label}`}
+            reduce={reduce}
+            onClick={addRange}
+          >
+            <Plus className="h-4 w-4" />
+          </IconButton>
+        </Tooltip>
+        <CopyMenu fromLabel={label} reduce={reduce} onApply={onCopy} />
+      </div>
+    </motion.div>
+  );
+}

--- a/components/motion/availability-scheduler/day-row.tsx
+++ b/components/motion/availability-scheduler/day-row.tsx
@@ -78,17 +78,39 @@ export function DayRow({
     onChange({ enabled: ranges.length > 0, ranges });
   };
 
+  const actions = (
+    <>
+      <Tooltip content="Add time">
+        <IconButton
+          label={`Add time range to ${label}`}
+          reduce={reduce}
+          onClick={addRange}
+        >
+          <Plus className="h-4 w-4" />
+        </IconButton>
+      </Tooltip>
+      <CopyMenu fromLabel={label} reduce={reduce} onApply={onCopy} />
+    </>
+  );
+
   return (
     <motion.div
       layout={reduce ? false : "position"}
       transition={SPRING_LAYOUT}
       style={{ zIndex: depth }}
-      className="relative flex items-start gap-4 py-4"
+      className="relative flex flex-col gap-3 py-4 sm:flex-row sm:items-start sm:gap-4"
     >
-      {/* toggle + label */}
-      <div className="flex w-36 shrink-0 items-center gap-3 pt-1">
-        <Switch checked={state.enabled} onCheckedChange={setEnabled} />
-        <span className="text-sm font-medium text-foreground">{label}</span>
+      {/* toggle + label; actions ride along on mobile */}
+      <div className="flex items-center justify-between sm:w-36 sm:shrink-0 sm:justify-start sm:pt-1">
+        <div className="flex items-center gap-2.5">
+          <Switch
+            checked={state.enabled}
+            onCheckedChange={setEnabled}
+            className="scale-90"
+          />
+          <span className="text-sm font-medium text-foreground">{label}</span>
+        </div>
+        <div className="flex items-center gap-1 sm:hidden">{actions}</div>
       </div>
 
       {/* ranges or unavailable */}
@@ -118,17 +140,21 @@ export function DayRow({
                 transition={SPRING_LAYOUT}
                 className="relative flex items-center gap-2"
               >
-                <TimeSelect
-                  value={r.start}
-                  options={options}
-                  onChange={(v) => updateRange(r.id, { start: v })}
-                />
+                <div className="min-w-0 flex-1 sm:max-w-[132px]">
+                  <TimeSelect
+                    value={r.start}
+                    options={options}
+                    onChange={(v) => updateRange(r.id, { start: v })}
+                  />
+                </div>
                 <span className="text-muted-foreground">–</span>
-                <TimeSelect
-                  value={r.end}
-                  options={options}
-                  onChange={(v) => updateRange(r.id, { end: v })}
-                />
+                <div className="min-w-0 flex-1 sm:max-w-[132px]">
+                  <TimeSelect
+                    value={r.end}
+                    options={options}
+                    onChange={(v) => updateRange(r.id, { end: v })}
+                  />
+                </div>
                 <Tooltip content="Remove">
                   <IconButton
                     label="Remove time range"
@@ -148,7 +174,7 @@ export function DayRow({
               animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
               exit={reduce ? { opacity: 0 } : { opacity: 0, y: -4 }}
               transition={SPRING_LAYOUT}
-              className="py-2 text-sm text-muted-foreground"
+              className="py-1 text-sm text-muted-foreground sm:py-2"
             >
               Unavailable
             </motion.span>
@@ -156,18 +182,9 @@ export function DayRow({
         </AnimatePresence>
       </div>
 
-      {/* actions */}
-      <div className="flex shrink-0 items-center gap-1 pt-0.5">
-        <Tooltip content="Add time">
-          <IconButton
-            label={`Add time range to ${label}`}
-            reduce={reduce}
-            onClick={addRange}
-          >
-            <Plus className="h-4 w-4" />
-          </IconButton>
-        </Tooltip>
-        <CopyMenu fromLabel={label} reduce={reduce} onApply={onCopy} />
+      {/* actions (desktop) */}
+      <div className="hidden shrink-0 items-center gap-1 pt-0.5 sm:flex">
+        {actions}
       </div>
     </motion.div>
   );

--- a/components/motion/availability-scheduler/icon-button.tsx
+++ b/components/motion/availability-scheduler/icon-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { motion } from "motion/react";
+import type { ReactNode } from "react";
+import { SPRING_PRESS } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+export function IconButton({
+  onClick,
+  label,
+  disabled,
+  expanded,
+  reduce,
+  children,
+  className,
+  // Rest props let a wrapping Tooltip inject its hover/focus handlers.
+  ...rest
+}: {
+  onClick: () => void;
+  label: string;
+  disabled?: boolean;
+  expanded?: boolean;
+  reduce: boolean;
+  children: ReactNode;
+  className?: string;
+  [key: string]: unknown;
+}) {
+  return (
+    <motion.button
+      {...rest}
+      type="button"
+      aria-label={label}
+      aria-expanded={expanded}
+      onClick={onClick}
+      disabled={disabled}
+      whileTap={reduce || disabled ? undefined : { scale: 0.86 }}
+      transition={SPRING_PRESS}
+      className={cn(
+        "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-40",
+        className,
+      )}
+    >
+      {children}
+    </motion.button>
+  );
+}

--- a/components/motion/availability-scheduler/index.tsx
+++ b/components/motion/availability-scheduler/index.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { LayoutGroup, useReducedMotion } from "motion/react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { DayRow } from "./day-row";
+import {
+  type DayAvailability,
+  type DayKey,
+  WEEKDAYS,
+  type WeekAvailability,
+  buildOptions,
+  defaultWeek,
+} from "./types";
+
+export type {
+  DayAvailability,
+  DayKey,
+  TimeRange,
+  WeekAvailability,
+} from "./types";
+export { defaultWeek } from "./types";
+
+export interface AvailabilitySchedulerProps {
+  value?: WeekAvailability;
+  defaultValue?: WeekAvailability;
+  onChange?: (value: WeekAvailability) => void;
+  /** Minutes between selectable times. Default 30. */
+  step?: number;
+  className?: string;
+}
+
+export function AvailabilityScheduler({
+  value,
+  defaultValue,
+  onChange,
+  step = 30,
+  className,
+}: AvailabilitySchedulerProps) {
+  const reduce = useReducedMotion() ?? false;
+  const groupId = useId();
+  const options = useMemo(() => buildOptions(step), [step]);
+  const idRef = useRef(0);
+
+  const [internal, setInternal] = useState<WeekAvailability>(
+    () => defaultValue ?? defaultWeek(),
+  );
+  const controlled = value !== undefined;
+  const week = controlled ? value : internal;
+
+  const commit = useCallback(
+    (next: WeekAvailability) => {
+      if (!controlled) setInternal(next);
+      onChange?.(next);
+    },
+    [controlled, onChange],
+  );
+
+  const setDay = useCallback(
+    (day: DayKey, next: DayAvailability) => {
+      commit({ ...week, [day]: next });
+    },
+    [commit, week],
+  );
+
+  const copyDay = useCallback(
+    (from: DayKey, targets: DayKey[]) => {
+      const source = week[from];
+      const next = { ...week };
+      for (const t of targets) {
+        next[t] = {
+          enabled: source.enabled,
+          ranges: source.ranges.map((r) => ({
+            ...r,
+            id: `${t}-c${idRef.current++}`,
+          })),
+        };
+      }
+      commit(next);
+    },
+    [commit, week],
+  );
+
+  return (
+    <LayoutGroup id={groupId}>
+      <div className={cn("w-full max-w-xl divide-y divide-border", className)}>
+        {WEEKDAYS.map(({ key, label }, i) => (
+          <DayRow
+            key={key}
+            day={key}
+            label={label}
+            state={week[key]}
+            options={options}
+            reduce={reduce}
+            depth={WEEKDAYS.length - i}
+            onChange={(next) => setDay(key, next)}
+            onCopy={(targets) => copyDay(key, targets)}
+          />
+        ))}
+      </div>
+    </LayoutGroup>
+  );
+}

--- a/components/motion/availability-scheduler/time-select.tsx
+++ b/components/motion/availability-scheduler/time-select.tsx
@@ -21,7 +21,7 @@ export function TimeSelect({
   options: TimeOption[];
 }) {
   return (
-    <Select value={value} onValueChange={onChange} className="w-[128px]">
+    <Select value={value} onValueChange={onChange} className="w-full">
       <SelectTrigger className="tabular-nums">
         <SelectValue className="whitespace-nowrap" />
       </SelectTrigger>

--- a/components/motion/availability-scheduler/time-select.tsx
+++ b/components/motion/availability-scheduler/time-select.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/motion/select";
+import type { TimeOption } from "./types";
+
+// Time field: the library Select, with the option list capped so the panel
+// measures a small height and scrolls instead of unfolding all 48 options.
+export function TimeSelect({
+  value,
+  onChange,
+  options,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: TimeOption[];
+}) {
+  return (
+    <Select value={value} onValueChange={onChange} className="w-[128px]">
+      <SelectTrigger className="tabular-nums">
+        <SelectValue className="whitespace-nowrap" />
+      </SelectTrigger>
+      <SelectContent>
+        <div className="max-h-56 overflow-y-auto overscroll-contain">
+          {options.map((o) => (
+            <SelectItem key={o.value} value={o.value} className="tabular-nums">
+              {o.label}
+            </SelectItem>
+          ))}
+        </div>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/components/motion/availability-scheduler/types.ts
+++ b/components/motion/availability-scheduler/types.ts
@@ -1,0 +1,68 @@
+export type DayKey = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
+
+export type TimeRange = { id: string; start: string; end: string };
+export type DayAvailability = { enabled: boolean; ranges: TimeRange[] };
+export type WeekAvailability = Record<DayKey, DayAvailability>;
+export type TimeOption = { value: string; label: string };
+
+export const WEEKDAYS: { key: DayKey; label: string }[] = [
+  { key: "mon", label: "Monday" },
+  { key: "tue", label: "Tuesday" },
+  { key: "wed", label: "Wednesday" },
+  { key: "thu", label: "Thursday" },
+  { key: "fri", label: "Friday" },
+  { key: "sat", label: "Saturday" },
+  { key: "sun", label: "Sunday" },
+];
+
+// ─── time helpers ────────────────────────────────────────────────────────────
+
+export const toMinutes = (v: string) => {
+  const [h, m] = v.split(":").map(Number);
+  return h * 60 + m;
+};
+
+export const toValue = (mins: number) => {
+  const clamped = Math.max(0, Math.min(24 * 60 - 1, mins));
+  const h = Math.floor(clamped / 60);
+  const m = clamped % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+};
+
+export const label12 = (v: string) => {
+  const [h, m] = v.split(":").map(Number);
+  const ap = h < 12 ? "AM" : "PM";
+  const h12 = h % 12 === 0 ? 12 : h % 12;
+  return `${h12}:${String(m).padStart(2, "0")} ${ap}`;
+};
+
+export function buildOptions(step: number): TimeOption[] {
+  const out: TimeOption[] = [];
+  for (let m = 0; m < 24 * 60; m += step) {
+    const value = toValue(m);
+    out.push({ value, label: label12(value) });
+  }
+  return out;
+}
+
+// Default: Mon–Fri 9–5, weekend off. Fixed ids so SSR and first client render
+// agree (new ranges get counter ids afterwards).
+export function defaultWeek(): WeekAvailability {
+  const workday = (day: DayKey): DayAvailability => ({
+    enabled: true,
+    ranges: [{ id: `${day}-0`, start: "09:00", end: "17:00" }],
+  });
+  const off = (day: DayKey): DayAvailability => ({
+    enabled: false,
+    ranges: [{ id: `${day}-0`, start: "09:00", end: "17:00" }],
+  });
+  return {
+    mon: workday("mon"),
+    tue: workday("tue"),
+    wed: workday("wed"),
+    thu: workday("thu"),
+    fri: workday("fri"),
+    sat: off("sat"),
+    sun: off("sun"),
+  };
+}

--- a/components/motion/popover-morph.tsx
+++ b/components/motion/popover-morph.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  cloneElement,
+  createContext,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { SPRING_PANEL } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+type Side = "top" | "bottom";
+type Align = "start" | "end";
+
+type MorphContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+  triggerId: string;
+  contentId: string;
+};
+
+const MorphContext = createContext<MorphContextValue | null>(null);
+
+function useMorphContext(component: string) {
+  const ctx = useContext(MorphContext);
+  if (!ctx) throw new Error(`${component} must be used within <MorphPopover>`);
+  return ctx;
+}
+
+export interface MorphPopoverProps {
+  children: ReactNode;
+  /** Controlled open state. */
+  open?: boolean;
+  /** Uncontrolled initial open state. */
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+}
+
+/**
+ * A popover whose panel morphs open from the trigger corner: it's laid out at
+ * full size but clipped to the corner nearest the trigger, then unclips as one
+ * piece. Closes on outside pointer / Escape. Controlled or uncontrolled.
+ */
+export function MorphPopover({
+  children,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  className,
+}: MorphPopoverProps) {
+  const baseId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const controlled = controlledOpen !== undefined;
+  const open = controlled ? controlledOpen : internalOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!controlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [controlled, onOpenChange],
+  );
+  const toggle = useCallback(() => setOpen(!open), [setOpen, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    const onPointer = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node))
+        setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("pointerdown", onPointer);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("pointerdown", onPointer);
+    };
+  }, [open, setOpen]);
+
+  const ctx = useMemo<MorphContextValue>(
+    () => ({
+      open,
+      setOpen,
+      toggle,
+      triggerId: `${baseId}-trigger`,
+      contentId: `${baseId}-content`,
+    }),
+    [open, setOpen, toggle, baseId],
+  );
+
+  return (
+    <MorphContext.Provider value={ctx}>
+      <div ref={rootRef} className={cn("relative inline-flex", className)}>
+        {children}
+      </div>
+    </MorphContext.Provider>
+  );
+}
+
+export interface MorphPopoverTriggerProps {
+  children: ReactElement;
+}
+
+/** Wraps a single element, toggling the popover on click. */
+export function MorphPopoverTrigger({ children }: MorphPopoverTriggerProps) {
+  const ctx = useMorphContext("MorphPopoverTrigger");
+  if (!isValidElement(children)) return children;
+
+  const child = children as ReactElement<Record<string, unknown>>;
+  const childOnClick = child.props.onClick as
+    | ((e: unknown) => void)
+    | undefined;
+
+  return cloneElement(child, {
+    id: ctx.triggerId,
+    onClick: (e: unknown) => {
+      childOnClick?.(e);
+      ctx.toggle();
+    },
+    "aria-haspopup": "menu",
+    "aria-expanded": ctx.open,
+    "aria-controls": ctx.open ? ctx.contentId : undefined,
+  });
+}
+
+const originFor = (side: Side, align: Align) =>
+  `${side === "bottom" ? "top" : "bottom"} ${align === "end" ? "right" : "left"}`;
+
+// A clip that hides everything but the corner nearest the trigger, so the
+// panel appears to grow out of it. inset(top right bottom left).
+function clipHidden(side: Side, align: Align, radius: number) {
+  const top = side === "bottom" ? "0%" : "92%";
+  const bottom = side === "bottom" ? "92%" : "0%";
+  const right = align === "end" ? "0%" : "92%";
+  const left = align === "end" ? "92%" : "0%";
+  return `inset(${top} ${right} ${bottom} ${left} round ${radius}px)`;
+}
+const clipShown = (radius: number) => `inset(0% 0% 0% 0% round ${radius}px)`;
+
+export interface MorphPopoverContentProps {
+  children: ReactNode;
+  side?: Side;
+  align?: Align;
+  /** Gap between trigger and panel, in px. Default 8. */
+  sideOffset?: number;
+  /** Panel corner radius, in px. Default 16. */
+  radius?: number;
+  className?: string;
+}
+
+export function MorphPopoverContent({
+  children,
+  side = "bottom",
+  align = "end",
+  sideOffset = 8,
+  radius = 16,
+  className,
+}: MorphPopoverContentProps) {
+  const ctx = useMorphContext("MorphPopoverContent");
+  const reduce = useReducedMotion() ?? false;
+
+  const posClass = cn(
+    side === "bottom" ? "top-full" : "bottom-full",
+    align === "end" ? "right-0" : "left-0",
+  );
+  const marginStyle =
+    side === "bottom" ? { marginTop: sideOffset } : { marginBottom: sideOffset };
+
+  // Close animates with the same spring as open, so it morphs back to the
+  // corner instead of snapping shut.
+  const wrap = reduce
+    ? undefined
+    : {
+        hidden: { opacity: 0, scale: 0.96 },
+        show: { opacity: 1, scale: 1, transition: SPRING_PANEL },
+        exit: { opacity: 0, scale: 0.96, transition: SPRING_PANEL },
+      };
+  const clip = reduce
+    ? undefined
+    : {
+        hidden: { clipPath: clipHidden(side, align, radius) },
+        show: { clipPath: clipShown(radius), transition: SPRING_PANEL },
+        exit: { clipPath: clipHidden(side, align, radius), transition: SPRING_PANEL },
+      };
+
+  return (
+    <AnimatePresence>
+      {ctx.open ? (
+        <motion.div
+          // Wrapper carries the shadow as a drop-shadow filter, which hugs the
+          // clipped shape below (box-shadow would just get clipped away).
+          variants={wrap}
+          initial={reduce ? { opacity: 0 } : "hidden"}
+          animate={reduce ? { opacity: 1 } : "show"}
+          exit={reduce ? { opacity: 0 } : "exit"}
+          transition={reduce ? { duration: 0.12 } : undefined}
+          style={{ transformOrigin: originFor(side, align), ...marginStyle }}
+          className={cn(
+            "absolute z-30 [filter:drop-shadow(0_10px_18px_rgba(0,0,0,0.14))]",
+            posClass,
+          )}
+        >
+          <motion.div
+            id={ctx.contentId}
+            variants={clip}
+            style={{ borderRadius: radius }}
+            className={cn(
+              "overflow-hidden border border-border bg-background",
+              className,
+            )}
+          >
+            {children}
+          </motion.div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/components/motion/popover.tsx
+++ b/components/motion/popover.tsx
@@ -29,7 +29,11 @@ type Side = "top" | "bottom";
 type Align = "start" | "center" | "end";
 type TriggerMode = "click" | "hover";
 
-const GOO_SPRING = { type: "spring", visualDuration: 0.32, bounce: 0.28 } as const;
+const GOO_SPRING = {
+  type: "spring",
+  visualDuration: 0.32,
+  bounce: 0.28,
+} as const;
 const HOVER_CLOSE_DELAY = 120;
 
 const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
@@ -401,7 +405,17 @@ export function PopoverContent({ children, className }: PopoverContentProps) {
   }, [triggerRef]);
 
   const geo = useMemo(
-    () => buildGeo(sizes.tW, sizes.tH, sizes.cW, sizes.cH, side, align, gap, panelRadius),
+    () =>
+      buildGeo(
+        sizes.tW,
+        sizes.tH,
+        sizes.cW,
+        sizes.cH,
+        side,
+        align,
+        gap,
+        panelRadius,
+      ),
     [sizes, side, align, gap, panelRadius],
   );
   geoRef.current = geo;
@@ -430,11 +444,20 @@ export function PopoverContent({ children, className }: PopoverContentProps) {
     <>
       {/* Goo filter: blur, sharpen the alpha back into solid shapes, then lay
           the crisp original on top so blobs merge with liquid edges. */}
-      <svg aria-hidden width="0" height="0" className="pointer-events-none absolute">
+      <svg
+        aria-hidden
+        width="0"
+        height="0"
+        className="pointer-events-none absolute"
+      >
         <title>Popover goo filter</title>
         <defs>
           <filter id={gooId} x="-50%" y="-50%" width="200%" height="200%">
-            <feGaussianBlur in="SourceGraphic" stdDeviation={gooStrength} result="blur" />
+            <feGaussianBlur
+              in="SourceGraphic"
+              stdDeviation={gooStrength}
+              result="blur"
+            />
             <feColorMatrix
               in="blur"
               mode="matrix"
@@ -479,7 +502,12 @@ export function PopoverContent({ children, className }: PopoverContentProps) {
           shadows the trigger; the open panel re-enables its own. */}
       <div
         className="pointer-events-none absolute z-10"
-        style={{ left: geo.left, top: geo.top, width: geo.layerW, height: geo.layerH }}
+        style={{
+          left: geo.left,
+          top: geo.top,
+          width: geo.layerW,
+          height: geo.layerH,
+        }}
       >
         <div
           ref={clipRef}

--- a/components/motion/tooltip.tsx
+++ b/components/motion/tooltip.tsx
@@ -1,15 +1,24 @@
 "use client";
 
-import { AnimatePresence, motion, useReducedMotion, type Variants } from "motion/react";
+import {
+  AnimatePresence,
+  motion,
+  useReducedMotion,
+  type Variants,
+} from "motion/react";
 import {
   cloneElement,
   isValidElement,
-  useId,
-  useRef,
-  useState,
   type ReactElement,
   type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { EASE_OUT } from "@/lib/ease";
 import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
 import { cn } from "@/lib/utils";
@@ -27,11 +36,15 @@ export interface TooltipProps {
   wrapperClassName?: string;
 }
 
-const wrapperClasses: Record<Side, string> = {
-  top: "bottom-full left-1/2 mb-2 -translate-x-1/2",
-  bottom: "top-full left-1/2 mt-2 -translate-x-1/2",
-  left: "right-full top-1/2 mr-2 -translate-y-1/2",
-  right: "left-full top-1/2 ml-2 -translate-y-1/2",
+// Gap between trigger and tooltip, in px.
+const GAP = 8;
+
+// Centering transform for the fixed-positioned anchor point, per side.
+const anchorTransform: Record<Side, string> = {
+  top: "translate(-50%, -100%)",
+  bottom: "translate(-50%, 0)",
+  left: "translate(-100%, -50%)",
+  right: "translate(0, -50%)",
 };
 
 const transformOrigin: Record<Side, string> = {
@@ -44,10 +57,10 @@ const transformOrigin: Record<Side, string> = {
 // Offset is in the direction *away* from the trigger — content originates near
 // the trigger and rises into resting position.
 const offsetFrom: Record<Side, { x?: number; y?: number }> = {
-  top: { y: 10 },
-  bottom: { y: -10 },
-  left: { x: 10 },
-  right: { x: -10 },
+  top: { y: 8 },
+  bottom: { y: -8 },
+  left: { x: 8 },
+  right: { x: -8 },
 };
 
 function buildVariants(side: Side): Variants {
@@ -55,8 +68,8 @@ function buildVariants(side: Side): Variants {
   return {
     initial: {
       opacity: 0,
-      scale: 0.85,
-      filter: "blur(10px)",
+      scale: 0.9,
+      filter: "blur(5px)",
       x: o.x ?? 0,
       y: o.y ?? 0,
     },
@@ -71,17 +84,17 @@ function buildVariants(side: Side): Variants {
         stiffness: 380,
         damping: 30,
         mass: 0.7,
-        opacity: { duration: 0.22, ease: EASE_OUT },
-        filter: { duration: 0.3, ease: EASE_OUT },
+        opacity: { duration: 0.14, ease: EASE_OUT },
+        filter: { duration: 0.18, ease: EASE_OUT },
       },
     },
     exit: {
       opacity: 0,
-      scale: 0.92,
-      filter: "blur(6px)",
+      scale: 0.94,
+      filter: "blur(3px)",
       x: (o.x ?? 0) * 0.6,
       y: (o.y ?? 0) * 0.6,
-      transition: { duration: 0.14, ease: EASE_OUT },
+      transition: { duration: 0.12, ease: EASE_OUT },
     },
   };
 }
@@ -97,67 +110,142 @@ const REDUCED_VARIANTS: Variants = {
 const WARM_WINDOW_MS = 300;
 let lastHiddenAt = 0;
 
-export function Tooltip({ content, children, side = "top", delay = 120, className, wrapperClassName }: TooltipProps) {
+export function Tooltip({
+  content,
+  children,
+  side = "top",
+  delay = 120,
+  className,
+  wrapperClassName,
+}: TooltipProps) {
   const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(
+    null,
+  );
   const id = useId();
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const anchorRef = useRef<HTMLSpanElement>(null);
   const reduce = useReducedMotion();
   const canHover = useHoverCapable();
 
-  const show = () => {
+  // Anchor point in viewport coords, on the edge of the trigger facing `side`.
+  // Position:fixed means these viewport coords place the tooltip directly, so
+  // it escapes every ancestor's stacking context and overflow.
+  const place = useCallback(() => {
+    const el = anchorRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const cx = r.left + r.width / 2;
+    const cy = r.top + r.height / 2;
+    const point: Record<Side, { top: number; left: number }> = {
+      top: { top: r.top - GAP, left: cx },
+      bottom: { top: r.bottom + GAP, left: cx },
+      left: { top: cy, left: r.left - GAP },
+      right: { top: cy, left: r.right + GAP },
+    };
+    setCoords(point[side]);
+  }, [side]);
+
+  const show = useCallback(() => {
     if (!canHover) return;
     if (timer.current) clearTimeout(timer.current);
     const warm = Date.now() - lastHiddenAt < WARM_WINDOW_MS;
-    timer.current = setTimeout(() => setOpen(true), warm ? 0 : delay);
-  };
-  const hide = () => {
+    timer.current = setTimeout(
+      () => {
+        place();
+        setOpen(true);
+      },
+      warm ? 0 : delay,
+    );
+  }, [canHover, delay, place]);
+
+  const hide = useCallback(() => {
     if (timer.current) {
       clearTimeout(timer.current);
       timer.current = null;
     }
-    if (open) lastHiddenAt = Date.now();
-    setOpen(false);
-  };
+    setOpen((wasOpen) => {
+      if (wasOpen) lastHiddenAt = Date.now();
+      return false;
+    });
+  }, []);
+
+  // Keep the tooltip pinned to the trigger while it's open and the page scrolls
+  // or resizes (fixed coords are viewport-relative).
+  useEffect(() => {
+    if (!open) return;
+    const onMove = () => place();
+    window.addEventListener("scroll", onMove, true);
+    window.addEventListener("resize", onMove);
+    return () => {
+      window.removeEventListener("scroll", onMove, true);
+      window.removeEventListener("resize", onMove);
+    };
+  }, [open, place]);
+
+  const variants = useMemo(
+    () => (reduce ? REDUCED_VARIANTS : buildVariants(side)),
+    [reduce, side],
+  );
 
   if (!isValidElement(children)) return children;
 
-  const trigger = cloneElement(children as ReactElement<Record<string, unknown>>, {
-    onMouseEnter: show,
-    onMouseLeave: hide,
-    onFocus: show,
-    onBlur: hide,
-    "aria-describedby": id,
-  });
-
-  const variants = reduce ? REDUCED_VARIANTS : buildVariants(side);
+  const trigger = cloneElement(
+    children as ReactElement<Record<string, unknown>>,
+    {
+      onMouseEnter: show,
+      onMouseLeave: hide,
+      onFocus: show,
+      onBlur: hide,
+      "aria-describedby": id,
+    },
+  );
 
   return (
-    <span className={cn("relative inline-flex align-middle", wrapperClassName)}>
-      {trigger}
-      <AnimatePresence mode="wait">
-        {open ? (
-          <span className={cn("pointer-events-none absolute z-50", wrapperClasses[side])}>
-            <motion.span
-              id={id}
-              role="tooltip"
-              variants={variants}
-              initial="initial"
-              animate="animate"
-              exit="exit"
-              style={{
-                transformOrigin: transformOrigin[side],
-                willChange: "transform, opacity, filter",
-              }}
-              className={cn(
-                "block whitespace-nowrap rounded-lg border border-border bg-popover/85 px-2.5 py-1 text-xs font-medium text-popover-foreground shadow-2xl backdrop-blur-xl",
-                className,
-              )}
-            >
-              {content}
-            </motion.span>
-          </span>
-        ) : null}
-      </AnimatePresence>
-    </span>
+    <>
+      <span
+        ref={anchorRef}
+        className={cn("relative inline-flex align-middle", wrapperClassName)}
+      >
+        {trigger}
+      </span>
+      {typeof document !== "undefined"
+        ? createPortal(
+            <AnimatePresence>
+              {open && coords ? (
+                <span
+                  aria-hidden
+                  className="pointer-events-none fixed z-[9999]"
+                  style={{
+                    top: coords.top,
+                    left: coords.left,
+                    transform: anchorTransform[side],
+                  }}
+                >
+                  <motion.span
+                    id={id}
+                    role="tooltip"
+                    variants={variants}
+                    initial="initial"
+                    animate="animate"
+                    exit="exit"
+                    style={{
+                      transformOrigin: transformOrigin[side],
+                      willChange: "transform, opacity",
+                    }}
+                    className={cn(
+                      "block whitespace-nowrap rounded-lg border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground shadow-lg",
+                      className,
+                    )}
+                  >
+                    {content}
+                  </motion.span>
+                </span>
+              ) : null}
+            </AnimatePresence>,
+            document.body,
+          )
+        : null}
+    </>
   );
 }

--- a/components/previews/blocks/availability-scheduler.preview.tsx
+++ b/components/previews/blocks/availability-scheduler.preview.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { AvailabilityScheduler } from "@/components/motion/availability-scheduler";
+
+export function AvailabilitySchedulerPreview() {
+  return (
+    <div className="flex w-full justify-center">
+      <AvailabilityScheduler />
+    </div>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -42,6 +42,11 @@ export const previews: Record<string, ComponentType> = {
   "blocks/wallet-card": dynamic(() =>
     import("./blocks/wallet-card.preview").then((m) => m.WalletCardPreview),
   ),
+  "blocks/availability-scheduler": dynamic(() =>
+    import("./blocks/availability-scheduler.preview").then(
+      (m) => m.AvailabilitySchedulerPreview,
+    ),
+  ),
   "motion/table": dynamic(() =>
     import("./motion/table.preview").then((m) => m.TablePreview),
   ),
@@ -153,6 +158,9 @@ export const previews: Record<string, ComponentType> = {
   ),
   "motion/popover": dynamic(() =>
     import("./motion/popover.preview").then((m) => m.PopoverPreview),
+  ),
+  "motion/popover-morph": dynamic(() =>
+    import("./motion/popover-morph.preview").then((m) => m.MorphPopoverPreview),
   ),
   "motion/morphing-modal": dynamic(() =>
     import("./motion/morphing-modal.preview").then((m) => m.MorphingModalPreview),

--- a/components/previews/motion/popover-morph.preview.tsx
+++ b/components/previews/motion/popover-morph.preview.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { ChevronDown, Copy, Pencil, Share2, Trash2 } from "lucide-react";
+import { useState } from "react";
+import {
+  MorphPopover,
+  MorphPopoverContent,
+  MorphPopoverTrigger,
+} from "@/components/motion/popover-morph";
+
+const ACTIONS = [
+  { icon: Pencil, label: "Edit" },
+  { icon: Copy, label: "Duplicate" },
+  { icon: Share2, label: "Share" },
+  { icon: Trash2, label: "Delete" },
+];
+
+export function MorphPopoverPreview() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <MorphPopover open={open} onOpenChange={setOpen}>
+      <MorphPopoverTrigger>
+        <button
+          type="button"
+          className="inline-flex h-10 items-center gap-2 rounded-xl border border-border bg-background px-4 text-sm font-medium text-foreground outline-none transition-colors hover:border-border-strong focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Options
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        </button>
+      </MorphPopoverTrigger>
+
+      <MorphPopoverContent align="start" className="w-48 p-1.5">
+        {ACTIONS.map(({ icon: Icon, label }) => (
+          <button
+            key={label}
+            type="button"
+            onClick={() => setOpen(false)}
+            className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm text-foreground outline-none transition-colors hover:bg-muted focus-visible:bg-muted"
+          >
+            <Icon className="h-4 w-4 text-muted-foreground" />
+            {label}
+          </button>
+        ))}
+      </MorphPopoverContent>
+    </MorphPopover>
+  );
+}

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -193,7 +193,7 @@ export const registry: CategoryEntry[] = [
         slug: "popover",
         name: "Popover",
         description:
-          "Gooey popover whose panel oozes out of the trigger through an SVG goo filter — a liquid neck that stretches and pinches — with crisp content fading in on top. Click or hover trigger, controlled or uncontrolled.",
+          "Gooey popover whose panel oozes out of the trigger through an SVG goo filter — a liquid neck that stretches and pinches — with crisp content fading in on top, plus a Morph variant that clip-morphs open from the trigger corner. Click or hover trigger, controlled or uncontrolled.",
         file: "components/motion/popover.tsx",
         badge: "new",
         launchedAt: "2026-07-07",
@@ -204,6 +204,30 @@ export const registry: CategoryEntry[] = [
           "svg goo filter",
           "metaball popover",
           "hover popover react",
+          "morph popover react",
+          "dropdown menu react",
+        ],
+        examples: [
+          {
+            slug: "gooey",
+            name: "Popover",
+            description:
+              "Composable Popover, PopoverTrigger, PopoverContent; the panel oozes out of the trigger through an SVG goo filter with a liquid neck, crisp content fading in on top. Click or hover, controlled or uncontrolled.",
+            installSlug: "popover",
+            file: "components/motion/popover.tsx",
+            previewKey: "motion/popover",
+            previewFile: "components/previews/motion/popover.preview.tsx",
+          },
+          {
+            slug: "morph",
+            name: "Morph Popover",
+            description:
+              "Composable MorphPopover, MorphPopoverTrigger, MorphPopoverContent; the panel is laid out full size but clipped to the corner nearest the trigger, then unclips as one piece — a single-surface morph with a drop-shadow that hugs the shape. Side/align aware, controlled or uncontrolled.",
+            installSlug: "popover-morph",
+            file: "components/motion/popover-morph.tsx",
+            previewKey: "motion/popover-morph",
+            previewFile: "components/previews/motion/popover-morph.preview.tsx",
+          },
         ],
       },
       {
@@ -533,6 +557,22 @@ export const registry: CategoryEntry[] = [
     name: "Blocks",
     description: "Composed, product-ready widgets built from beUI motion primitives.",
     components: [
+      {
+        slug: "availability-scheduler",
+        name: "Availability Scheduler",
+        description: "Weekly availability editor where each day springs between available and unavailable, time ranges add and remove with blur-slide motion, times pick from a scrollable dropdown, and a copy menu clones hours to other days.",
+        file: "components/motion/availability-scheduler/index.tsx",
+        badge: "new",
+        launchedAt: "2026-07-10",
+        keywords: [
+          "availability scheduler react",
+          "weekly hours picker react",
+          "working hours component",
+          "cal.com availability component",
+          "time range picker react",
+          "business hours editor",
+        ],
+      },
       {
         slug: "swap",
         name: "Multi-chain Swap",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -210,7 +210,7 @@ export const registry: CategoryEntry[] = [
         examples: [
           {
             slug: "gooey",
-            name: "Popover",
+            name: "Gooey Popover",
             description:
               "Composable Popover, PopoverTrigger, PopoverContent; the panel oozes out of the trigger through an SVG goo filter with a liquid neck, crisp content fading in on top. Click or hover, controlled or uncontrolled.",
             installSlug: "popover",


### PR DESCRIPTION
Weekly availability editor (cal.com-style), built in beUI's own style.

## Block — Availability Scheduler (`blocks`)
- Per-day spring toggle (Switch); flipping off springs the row to "Unavailable".
- Time ranges add/remove with blur-slide + layout reflow (`AnimatePresence` + `SPRING_LAYOUT`).
- Times pick from the library `Select` (scrollable list).
- Copy menu clones a day's hours to selected days / every day, with a copy→check confirmation.
- Controlled + uncontrolled, reduced-motion safe.
- Split into `components/motion/availability-scheduler/` (`types`, `icon-button`, `time-select`, `copy-menu`, `day-row`, `index`).
- Mobile: rows stack (header + actions, ranges below), time selects go fluid.

## Popover — Morph variant
- New `MorphPopover` / `MorphPopoverTrigger` / `MorphPopoverContent` (`components/motion/popover-morph.tsx`), installs as `@beui/popover-morph`.
- Panel is laid out full size but clipped to the corner nearest the trigger, then unclips as one piece; a `drop-shadow` filter hugs the clipped shape (box-shadow gets clipped). Open + close use the same spring.
- Registered as a `popover` variant alongside the renamed **Gooey Popover**.

## Tooltip
- Renders through a portal at fixed viewport coords, so it escapes row stacking contexts instead of being painted over.
- Dropped `backdrop-blur` for a solid surface; kept the motion (filter) blur; memoized variants.

## Misc
- Example preview stage no longer has a `bg-card` box (matches the single-preview stage), so goo/morph panels contrast instead of blending.

`bun run check` passes (typecheck, lint, registry — 45 components).