### PR TITLE
feat: add sponsor plans

### DIFF
--- a/app/sponsors/page.tsx
+++ b/app/sponsors/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { ArrowUpRight, Check, Gem, Medal, Trophy } from "lucide-react";
+import { ArrowUpRight, Check, CircleCheck, Gem, Medal, Trophy } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { CopyButton } from "@/components/app/docs/copy-button";
 import { PressLink } from "@/components/app/press-link";
@@ -156,7 +156,13 @@ function SponsorPlanCard({
   );
 }
 
-export default function SponsorsPage() {
+export default async function SponsorsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ success?: string }>;
+}) {
+  const resolvedSearchParams = await searchParams;
+  const checkoutSucceeded = resolvedSearchParams?.success === "true";
   const evmAddress = process.env.SPONSOR_EVM_ADDRESS;
   const solAddress = process.env.SPONSOR_SOL_ADDRESS;
   const sponsorPlans = [
@@ -211,6 +217,20 @@ export default function SponsorsPage() {
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-16">
+      {checkoutSucceeded ? (
+        <div className="mx-auto mb-8 flex max-w-xl gap-3 rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-4">
+          <CircleCheck className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+          <div>
+            <p className="text-sm font-semibold text-emerald-950 dark:text-emerald-100">
+              Sponsorship checkout complete
+            </p>
+            <p className="mt-1 text-sm leading-relaxed text-emerald-900/75 dark:text-emerald-100/75">
+              Thanks for sponsoring beUI. I’ll follow up for logo assets and
+              placement details.
+            </p>
+          </div>
+        </div>
+      ) : null}
       <div className="max-w-2xl">
         <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           Sponsors

--- a/app/sponsors/page.tsx
+++ b/app/sponsors/page.tsx
@@ -1,17 +1,19 @@
 import type { Metadata } from "next";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, Check, Gem } from "lucide-react";
 import { CopyButton } from "@/components/app/docs/copy-button";
 import { PressLink } from "@/components/app/press-link";
+import { SponsorPlanBeam } from "@/components/app/sponsors/sponsor-plan-beam";
+import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "Sponsors",
   description:
-    "Support beUI's development through GitHub Sponsors or directly with crypto.",
+    "Support beUI's development with one-time sponsor stages through Dodo Payments, GitHub Sponsors, or crypto.",
   alternates: { canonical: "/sponsors" },
   openGraph: {
     title: "Sponsors · beUI",
     description:
-      "Support beUI's development through GitHub Sponsors or directly with crypto.",
+      "Support beUI's development with one-time sponsor stages through Dodo Payments, GitHub Sponsors, or crypto.",
     url: "/sponsors",
     type: "website",
     siteName: "beUI",
@@ -25,6 +27,22 @@ export const metadata: Metadata = {
 };
 
 const GITHUB_SPONSORS_URL = "https://github.com/sponsors/starc007";
+const CONTACT_URL = "mailto:hello@beui.dev?subject=beUI%20sponsorship";
+
+const PLAN_STYLES = {
+  diamond: {
+    card: "border-border bg-card",
+    icon: "bg-foreground text-background",
+  },
+  platinum: {
+    card: "border-border bg-card",
+    icon: "bg-foreground text-background",
+  },
+  silver: {
+    card: "border-border bg-card",
+    icon: "bg-muted text-foreground",
+  },
+} as const;
 
 function truncateAddress(address: string) {
   return address.length > 14
@@ -46,35 +64,170 @@ function AddressRow({ label, address }: { label: string; address: string }) {
   );
 }
 
+function SponsorPlanCard({
+  name,
+  price,
+  description,
+  benefits,
+  paymentUrl,
+  featured = false,
+  tone,
+}: {
+  name: string;
+  price: string;
+  description: string;
+  benefits: string[];
+  paymentUrl?: string;
+  featured?: boolean;
+  tone: keyof typeof PLAN_STYLES;
+}) {
+  const styles = PLAN_STYLES[tone];
+  const href = paymentUrl || CONTACT_URL;
+
+  return (
+    <SponsorPlanBeam enabled={featured} className="h-full">
+      <div
+        className={cn(
+          "relative flex h-full flex-col rounded-2xl border p-5",
+          styles.card,
+        )}
+      >
+        {featured ? (
+          <span className="absolute right-4 top-4 rounded-full bg-foreground px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-wider text-background">
+            Highest impact
+          </span>
+        ) : null}
+        <div
+          className={cn(
+            "flex h-10 w-10 items-center justify-center rounded-full",
+            styles.icon,
+          )}
+        >
+          <Gem className="h-4 w-4" />
+        </div>
+        <h2 className="mt-5 text-xl font-semibold tracking-tight text-foreground">
+          {name}
+        </h2>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+        <div className="mt-5">
+          <span className="text-3xl font-semibold tracking-tight text-foreground">
+            {price}
+          </span>
+          <span className="ml-2 text-sm text-muted-foreground">one-time</span>
+        </div>
+        <ul className="mt-6 space-y-3 text-sm text-foreground">
+          {benefits.map((benefit) => (
+            <li key={benefit} className="flex gap-2.5">
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+              <span>{benefit}</span>
+            </li>
+          ))}
+        </ul>
+        <PressLink
+          href={href}
+          target={paymentUrl ? "_blank" : undefined}
+          rel={paymentUrl ? "noreferrer noopener" : undefined}
+          className={cn(
+            "group mt-7 inline-flex items-center justify-center gap-2 rounded-full px-5 py-3 text-sm font-semibold transition-colors",
+            featured
+              ? "bg-primary text-primary-foreground hover:bg-primary/90"
+              : "border border-border bg-background text-foreground hover:border-border-strong",
+          )}
+        >
+          {paymentUrl ? `Sponsor as ${name}` : "Request payment link"}
+          <ArrowUpRight className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+        </PressLink>
+      </div>
+    </SponsorPlanBeam>
+  );
+}
+
 export default function SponsorsPage() {
   const evmAddress = process.env.SPONSOR_EVM_ADDRESS;
   const solAddress = process.env.SPONSOR_SOL_ADDRESS;
+  const sponsorPlans = [
+    {
+      name: "Diamond",
+      price: "$500",
+      description:
+        "Maximum visibility for teams that want to back beUI where developers discover components.",
+      benefits: [
+        "Largest logo placement on the sponsors page",
+        "Largest logo placement in the README",
+        "Shoutout on X after sponsorship",
+        "Priority feedback channel for requests",
+      ],
+      paymentUrl: process.env.DODO_SPONSOR_DIAMOND_URL,
+      featured: true,
+      tone: "diamond" as const,
+    },
+    {
+      name: "Platinum",
+      price: "$250",
+      description:
+        "Prominent placement for product teams supporting polished open-source UI.",
+      benefits: [
+        "Larger logo placement on the sponsors page",
+        "Larger logo placement in the README",
+        "Shoutout on X after sponsorship",
+      ],
+      paymentUrl: process.env.DODO_SPONSOR_PLATINUM_URL,
+      tone: "platinum" as const,
+    },
+    {
+      name: "Silver",
+      price: "$100",
+      description:
+        "A simple way to support ongoing component work and be listed publicly.",
+      benefits: [
+        "Logo on the sponsors page",
+        "Logo in the README",
+        "Public sponsor listing",
+      ],
+      paymentUrl: process.env.DODO_SPONSOR_SILVER_URL,
+      tone: "silver" as const,
+    },
+  ];
 
   return (
-    <div className="mx-auto max-w-xl px-4 py-16">
-      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-        Sponsors
-      </p>
-      <h1 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
-        Support beUI
-      </h1>
-      <p className="mt-3 text-muted-foreground">
-        beUI is free and open source. If it's saved you time, consider
-        supporting its development.
-      </p>
+    <div className="mx-auto max-w-7xl px-4 py-16">
+      <div className="max-w-2xl">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Sponsors
+        </p>
+        <h1 className="mt-2 text-4xl font-semibold tracking-tight text-foreground">
+          Support beUI
+        </h1>
+        <p className="mt-3 text-muted-foreground">
+          beUI is free and open source. Sponsor a one-time stage to help fund
+          new components, registry maintenance, and better docs for everyone.
+        </p>
 
-      <PressLink
-        href={GITHUB_SPONSORS_URL}
-        target="_blank"
-        rel="noreferrer noopener"
-        className="group mt-8 inline-flex items-center justify-center gap-2 rounded-full bg-primary px-7 py-3.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
-      >
-        Sponsor on GitHub
-        <ArrowUpRight className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
-      </PressLink>
+        <div className="mt-8 flex flex-wrap gap-3">
+          <PressLink
+            href={GITHUB_SPONSORS_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="group inline-flex items-center justify-center gap-2 rounded-full border border-border bg-background px-5 py-3 text-sm font-semibold text-foreground transition-colors hover:border-border-strong"
+          >
+            Sponsor on GitHub
+            <ArrowUpRight className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+          </PressLink>
+        </div>
+      </div>
+
+      <section id="sponsor-plans" className="mt-12">
+        <div className="grid gap-4 md:grid-cols-3">
+          {sponsorPlans.map((plan) => (
+            <SponsorPlanCard key={plan.name} {...plan} />
+          ))}
+        </div>
+      </section>
 
       {evmAddress || solAddress ? (
-        <div className="mt-10 space-y-3">
+        <div className="mt-14 max-w-xl space-y-3">
           <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             Crypto
           </p>

--- a/app/sponsors/page.tsx
+++ b/app/sponsors/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { ArrowUpRight, Check, Gem } from "lucide-react";
+import { ArrowUpRight, Check, Gem, Medal, Trophy } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { CopyButton } from "@/components/app/docs/copy-button";
 import { PressLink } from "@/components/app/press-link";
 import { SponsorPlanBeam } from "@/components/app/sponsors/sponsor-plan-beam";
@@ -8,12 +9,12 @@ import { cn } from "@/lib/utils";
 export const metadata: Metadata = {
   title: "Sponsors",
   description:
-    "Support beUI's development with one-time sponsor stages through Dodo Payments, GitHub Sponsors, or crypto.",
+    "Support beUI's development with monthly sponsor stages through Dodo Payments, GitHub Sponsors, or crypto.",
   alternates: { canonical: "/sponsors" },
   openGraph: {
     title: "Sponsors · beUI",
     description:
-      "Support beUI's development with one-time sponsor stages through Dodo Payments, GitHub Sponsors, or crypto.",
+      "Support beUI's development with monthly sponsor stages through Dodo Payments, GitHub Sponsors, or crypto.",
     url: "/sponsors",
     type: "website",
     siteName: "beUI",
@@ -31,18 +32,24 @@ const CONTACT_URL = "mailto:hello@beui.dev?subject=beUI%20sponsorship";
 
 const PLAN_STYLES = {
   diamond: {
-    card: "border-border bg-card",
-    icon: "bg-foreground text-background",
+    card: "border-border bg-card shadow-[0_24px_80px_-48px_rgba(255,255,255,0.75)]",
+    icon: "border border-border bg-muted text-foreground",
+    Icon: Gem,
   },
   platinum: {
     card: "border-border bg-card",
-    icon: "bg-foreground text-background",
+    icon: "border border-border bg-muted text-foreground",
+    Icon: Trophy,
   },
   silver: {
     card: "border-border bg-card",
-    icon: "bg-muted text-foreground",
+    icon: "border border-border bg-muted text-foreground",
+    Icon: Medal,
   },
-} as const;
+} satisfies Record<
+  string,
+  { card: string; icon: string; Icon: LucideIcon }
+>;
 
 function truncateAddress(address: string) {
   return address.length > 14
@@ -52,13 +59,13 @@ function truncateAddress(address: string) {
 
 function AddressRow({ label, address }: { label: string; address: string }) {
   return (
-    <div className="flex items-center justify-between gap-4 rounded-xl border border-border px-4 py-3">
-      <div className="min-w-0">
-        <p className="text-xs font-medium text-muted-foreground">{label}</p>
-        <p className="mt-0.5 truncate font-mono text-sm text-foreground">
-          {truncateAddress(address)}
-        </p>
-      </div>
+    <div className="grid grid-cols-[5rem_minmax(0,1fr)_auto] items-center gap-4 rounded-xl border border-border px-4 py-3">
+      <p className="whitespace-nowrap text-sm font-medium text-muted-foreground">
+        {label}
+      </p>
+      <p className="min-w-0 truncate whitespace-nowrap font-mono text-sm text-foreground">
+        {truncateAddress(address)}
+      </p>
       <CopyButton text={address} eventName="copy_sponsor_address" eventLabel={label} />
     </div>
   );
@@ -82,45 +89,50 @@ function SponsorPlanCard({
   tone: keyof typeof PLAN_STYLES;
 }) {
   const styles = PLAN_STYLES[tone];
+  const Icon = styles.Icon;
   const href = paymentUrl || CONTACT_URL;
 
   return (
     <SponsorPlanBeam enabled={featured} className="h-full">
       <div
         className={cn(
-          "relative flex h-full flex-col rounded-2xl border p-5",
+          "relative flex h-full flex-col overflow-hidden rounded-3xl border p-5",
           styles.card,
         )}
       >
         {featured ? (
-          <span className="absolute right-4 top-4 rounded-full bg-foreground px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-wider text-background">
+          <span className="absolute right-4 top-4 rounded-full border border-white/10 bg-foreground px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-wider text-background">
             Highest impact
           </span>
         ) : null}
-        <div
-          className={cn(
-            "flex h-10 w-10 items-center justify-center rounded-full",
-            styles.icon,
+        <div className="flex items-start justify-between gap-4 pr-24">
+          <div
+            className={cn(
+              "flex h-11 w-11 items-center justify-center rounded-2xl",
+              styles.icon,
           )}
         >
-          <Gem className="h-4 w-4" />
+          <Icon className="h-4 w-4" />
         </div>
-        <h2 className="mt-5 text-xl font-semibold tracking-tight text-foreground">
-          {name}
-        </h2>
-        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-          {description}
-        </p>
-        <div className="mt-5">
-          <span className="text-3xl font-semibold tracking-tight text-foreground">
+        </div>
+        <div className="mt-6">
+          <h2 className="text-xl font-semibold tracking-tight text-foreground">
+            {name}
+          </h2>
+          <p className="mt-2 min-h-12 text-sm leading-relaxed text-muted-foreground">
+            {description}
+          </p>
+        </div>
+        <div className="mt-6 border-t border-border pt-5">
+          <span className="text-4xl font-semibold tracking-tight text-foreground">
             {price}
           </span>
-          <span className="ml-2 text-sm text-muted-foreground">one-time</span>
+          <span className="ml-2 text-sm text-muted-foreground">/mo</span>
         </div>
-        <ul className="mt-6 space-y-3 text-sm text-foreground">
+        <ul className="mt-6 min-h-32 space-y-3 text-sm text-foreground">
           {benefits.map((benefit) => (
             <li key={benefit} className="flex gap-2.5">
-              <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-foreground" />
               <span>{benefit}</span>
             </li>
           ))}
@@ -130,7 +142,7 @@ function SponsorPlanCard({
           target={paymentUrl ? "_blank" : undefined}
           rel={paymentUrl ? "noreferrer noopener" : undefined}
           className={cn(
-            "group mt-7 inline-flex items-center justify-center gap-2 rounded-full px-5 py-3 text-sm font-semibold transition-colors",
+            "group mt-auto inline-flex items-center justify-center gap-2 rounded-full px-5 py-3 text-sm font-semibold transition-colors",
             featured
               ? "bg-primary text-primary-foreground hover:bg-primary/90"
               : "border border-border bg-background text-foreground hover:border-border-strong",
@@ -150,22 +162,24 @@ export default function SponsorsPage() {
   const sponsorPlans = [
     {
       name: "Diamond",
-      price: "$500",
+      price: "$399",
       description:
-        "Maximum visibility for teams that want to back beUI where developers discover components.",
+        "Maximum visibility for teams that want their logo in the highest-signal sponsor slot.",
       benefits: [
         "Largest logo placement on the sponsors page",
         "Largest logo placement in the README",
         "Shoutout on X after sponsorship",
         "Priority feedback channel for requests",
       ],
-      paymentUrl: process.env.DODO_SPONSOR_DIAMOND_URL,
+      paymentUrl:
+        process.env.DODO_SPONSOR_DIAMOND_SUBSCRIPTION_URL ??
+        process.env.DODO_SPONSOR_DIAMOND_URL,
       featured: true,
       tone: "diamond" as const,
     },
     {
       name: "Platinum",
-      price: "$250",
+      price: "$199",
       description:
         "Prominent placement for product teams supporting polished open-source UI.",
       benefits: [
@@ -173,12 +187,14 @@ export default function SponsorsPage() {
         "Larger logo placement in the README",
         "Shoutout on X after sponsorship",
       ],
-      paymentUrl: process.env.DODO_SPONSOR_PLATINUM_URL,
+      paymentUrl:
+        process.env.DODO_SPONSOR_PLATINUM_SUBSCRIPTION_URL ??
+        process.env.DODO_SPONSOR_PLATINUM_URL,
       tone: "platinum" as const,
     },
     {
       name: "Silver",
-      price: "$100",
+      price: "$99",
       description:
         "A simple way to support ongoing component work and be listed publicly.",
       benefits: [
@@ -186,7 +202,9 @@ export default function SponsorsPage() {
         "Logo in the README",
         "Public sponsor listing",
       ],
-      paymentUrl: process.env.DODO_SPONSOR_SILVER_URL,
+      paymentUrl:
+        process.env.DODO_SPONSOR_SILVER_SUBSCRIPTION_URL ??
+        process.env.DODO_SPONSOR_SILVER_URL,
       tone: "silver" as const,
     },
   ];
@@ -201,8 +219,9 @@ export default function SponsorsPage() {
           Support beUI
         </h1>
         <p className="mt-3 text-muted-foreground">
-          beUI is free and open source. Sponsor a one-time stage to help fund
-          new components, registry maintenance, and better docs for everyone.
+          beUI is free and open source. Sponsor a monthly stage to reach
+          developers actively browsing motion components, blocks, and registry
+          installs.
         </p>
 
         <div className="mt-8 flex flex-wrap gap-3">
@@ -227,12 +246,16 @@ export default function SponsorsPage() {
       </section>
 
       {evmAddress || solAddress ? (
-        <div className="mt-14 max-w-xl space-y-3">
+        <div className="mt-14">
           <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             Crypto
           </p>
-          {evmAddress ? <AddressRow label="EVM" address={evmAddress} /> : null}
-          {solAddress ? <AddressRow label="Solana" address={solAddress} /> : null}
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            {evmAddress ? <AddressRow label="EVM" address={evmAddress} /> : null}
+            {solAddress ? (
+              <AddressRow label="Solana" address={solAddress} />
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@tanstack/react-virtual": "^3.14.4",
         "@vercel/analytics": "^1.4.1",
         "@vercel/speed-insights": "^1.1.0",
+        "border-beam": "^1.3.0",
         "clsx": "^2.1.1",
         "geist": "^1.7.2",
         "lenis": "^1.3.23",
@@ -276,6 +277,8 @@
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "axe-core": ["axe-core@3.5.6", "", {}, "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ=="],
+
+    "border-beam": ["border-beam@1.3.0", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-oZSISp3aQau4ASTmzm5pzxeBinO6Fh2HW0gyEixJgtpUZvRiU0vNpP+IwGRrNpIyqPjA7Rf5EBnVqDSJ49cm5w=="],
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 

--- a/components/app/sponsors/sponsor-plan-beam.tsx
+++ b/components/app/sponsors/sponsor-plan-beam.tsx
@@ -21,8 +21,8 @@ export function SponsorPlanBeam({
     <BorderBeam
       size="md"
       colorVariant="colorful"
-      strength={0.78}
-      borderRadius={16}
+      strength={0.82}
+      borderRadius={24}
       className={cn("h-full", className)}
     >
       {children}

--- a/components/app/sponsors/sponsor-plan-beam.tsx
+++ b/components/app/sponsors/sponsor-plan-beam.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { BorderBeam } from "border-beam";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function SponsorPlanBeam({
+  enabled,
+  children,
+  className,
+}: {
+  enabled: boolean;
+  children: ReactNode;
+  className?: string;
+}) {
+  if (!enabled) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <BorderBeam
+      size="md"
+      colorVariant="colorful"
+      strength={0.78}
+      borderRadius={16}
+      className={cn("h-full", className)}
+    >
+      {children}
+    </BorderBeam>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@tanstack/react-virtual": "^3.14.4",
     "@vercel/analytics": "^1.4.1",
     "@vercel/speed-insights": "^1.1.0",
+    "border-beam": "^1.3.0",
     "clsx": "^2.1.1",
     "geist": "^1.7.2",
     "lenis": "^1.3.23",


### PR DESCRIPTION
## Summary
- add monthly sponsor tiers for Diamond, Platinum, and Silver
- wire Dodo subscription checkout URLs with legacy URL fallbacks
- add a BorderBeam-highlighted Diamond card and success state for `/sponsors?success=true`
- keep crypto sponsor addresses side-by-side on desktop

## Validation
- `bun run typecheck`
- `bunx biome lint app/sponsors/page.tsx components/app/sponsors/sponsor-plan-beam.tsx`
- `bun run check:registry`