### PR TITLE
feat: add AI-friendly component markdown

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -21,11 +21,13 @@ import {
 } from "@/components/motion/tabs";
 import { NewBadge } from "@/components/app/docs/new-badge";
 import { ComponentCard } from "@/components/app/docs/component-card";
+import { CopyPage } from "@/components/app/docs/copy-page";
 import { JsonLd } from "@/components/app/analytics/json-ld";
 import { getPreview, previews } from "@/components/previews";
 import { pageUrlFor, withSignature } from "@/lib/signature";
 import { readSourceFile } from "@/lib/source-files";
 import { getComponentProps } from "@/lib/props-extractor";
+import { componentDates } from "@/lib/component-dates";
 import {
   breadcrumbJsonLd,
   componentJsonLd,
@@ -134,6 +136,7 @@ export default async function ComponentPage({
   if (!cat || !comp) notFound();
   const hasVariantInstallCommands =
     comp.examples?.some((example) => example.installSlug) ?? false;
+  const dates = componentDates(cat.slug, comp.slug);
   const related = relatedComponents(cat.slug, comp.slug, 3);
   const propsDocs = comp.examples?.length ? [] : getComponentProps(comp.file);
   const variantNavItems: PageNavItem[] =
@@ -205,14 +208,30 @@ export default async function ComponentPage({
             <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
             <span className="font-medium text-foreground">{comp.name}</span>
           </nav>
-          <div className="mt-4 flex items-center gap-3">
-            <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-              {comp.name}
-            </h1>
-            {comp.badge === "new" ? <NewBadge className="mt-1" /> : null}
+          <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-center gap-3">
+              <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+                {comp.name}
+              </h1>
+              {comp.badge === "new" ? <NewBadge className="mt-1" /> : null}
+            </div>
+            <CopyPage
+              pageUrl={pageUrlFor(cat.slug, comp.slug)}
+              markdownPath={`/components/${cat.slug}/${comp.slug}.md`}
+              componentName={comp.name}
+            />
           </div>
           <p className="mt-2 max-w-2xl text-muted-foreground">
             {comp.description}
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Updated{" "}
+            <time dateTime={dates.updatedAt}>
+              {new Intl.DateTimeFormat("en", {
+                dateStyle: "medium",
+                timeZone: "UTC",
+              }).format(new Date(`${dates.updatedAt}T00:00:00Z`))}
+            </time>
           </p>
         </div>
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -14,11 +14,12 @@ export async function GET() {
   lines.push(`- Registry index (JSON): ${idx.endpoints.index}`);
   lines.push(`- Component detail (JSON): ${idx.endpoints.detail}`);
   lines.push(`- Raw source (text/plain): ${idx.endpoints.raw}`);
+  lines.push(`- Component Markdown: ${idx.endpoints.markdown}`);
   lines.push("");
   lines.push("## Components");
   lines.push("");
   for (const c of idx.components) {
-    lines.push(`- [${c.name}](${c.detail_url}): ${c.description}`);
+    lines.push(`- [${c.name}](${c.markdown_url}): ${c.description}`);
   }
   lines.push("");
   lines.push("## Usage for agents");

--- a/app/r/[slug]/route.ts
+++ b/app/r/[slug]/route.ts
@@ -1,24 +1,48 @@
 import { NextResponse } from "next/server";
-import { allRegistryTargets, allShadcnTargets, buildEntry, buildShadcnItem, findCategoryBySlug } from "@/lib/registry-server";
+import { buildComponentMarkdown } from "@/lib/component-markdown";
+import { allRegistryTargets, allShadcnTargets, buildEntry, buildShadcnItem, findCategoryBySlug, findRegistryTarget } from "@/lib/registry-server";
 
 export const dynamic = "force-static";
 
 export function generateStaticParams() {
   return [
     ...allRegistryTargets().map((component) => ({ slug: component.slug })),
+    ...allRegistryTargets().map((component) => ({ slug: `${component.slug}.md` })),
     ...allShadcnTargets().map((component) => ({ slug: `${component.slug}.json` })),
   ];
 }
 
 export async function GET(
-  _req: Request,
+  req: Request,
   ctx: { params: Promise<{ slug: string }> },
 ) {
   const { slug } = await ctx.params;
+  const isMarkdown = slug.endsWith(".md");
   const isShadcnItem = slug.endsWith(".json");
-  const componentSlug = isShadcnItem ? slug.replace(/\.json$/, "") : slug;
+  const componentSlug = slug.replace(/\.(?:json|md)$/, "");
   const cat = findCategoryBySlug(componentSlug);
   if (!cat) return NextResponse.json({ error: "not_found" }, { status: 404 });
+
+  if (isMarkdown) {
+    const target = findRegistryTarget(componentSlug);
+    if (!target) return new Response("not_found", { status: 404 });
+    const requestedCategory = new URL(req.url).searchParams.get("category");
+    if (requestedCategory && requestedCategory !== cat.slug) {
+      return new Response("not_found", { status: 404 });
+    }
+    const markdown = await buildComponentMarkdown(cat.slug, target.pageSlug);
+    if (!markdown) return new Response("not_found", { status: 404 });
+    return new Response(markdown, {
+      headers: {
+        "content-type": "text/markdown; charset=utf-8",
+        "cache-control": "public, max-age=300, s-maxage=3600",
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, OPTIONS",
+        "x-robots-tag": "noindex",
+        link: `<${target.pageSlug === componentSlug ? `/components/${cat.slug}/${componentSlug}` : `/components/${cat.slug}/${target.pageSlug}`}>; rel="canonical"; type="text/html"`,
+      },
+    });
+  }
 
   if (isShadcnItem) {
     const item = await buildShadcnItem(cat.slug, componentSlug);
@@ -40,7 +64,7 @@ export async function GET(
       "cache-control": "public, max-age=300, s-maxage=3600",
       "access-control-allow-origin": "*",
       "access-control-allow-methods": "GET, OPTIONS",
-      "link": `</r/${slug}/raw>; rel="alternate"; type="text/plain", </llms.txt>; rel="describedby"; type="text/plain"`,
+      "link": `</r/${slug}/raw>; rel="alternate"; type="text/plain", </components/${cat.slug}/${componentSlug}.md>; rel="alternate"; type="text/markdown", </llms.txt>; rel="describedby"; type="text/plain"`,
     },
   });
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -2,6 +2,12 @@ import type { MetadataRoute } from "next";
 import { SITE_URL as SITE } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
+  const searchCrawlerRule = (userAgent: string) => ({
+    userAgent,
+    allow: ["/", "/api/og"],
+    disallow: ["/api/"],
+  });
+
   return {
     rules: [
       {
@@ -14,6 +20,8 @@ export default function robots(): MetadataRoute.Robots {
         // crawlable so bots can read its X-Robots-Tag: noindex directive.
         disallow: ["/api/"],
       },
+      searchCrawlerRule("OAI-SearchBot"),
+      searchCrawlerRule("ChatGPT-User"),
     ],
     sitemap: `${SITE}/sitemap.xml`,
     host: SITE,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,29 +1,40 @@
 import type { MetadataRoute } from "next";
 import { allComponents, registry } from "@/lib/registry";
+import { componentDates } from "@/lib/component-dates";
 import { SITE_URL as SITE } from "@/lib/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const now = new Date();
+  const components = allComponents();
+  const newestComponentDate = components
+    .map((component) => componentDates(component.category.slug, component.slug).updatedAt)
+    .sort()
+    .at(-1);
   const staticPages: MetadataRoute.Sitemap = [
-    { url: `${SITE}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
-    { url: `${SITE}/docs/ai-agents`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${SITE}/docs/motion-patterns`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${SITE}/docs/theme`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
-    { url: `${SITE}/llms.txt`, lastModified: now, changeFrequency: "weekly", priority: 0.5 },
+    { url: `${SITE}/`, lastModified: newestComponentDate, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE}/docs/ai-agents`, lastModified: "2026-07-04", changeFrequency: "monthly", priority: 0.7 },
+    { url: `${SITE}/docs/motion-patterns`, lastModified: "2026-07-09", changeFrequency: "monthly", priority: 0.7 },
+    { url: `${SITE}/docs/theme`, lastModified: "2026-07-04", changeFrequency: "monthly", priority: 0.6 },
+    { url: `${SITE}/llms.txt`, lastModified: newestComponentDate, changeFrequency: "weekly", priority: 0.5 },
   ];
 
-  const categoryPages: MetadataRoute.Sitemap = registry.map((c) => ({
-    url: `${SITE}/components/${c.slug}`,
-    lastModified: now,
-    changeFrequency: "weekly",
-    priority: 0.8,
-  }));
+  const categoryPages: MetadataRoute.Sitemap = registry.map((category) => {
+    const lastModified = category.components
+      .map((component) => componentDates(category.slug, component.slug).updatedAt)
+      .sort()
+      .at(-1);
+    return {
+      url: `${SITE}/components/${category.slug}`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    };
+  });
 
   // Component detail pages are the primary content. Machine endpoints
   // (/r/* JSON and raw text) are intentionally excluded from search.
-  const componentPages: MetadataRoute.Sitemap = allComponents().map((c) => ({
+  const componentPages: MetadataRoute.Sitemap = components.map((c) => ({
     url: `${SITE}/components/${c.category.slug}/${c.slug}`,
-    lastModified: now,
+    lastModified: componentDates(c.category.slug, c.slug).updatedAt,
     changeFrequency: "weekly",
     priority: 0.7,
   }));

--- a/components/app/docs/copy-page.tsx
+++ b/components/app/docs/copy-page.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { Check, ChevronDown, Copy, FileDown, LoaderCircle, TriangleAlert } from "lucide-react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import {
+  MorphPopover,
+  MorphPopoverContent,
+  MorphPopoverTrigger,
+} from "@/components/motion/popover-morph";
+import { trackEvent } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+
+type CopyState = "idle" | "copying" | "copied" | "error";
+
+function V0Icon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 147 70"
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M56 50.203V14h14v46.156C70 65.593 65.593 70 60.156 70c-2.596 0-5.158-1-7-2.843L0 14h19.797L56 50.203ZM147 56h-14V23.953L100.953 56H133v14H96.687C85.814 70 77 61.186 77 50.312V14h14v32.156L123.156 14H91V0h36.312C138.186 0 147 8.814 147 19.688V56Z" />
+    </svg>
+  );
+}
+
+function ChatGPTIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
+      <path
+        d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08-4.778 2.758a.795.795 0 0 0-.393.681zm1.097-2.365 2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function ClaudeIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
+      <path
+        d="m4.714 15.956 4.718-2.648.079-.23-.08-.128h-.23l-.79-.048-2.695-.073-2.337-.097-2.265-.122-.57-.121-.535-.704.055-.353.48-.321.685.06 1.518.104 2.277.157 1.651.098 2.447.255h.389l.054-.158-.133-.097-.103-.098-2.356-1.596-2.55-1.688-1.336-.972-.722-.491L2 6.223l-.158-1.008.655-.722.88.06.225.061.893.686 1.906 1.476 2.49 1.833.364.304.146-.104.018-.072-.164-.274-1.354-2.446-1.445-2.49-.644-1.032-.17-.619a2.972 2.972 0 0 1-.103-.729L6.287.133 6.7 0l.995.134.42.364.619 1.415L9.735 4.14l1.555 3.03.455.898.243.832.09.255h.159V9.01l.127-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.583.28.48.685-.067.444-.286 1.851-.558 2.903-.365 1.942h.213l.243-.242.983-1.306 1.652-2.064.728-.82.85-.904.547-.431h1.032l.759 1.129-.34 1.166-1.063 1.347-.88 1.142-1.263 1.7-.79 1.36.074.11.188-.02 2.853-.606 1.542-.28 1.84-.315.832.388.09.395-.327.807-1.967.486-2.307.462-3.436.813-.043.03.049.061 1.548.146.662.036h1.62l3.018.225.79.522.473.638-.08.485-1.213.62-1.64-.389-3.825-.91-1.31-.329h-.183v.11l1.093 1.068 2.003 1.81 2.508 2.33.127.578-.321.455-.34-.049-2.204-1.657-.85-.747-1.925-1.62h-.127v.17l.443.649 2.343 3.521.122 1.08-.17.353-.607.213-.668-.122-1.372-1.924-1.415-2.168-1.141-1.943-.14.08-.674 7.254-.316.37-.728.28-.607-.461-.322-.747.322-1.476.388-1.924.316-1.53.285-1.9.17-.632-.012-.042-.14.018-1.432 1.967-2.18 2.945-1.724 1.845-.413.164-.716-.37.066-.662.401-.589 2.386-3.036 1.439-1.882.929-1.086-.006-.158h-.055L4.138 18.56l-1.13.146-.485-.456.06-.746.231-.243 1.907-1.312Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function promptUrl(baseUrl: string, pageUrl: string) {
+  const prompt = `I'm looking at this beUI component documentation: ${pageUrl}.
+Help me understand how to use it. Be ready to explain the API, give examples, or help debug an implementation based on it.`;
+  return `${baseUrl}?q=${encodeURIComponent(prompt)}`;
+}
+
+const actionClassName =
+  "flex min-h-10 w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-foreground outline-none transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:ring-2 focus-visible:ring-ring";
+
+export function CopyPage({
+  pageUrl,
+  markdownPath,
+  componentName,
+}: {
+  pageUrl: string;
+  markdownPath: string;
+  componentName: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const resetTimer = useRef<number | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const wasOpen = useRef(false);
+
+  useEffect(() => {
+    if (wasOpen.current && !open && menuRef.current?.contains(document.activeElement)) {
+      triggerRef.current?.focus();
+    }
+    wasOpen.current = open;
+  }, [open]);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current) window.clearTimeout(resetTimer.current);
+    },
+    [],
+  );
+
+  const resetLater = () => {
+    if (resetTimer.current) window.clearTimeout(resetTimer.current);
+    resetTimer.current = window.setTimeout(() => setCopyState("idle"), 1800);
+  };
+
+  const copyMarkdown = async () => {
+    setCopyState("copying");
+    try {
+      const response = await fetch(markdownPath);
+      if (!response.ok) throw new Error(`Markdown request failed: ${response.status}`);
+      const markdown = await response.text();
+      await navigator.clipboard.writeText(markdown);
+      setCopyState("copied");
+      trackEvent("copy_component_page", {
+        label: componentName,
+        chars: markdown.length,
+      });
+    } catch {
+      setCopyState("error");
+    }
+    resetLater();
+  };
+
+  const focusMenuItem = (edge: "first" | "last") => {
+    setOpen(true);
+    window.setTimeout(() => {
+      const items = menuRef.current?.querySelectorAll<HTMLAnchorElement>("a");
+      items?.[edge === "first" ? 0 : items.length - 1]?.focus();
+    });
+  };
+
+  const handleMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!menuRef.current || !["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+      return;
+    }
+    const items = Array.from(menuRef.current.querySelectorAll<HTMLAnchorElement>("a"));
+    if (!items.length) return;
+    event.preventDefault();
+    const current = items.indexOf(document.activeElement as HTMLAnchorElement);
+    if (event.key === "Home") items[0]?.focus();
+    else if (event.key === "End") items.at(-1)?.focus();
+    else if (event.key === "ArrowDown") items[(current + 1) % items.length]?.focus();
+    else items[(current - 1 + items.length) % items.length]?.focus();
+  };
+
+  const actions = [
+    {
+      label: "View as Markdown",
+      href: markdownPath,
+      icon: <FileDown className="h-4 w-4" aria-hidden="true" />,
+    },
+    {
+      label: "Open in v0",
+      href: promptUrl("https://v0.dev", pageUrl),
+      icon: <V0Icon className="h-4 w-4" />,
+    },
+    {
+      label: "Open in ChatGPT",
+      href: promptUrl("https://chatgpt.com", pageUrl),
+      icon: <ChatGPTIcon className="h-4 w-4" />,
+    },
+    {
+      label: "Open in Claude",
+      href: promptUrl("https://claude.ai/new", pageUrl),
+      icon: <ClaudeIcon className="h-4 w-4" />,
+    },
+  ];
+
+  const copyLabel =
+    copyState === "error" ? "Try again" : "Copy Page";
+  const copyAriaLabel =
+    copyState === "copied"
+      ? "Page copied"
+      : copyState === "error"
+        ? "Copy failed. Try again"
+        : "Copy page as Markdown";
+
+  return (
+    <MorphPopover
+      open={open}
+      onOpenChange={setOpen}
+      className="hidden sm:inline-flex"
+    >
+      <div className="inline-flex rounded-lg bg-muted/70">
+        <button
+          type="button"
+          onClick={copyMarkdown}
+          disabled={copyState === "copying"}
+          aria-busy={copyState === "copying"}
+          aria-label={copyAriaLabel}
+          className="inline-flex min-h-10 items-center gap-2 rounded-l-lg px-3 text-sm font-medium text-foreground outline-none transition-colors hover:bg-muted focus-visible:relative focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-wait sm:min-h-8 sm:px-2.5 sm:text-xs"
+        >
+          {copyState === "copying" ? (
+            <LoaderCircle className="h-3.5 w-3.5 motion-safe:animate-spin" aria-hidden="true" />
+          ) : copyState === "copied" ? (
+            <Check className="h-3.5 w-3.5 text-(--color-success)" aria-hidden="true" />
+          ) : copyState === "error" ? (
+            <TriangleAlert className="h-3.5 w-3.5 text-destructive" aria-hidden="true" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+          <span>{copyLabel}</span>
+        </button>
+        <span className="my-2 w-px bg-border" aria-hidden="true" />
+        <MorphPopoverTrigger>
+          <button
+            ref={triggerRef}
+            type="button"
+            aria-label="More page actions"
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                focusMenuItem("first");
+              } else if (event.key === "ArrowUp") {
+                event.preventDefault();
+                focusMenuItem("last");
+              }
+            }}
+            className="inline-flex min-h-10 w-10 items-center justify-center rounded-r-lg text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:relative focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring sm:min-h-8 sm:w-8"
+          >
+            <ChevronDown
+              className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-180")}
+              aria-hidden="true"
+            />
+          </button>
+        </MorphPopoverTrigger>
+      </div>
+
+      <MorphPopoverContent align="end" className="w-56 p-1.5">
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Page actions"
+          onKeyDown={handleMenuKeyDown}
+        >
+          {actions.map((action) => (
+            <a
+              key={action.label}
+              href={action.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              role="menuitem"
+              onClick={() => setOpen(false)}
+              className={actionClassName}
+            >
+              <span className="text-muted-foreground">{action.icon}</span>
+              {action.label}
+            </a>
+          ))}
+        </div>
+      </MorphPopoverContent>
+    </MorphPopover>
+  );
+}

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -1,0 +1,67 @@
+/**
+ * Component publication and modification dates derived from git history.
+ * Keep these dates in sync when a component's public docs or implementation
+ * changes so sitemap and article freshness signals stay truthful.
+ */
+const COMPONENT_DATES = {
+  "motion/tilt-card": { publishedAt: "2026-05-17", updatedAt: "2026-06-22" },
+  "motion/button": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "motion/marquee": { publishedAt: "2026-05-17", updatedAt: "2026-07-04" },
+  "motion/tabs": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "motion/switch": { publishedAt: "2026-05-17", updatedAt: "2026-06-10" },
+  "motion/input": { publishedAt: "2026-06-29", updatedAt: "2026-07-05" },
+  "motion/select": { publishedAt: "2026-06-28", updatedAt: "2026-07-13" },
+  "motion/checkbox": { publishedAt: "2026-06-23", updatedAt: "2026-07-01" },
+  "motion/radio": { publishedAt: "2026-06-23", updatedAt: "2026-07-13" },
+  "motion/bottom-sheet": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "motion/shared-layout-bg": { publishedAt: "2026-05-17", updatedAt: "2026-06-22" },
+  "motion/preview-rail": { publishedAt: "2026-07-11", updatedAt: "2026-07-11" },
+  "motion/dock": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "motion/tooltip": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "motion/popover": { publishedAt: "2026-07-07", updatedAt: "2026-07-13" },
+  "motion/morphing-modal": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "motion/text-animation": { publishedAt: "2026-05-17", updatedAt: "2026-06-28" },
+  "motion/number": { publishedAt: "2026-05-17", updatedAt: "2026-06-28" },
+  "motion/animated-badge": { publishedAt: "2026-06-05", updatedAt: "2026-06-10" },
+  "motion/action-swap": { publishedAt: "2026-06-10", updatedAt: "2026-06-28" },
+  "motion/animated-toast-stack": { publishedAt: "2026-06-05", updatedAt: "2026-07-13" },
+  "motion/theme-toggle": { publishedAt: "2026-06-15", updatedAt: "2026-06-20" },
+  "motion/bouncy-accordion": { publishedAt: "2026-06-16", updatedAt: "2026-07-13" },
+  "motion/drawer": { publishedAt: "2026-06-22", updatedAt: "2026-06-22" },
+  "motion/scroll-animation": { publishedAt: "2026-06-24", updatedAt: "2026-06-28" },
+  "motion/range-slider": { publishedAt: "2026-06-24", updatedAt: "2026-06-24" },
+  "motion/wheel-picker": { publishedAt: "2026-07-09", updatedAt: "2026-07-09" },
+  "motion/table": { publishedAt: "2026-07-01", updatedAt: "2026-07-13" },
+  "motion/shader-background": { publishedAt: "2026-07-02", updatedAt: "2026-07-13" },
+  "motion/cylinder-carousel": { publishedAt: "2026-07-04", updatedAt: "2026-07-13" },
+  "motion/loader": { publishedAt: "2026-07-04", updatedAt: "2026-07-13" },
+  "blocks/knockout-bracket": { publishedAt: "2026-07-12", updatedAt: "2026-07-12" },
+  "blocks/availability-scheduler": { publishedAt: "2026-07-10", updatedAt: "2026-07-10" },
+  "blocks/swap": { publishedAt: "2026-05-19", updatedAt: "2026-06-13" },
+  "blocks/dynamic-island": { publishedAt: "2026-06-10", updatedAt: "2026-07-13" },
+  "blocks/command-palette": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "blocks/expandable-action-bar": { publishedAt: "2026-06-05", updatedAt: "2026-06-22" },
+  "blocks/overflow-actions": { publishedAt: "2026-06-19", updatedAt: "2026-06-28" },
+  "blocks/expandable-tabs": { publishedAt: "2026-06-14", updatedAt: "2026-06-28" },
+  "blocks/swipeable-list": { publishedAt: "2026-06-15", updatedAt: "2026-06-28" },
+  "blocks/file-upload": { publishedAt: "2026-06-18", updatedAt: "2026-06-21" },
+  "blocks/prediction-market": { publishedAt: "2026-06-18", updatedAt: "2026-06-21" },
+  "blocks/wallet-card": { publishedAt: "2026-07-03", updatedAt: "2026-07-03" },
+  "blocks/otp-input": { publishedAt: "2026-06-13", updatedAt: "2026-07-13" },
+  "blocks/bloom-menu": { publishedAt: "2026-06-26", updatedAt: "2026-06-26" },
+  "blocks/feedback-widget": { publishedAt: "2026-06-29", updatedAt: "2026-07-13" },
+  "blocks/not-found": { publishedAt: "2026-06-21", updatedAt: "2026-06-21" },
+} as const;
+
+export type ComponentDates = {
+  publishedAt: string;
+  updatedAt: string;
+};
+
+export function componentDates(category: string, slug: string): ComponentDates {
+  const dates = COMPONENT_DATES[`${category}/${slug}` as keyof typeof COMPONENT_DATES];
+  if (!dates) {
+    throw new Error(`Missing component dates for ${category}/${slug}`);
+  }
+  return dates;
+}

--- a/lib/component-markdown.ts
+++ b/lib/component-markdown.ts
@@ -1,0 +1,144 @@
+import { componentDates } from "@/lib/component-dates";
+import { getComponentProps } from "@/lib/props-extractor";
+import { findComponent, type ComponentExample } from "@/lib/registry";
+import { buildEntry } from "@/lib/registry-server";
+import { pageUrlFor } from "@/lib/signature";
+import { readOptionalSourceFile } from "@/lib/source-files";
+
+function escapeTableCell(value: string) {
+  return value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+}
+
+function codeLanguage(file: string) {
+  if (file.endsWith(".tsx")) return "tsx";
+  if (file.endsWith(".ts")) return "ts";
+  if (file.endsWith(".css")) return "css";
+  return "text";
+}
+
+function apiReference(file: string) {
+  const docs = getComponentProps(file);
+  if (!docs.length) return [];
+
+  const lines: string[] = [];
+  for (const doc of docs) {
+    if (!doc.props.length) continue;
+    lines.push(`### ${doc.displayName}`, "");
+    lines.push("| Prop | Type | Default | Required | Description |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const prop of doc.props) {
+      lines.push(
+        `| \`${prop.name}\` | \`${escapeTableCell(prop.type)}\` | ${
+          prop.defaultValue ? `\`${escapeTableCell(prop.defaultValue)}\`` : "—"
+        } | ${prop.required ? "Yes" : "No"} | ${
+          escapeTableCell(prop.description) || "—"
+        } |`,
+      );
+    }
+    lines.push("");
+  }
+  return lines.length > 2 ? lines : [];
+}
+
+async function usageSection(example: ComponentExample) {
+  const usage = await readOptionalSourceFile(example.previewFile);
+  if (!usage) return [];
+  return [
+    `### ${example.name} usage`,
+    "",
+    ...(example.description ? [example.description, ""] : []),
+    `\`\`\`${codeLanguage(example.previewFile)}`,
+    usage.trim(),
+    "```",
+    "",
+  ];
+}
+
+export async function buildComponentMarkdown(
+  categorySlug: string,
+  componentSlug: string,
+) {
+  const component = findComponent(categorySlug, componentSlug);
+  if (!component) return null;
+
+  const pageUrl = pageUrlFor(categorySlug, component.slug);
+  const markdownUrl = `${pageUrl}.md`;
+  const dates = componentDates(categorySlug, component.slug);
+  const examples = component.examples ?? [];
+  const installTargets = examples.some((example) => example.installSlug)
+    ? examples.filter((example) => example.installSlug)
+    : [];
+  const primaryEntry = await buildEntry(categorySlug, component.slug);
+  if (!primaryEntry) return null;
+
+  const lines = [
+    "---",
+    `title: ${JSON.stringify(component.name)}`,
+    `description: ${JSON.stringify(component.description)}`,
+    `category: ${JSON.stringify(categorySlug === "blocks" ? "Blocks" : "Components")}`,
+    `publishedAt: ${JSON.stringify(dates.publishedAt)}`,
+    `updatedAt: ${JSON.stringify(dates.updatedAt)}`,
+    `documentation: ${JSON.stringify(pageUrl)}`,
+    `markdown: ${JSON.stringify(markdownUrl)}`,
+    `license: ${JSON.stringify("MIT")}`,
+    "---",
+    "",
+    `# ${component.name}`,
+    "",
+    `> ${component.description}`,
+    "",
+    "## Install",
+    "",
+  ];
+
+  if (installTargets.length) {
+    for (const example of installTargets) {
+      lines.push(`### ${example.name}`, "");
+      if (example.description) lines.push(example.description, "");
+      lines.push("```bash");
+      lines.push(`npx shadcn@latest add @beui/${example.installSlug}`);
+      lines.push("```", "");
+    }
+  } else {
+    lines.push("```bash");
+    lines.push(`npx shadcn@latest add @beui/${component.slug}`);
+    lines.push("```", "");
+  }
+
+  lines.push("## Dependencies", "");
+  lines.push(
+    primaryEntry.dependencies.length
+      ? primaryEntry.dependencies.map((dependency) => `- \`${dependency}\``).join("\n")
+      : "This component has no external package dependencies.",
+  );
+  lines.push("", "## Usage", "");
+
+  if (examples.length) {
+    for (const example of examples) lines.push(...(await usageSection(example)));
+  } else {
+    const previewFile = `components/previews/${categorySlug}/${component.slug}.preview.tsx`;
+    const usage = await readOptionalSourceFile(previewFile);
+    if (usage) {
+      lines.push(`\`\`\`${codeLanguage(previewFile)}`, usage.trim(), "```", "");
+    } else {
+      lines.push(`See the live example at ${pageUrl}.`, "");
+    }
+  }
+
+  const apiFiles = examples.length
+    ? Array.from(new Set(examples.map((example) => example.file)))
+    : [component.file];
+  const apiLines = apiFiles.flatMap((file) => apiReference(file));
+  if (apiLines.length) lines.push("## API Reference", "", ...apiLines);
+
+  lines.push(
+    "## Source",
+    "",
+    `- Registry detail: ${primaryEntry.detail_url}`,
+    `- Raw source: ${primaryEntry.raw_url}`,
+    `- GitHub: https://github.com/starc007/ui-components`,
+    "",
+  );
+
+  return `${lines.join("\n").replace(/\n{3,}/g, "\n\n").trim()}\n`;
+}

--- a/lib/registry-server.ts
+++ b/lib/registry-server.ts
@@ -1,4 +1,5 @@
 import { allComponents, findCategory, registry } from "@/lib/registry";
+import { componentDates } from "@/lib/component-dates";
 import { pageUrlFor, withSignature } from "@/lib/signature";
 import { SITE_URL } from "@/lib/site";
 import { readOptionalSourceFile, readSourceFile, resolveSourceImport, type SourceFile } from "@/lib/source-files";
@@ -18,6 +19,9 @@ export type RegistryEntry = {
   detail_url: string;
   raw_url: string;
   page_url: string;
+  markdown_url: string;
+  published_at: string;
+  updated_at: string;
   dependencies: string[];
   internal: string[];
   files: RegistryFile[];
@@ -257,6 +261,7 @@ export async function buildEntry(categorySlug: string, slug: string): Promise<Re
   const previewGraph = previewSource ? await collectSourceGraph([previewPath]) : null;
   const componentFileSet = new Set(requiredFiles);
   const pageUrl = pageUrlFor(categorySlug, comp.pageSlug);
+  const dates = componentDates(categorySlug, comp.pageSlug);
   const files = mergeRegistryFiles(componentGraph.files, previewGraph?.files ?? [], componentFileSet, previewPath, pageUrl);
 
   return {
@@ -268,6 +273,9 @@ export async function buildEntry(categorySlug: string, slug: string): Promise<Re
     detail_url: `${SITE_URL}/r/${slug}`,
     raw_url: `${SITE_URL}/r/${slug}/raw`,
     page_url: `${SITE_URL}/components/${categorySlug}/${comp.pageSlug}`,
+    markdown_url: `${SITE_URL}/components/${categorySlug}/${comp.pageSlug}.md`,
+    published_at: dates.publishedAt,
+    updated_at: dates.updatedAt,
     dependencies: Array.from(new Set([...componentGraph.external, ...(previewGraph?.external ?? [])])).sort(),
     internal: Array.from(new Set([...componentGraph.internal, ...(previewGraph?.internal ?? [])])).sort(),
     files,
@@ -364,21 +372,28 @@ export async function buildIndex() {
       directory_item: `${SITE_URL}/{slug}.json`,
       detail: `${SITE_URL}/r/{slug}`,
       raw: `${SITE_URL}/r/{slug}/raw`,
+      markdown: `${SITE_URL}/components/{category}/{slug}.md`,
     },
     categories: registry.map((c) => ({
       slug: c.slug,
       name: c.name,
       description: c.description,
     })),
-    components: allComponents().map((c) => ({
-      slug: c.slug,
-      name: c.name,
-      description: c.description,
-      category: c.category.slug,
-      detail_url: `${SITE_URL}/r/${c.slug}`,
-      raw_url: `${SITE_URL}/r/${c.slug}/raw`,
-      page_url: `${SITE_URL}/components/${c.category.slug}/${c.slug}`,
-    })),
+    components: allComponents().map((c) => {
+      const dates = componentDates(c.category.slug, c.slug);
+      return {
+        slug: c.slug,
+        name: c.name,
+        description: c.description,
+        category: c.category.slug,
+        published_at: dates.publishedAt,
+        updated_at: dates.updatedAt,
+        detail_url: `${SITE_URL}/r/${c.slug}`,
+        raw_url: `${SITE_URL}/r/${c.slug}/raw`,
+        page_url: `${SITE_URL}/components/${c.category.slug}/${c.slug}`,
+        markdown_url: `${SITE_URL}/components/${c.category.slug}/${c.slug}.md`,
+      };
+    }),
   };
 }
 

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,4 +1,5 @@
 import type { JsonLdSchema } from "@/components/app/analytics/json-ld";
+import { componentDates } from "@/lib/component-dates";
 import {
   type CategoryEntry,
   type ComponentEntry,
@@ -139,6 +140,7 @@ export function componentJsonLd(
   comp: ComponentEntry,
 ): JsonLdSchema {
   const url = abs(`/components/${cat.slug}/${comp.slug}`);
+  const dates = componentDates(cat.slug, comp.slug);
   return {
     "@context": "https://schema.org",
     "@type": "TechArticle",
@@ -150,13 +152,21 @@ export function componentJsonLd(
     image: abs(`/api/og?component=${comp.slug}`),
     inLanguage: "en",
     isPartOf: { "@id": `${SITE}/#website` },
-    author: { "@type": "Person", name: AUTHOR },
+    datePublished: dates.publishedAt,
+    dateModified: dates.updatedAt,
+    author: {
+      "@type": "Person",
+      name: AUTHOR,
+      url: "https://saura3h.xyz",
+      sameAs: "https://github.com/starc007",
+    },
     publisher: { "@id": `${SITE}/#org` },
     about: {
       "@type": "SoftwareSourceCode",
       name: comp.name,
       description: comp.description,
       codeRepository: "https://github.com/starc007/ui-components",
+      license: "https://github.com/starc007/ui-components/blob/main/LICENSE",
       programmingLanguage: "TypeScript",
       runtimePlatform: "React",
       codeSampleType: "full (compile ready)",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -83,6 +83,14 @@ const LEGACY_COMPONENT_REDIRECTS = [
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: "/components/:category/:slug.md",
+        destination: "/r/:slug.md?category=:category",
+      },
+    ];
+  },
   async redirects() {
     return [
       ...BLOCK_COMPONENTS.map((slug) => ({

--- a/scripts/check-registry.ts
+++ b/scripts/check-registry.ts
@@ -1,4 +1,5 @@
 import { allComponents } from "../lib/registry";
+import { componentDates } from "../lib/component-dates";
 import { allShadcnTargets, buildEntry, buildShadcnItem } from "../lib/registry-server";
 import { readSourceFile } from "../lib/source-files";
 
@@ -9,6 +10,12 @@ const installSlugLabels = new Map<string, string[]>();
 for (const component of allComponents()) {
   const label = `${component.category.slug}/${component.slug}`;
   slugLabels.set(component.slug, [...(slugLabels.get(component.slug) ?? []), label]);
+
+  try {
+    componentDates(component.category.slug, component.slug);
+  } catch (error) {
+    errors.push(`${label}: ${(error as Error).message}`);
+  }
 
   try {
     const entry = await buildEntry(component.category.slug, component.slug);


### PR DESCRIPTION
## Summary

- publish MDX-style Markdown documents for every component page
- add the compact Copy Page menu with Markdown, v0, ChatGPT, and Claude actions
- add truthful component freshness metadata and sitemap dates
- expose Markdown URLs through llms.txt and registry responses
- explicitly allow OpenAI search crawlers

## Validation

- bun run typecheck
- bun run lint
- bun run check:registry