### PR TITLE
fix: refine action swap roll motion

### DIFF
--- a/components/motion/action-swap.tsx
+++ b/components/motion/action-swap.tsx
@@ -49,9 +49,10 @@ export interface ActionSwapIconProps {
 }
 
 const BLUR_TRANSITION = { duration: 0.2, ease: "easeInOut" } as const;
-const ROLL_TRANSITION = { duration: 0.24, ease: EASE_OUT } as const;
+const ROLL_TRANSITION = SPRING_SWAP;
+const ROLL_EXIT_TRANSITION = { duration: 0.14, ease: EASE_OUT } as const;
 const SWAP_BLUR = "blur(8px)";
-const ROLL_BLUR = "blur(6px)";
+const ROLL_BLUR = "blur(3px)";
 
 // Cascade rolls the label one letter at a time, left to right. The leaving
 // and landing strings overlap as independent layers (no shared cells), so
@@ -92,7 +93,7 @@ const TEXT_VARIANTS: Record<CoreAnimation, Variants> = {
     },
   },
   roll: {
-    initial: { opacity: 0, y: "115%", filter: ROLL_BLUR },
+    initial: { opacity: 0, y: "90%", filter: ROLL_BLUR },
     animate: {
       opacity: 1,
       y: "0%",
@@ -101,9 +102,9 @@ const TEXT_VARIANTS: Record<CoreAnimation, Variants> = {
     },
     exit: {
       opacity: 0,
-      y: "-115%",
+      y: "-90%",
       filter: ROLL_BLUR,
-      transition: { duration: 0.18, ease: "easeInOut" },
+      transition: ROLL_EXIT_TRANSITION,
     },
   },
 };
@@ -125,7 +126,7 @@ const ICON_VARIANTS: Record<CoreAnimation, Variants> = {
     },
   },
   roll: {
-    initial: { opacity: 0, y: 16, filter: ROLL_BLUR },
+    initial: { opacity: 0, y: 12, filter: ROLL_BLUR },
     animate: {
       opacity: 1,
       y: 0,
@@ -134,9 +135,9 @@ const ICON_VARIANTS: Record<CoreAnimation, Variants> = {
     },
     exit: {
       opacity: 0,
-      y: -16,
+      y: -12,
       filter: ROLL_BLUR,
-      transition: { duration: 0.18, ease: "easeInOut" },
+      transition: ROLL_EXIT_TRANSITION,
     },
   },
 };

--- a/components/motion/notification-stack.tsx
+++ b/components/motion/notification-stack.tsx
@@ -245,7 +245,7 @@ export function NotificationStack({
           layout
           initial={false}
           transition={backgroundTransition}
-          className="absolute inset-0 rounded-3xl bg-muted/70"
+          className="absolute inset-0 rounded-3xl bg-muted"
         />
         <span
           className={cn(


### PR DESCRIPTION
## Summary
- refine the shared ActionSwap roll with shorter travel and lighter blur
- use the shared swap spring for a cleaner landing
- tighten roll exits and icon movement
- strengthen the Notification Stack container background

## Verification
- bun run check