### PR TITLE
feat: add center morph modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `tooltip` | `components/motion/tooltip.tsx` | Hover/focus tooltip with blur enter/exit and spring spawn |
 | `popover` | `components/motion/popover.tsx`, `popover-morph.tsx` | Composable popover, two variants. **Gooey** (`Popover`, `PopoverTrigger`, `PopoverContent`, install `@beui/popover`): panel oozes out of the trigger via an SVG goo filter (liquid neck that stretches/pinches) with crisp content fading in on top. **Morph** (`MorphPopover`, `MorphPopoverTrigger`, `MorphPopoverContent`, install `@beui/popover-morph`): panel laid out full size but clipped to the corner nearest the trigger, then unclips as one piece with a drop-shadow that hugs the shape; side/align aware. Both inline-anchored, click trigger, controlled/uncontrolled |
 | `morphing-modal` | `components/motion/morphing-modal.tsx` | Panel that morphs height across inner views with blur cross-fade |
+| `center-morph-modal` | `components/motion/center-morph-modal.tsx` | Composable modal whose full-size surface unfolds from its exact center toward every edge, then folds back the same way with an inset close control |
 | `text-reveal` | `components/motion/text-reveal.tsx` | Word or character reveal with spring slide-up and blur |
 | `text-shimmer` | `components/motion/text-shimmer.tsx` | Gradient sweep across text for loading or emphasis |
 | `text-cascade` | `components/motion/text-cascade.tsx` | Letter-by-letter slot roll for standalone text |

--- a/components/motion/center-morph-modal.tsx
+++ b/components/motion/center-morph-modal.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { X } from "lucide-react";
+import {
+  AnimatePresence,
+  motion,
+  useIsPresent,
+  useReducedMotion,
+} from "motion/react";
+import {
+  cloneElement,
+  createContext,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { EASE_OUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+type CenterMorphModalContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  triggerId: string;
+  contentId: string;
+};
+
+const CenterMorphModalContext =
+  createContext<CenterMorphModalContextValue | null>(null);
+
+function useCenterMorphModalContext(component: string) {
+  const context = useContext(CenterMorphModalContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <CenterMorphModal>`);
+  }
+  return context;
+}
+
+export interface CenterMorphModalProps {
+  children: ReactNode;
+  /** Controlled open state. */
+  open?: boolean;
+  /** Initial state when used uncontrolled. */
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+/**
+ * A modal whose full-size surface unfolds outward from its exact center.
+ * Supports controlled and uncontrolled state through composable primitives.
+ */
+export function CenterMorphModal({
+  children,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+}: CenterMorphModalProps) {
+  const id = useId();
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const controlled = controlledOpen !== undefined;
+  const open = controlled ? controlledOpen : internalOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!controlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [controlled, onOpenChange],
+  );
+
+  const value = useMemo<CenterMorphModalContextValue>(
+    () => ({
+      open,
+      setOpen,
+      triggerId: `${id}-trigger`,
+      contentId: `${id}-content`,
+    }),
+    [id, open, setOpen],
+  );
+
+  return (
+    <CenterMorphModalContext.Provider value={value}>
+      {children}
+    </CenterMorphModalContext.Provider>
+  );
+}
+
+export interface CenterMorphModalTriggerProps {
+  children: ReactElement;
+}
+
+/** Wraps one interactive element and opens or closes the modal. */
+export function CenterMorphModalTrigger({
+  children,
+}: CenterMorphModalTriggerProps) {
+  const context = useCenterMorphModalContext("CenterMorphModalTrigger");
+  if (!isValidElement(children)) return children;
+
+  const child = children as ReactElement<Record<string, unknown>>;
+  const childOnClick = child.props.onClick as
+    | ((event: React.MouseEvent<HTMLElement>) => void)
+    | undefined;
+
+  return cloneElement(child, {
+    id: context.triggerId,
+    onClick: (event: React.MouseEvent<HTMLElement>) => {
+      childOnClick?.(event);
+      if (!event.defaultPrevented) context.setOpen(!context.open);
+    },
+    "aria-haspopup": "dialog",
+    "aria-expanded": context.open,
+    "aria-controls": context.open ? context.contentId : undefined,
+  });
+}
+
+export interface CenterMorphModalCloseProps {
+  children: ReactElement;
+}
+
+/** Wraps one interactive element and closes the modal. */
+export function CenterMorphModalClose({
+  children,
+}: CenterMorphModalCloseProps) {
+  const context = useCenterMorphModalContext("CenterMorphModalClose");
+  if (!isValidElement(children)) return children;
+
+  const child = children as ReactElement<Record<string, unknown>>;
+  const childOnClick = child.props.onClick as
+    | ((event: React.MouseEvent<HTMLElement>) => void)
+    | undefined;
+
+  return cloneElement(child, {
+    onClick: (event: React.MouseEvent<HTMLElement>) => {
+      childOnClick?.(event);
+      if (!event.defaultPrevented) context.setOpen(false);
+    },
+  });
+}
+
+export interface CenterMorphModalContentProps {
+  children: ReactNode;
+  /** Accessible name announced by screen readers. */
+  ariaLabel: string;
+  /** Optional id of descriptive content inside the modal. */
+  ariaDescribedBy?: string;
+  /** Close on Escape or backdrop press. Default true. */
+  dismissible?: boolean;
+  /** Render the close control inside the panel's top-right corner. Default true. */
+  showCloseButton?: boolean;
+  closeButtonLabel?: string;
+  className?: string;
+  backdropClassName?: string;
+}
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+const CENTER_FOLDED_CLIP =
+  "inset(48% 48% 48% 48% round 30px)";
+const CENTER_OPEN_CLIP = "inset(0% 0% 0% 0% round 30px)";
+
+// Complex clip-path strings can snap when a spring resolves its final distance.
+// Keep the radius constant so the whole duration reads as surface unfolding,
+// rather than finishing early and spending its last frames rounding corners.
+const CENTER_UNFOLD_EASE = [0.2, 0, 0.2, 1] as const;
+const CENTER_UNFOLD_TRANSITION = {
+  duration: 0.43,
+  ease: CENTER_UNFOLD_EASE,
+} as const;
+
+function getFocusableElements(root: HTMLElement | null) {
+  if (!root) return [];
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((element) => element.tabIndex >= 0);
+}
+
+function PresencePointerGate({
+  children,
+}: {
+  children: (isPresent: boolean) => ReactNode;
+}) {
+  return children(useIsPresent());
+}
+
+export function CenterMorphModalContent({
+  children,
+  ariaLabel,
+  ariaDescribedBy,
+  dismissible = true,
+  showCloseButton = true,
+  closeButtonLabel = "Close modal",
+  className,
+  backdropClassName,
+}: CenterMorphModalContentProps) {
+  const context = useCenterMorphModalContext("CenterMorphModalContent");
+  const reduce = useReducedMotion() ?? false;
+  const [mounted, setMounted] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!context.open) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const focusFrame = requestAnimationFrame(() => {
+      const [firstFocusable] = getFocusableElements(overlayRef.current);
+      (firstFocusable ?? panelRef.current)?.focus();
+    });
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && dismissible) {
+        event.preventDefault();
+        context.setOpen(false);
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+      const focusable = getFocusableElements(overlayRef.current);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        panelRef.current?.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      cancelAnimationFrame(focusFrame);
+      window.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+      document.getElementById(context.triggerId)?.focus();
+    };
+  }, [context, dismissible]);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <AnimatePresence>
+      {context.open ? (
+        <PresencePointerGate>
+          {(isPresent) => (
+            <div
+              ref={overlayRef}
+              className="pointer-events-none fixed inset-0 z-[100]"
+            >
+          <motion.button
+            type="button"
+            aria-label="Dismiss modal"
+            tabIndex={-1}
+            disabled={!dismissible}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            style={{ pointerEvents: isPresent ? "auto" : "none" }}
+            transition={{
+              duration: reduce ? 0.1 : 0.28,
+              ease: EASE_OUT,
+            }}
+            onClick={() => context.setOpen(false)}
+            className={cn(
+              "pointer-events-auto absolute inset-0 h-full w-full cursor-default bg-background/10 backdrop-blur-sm",
+              backdropClassName,
+            )}
+          />
+
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center overflow-y-auto p-4 drop-shadow-2xl">
+            {/* Drop-shadow reads the clipped child's alpha, so depth follows the
+                unfolding silhouette without introducing another panel layer. */}
+            <div className="flex w-full flex-col items-center py-8">
+              <motion.div
+                ref={panelRef}
+                id={context.contentId}
+                role="dialog"
+                aria-modal="true"
+                aria-label={ariaLabel}
+                aria-describedby={ariaDescribedBy}
+                tabIndex={-1}
+                initial={
+                  reduce
+                    ? { opacity: 0, clipPath: CENTER_OPEN_CLIP }
+                    : { opacity: 1, clipPath: CENTER_FOLDED_CLIP }
+                }
+                animate={{
+                  opacity: 1,
+                  clipPath: CENTER_OPEN_CLIP,
+                }}
+                exit={
+                  reduce
+                    ? {
+                        opacity: 0,
+                        clipPath: CENTER_OPEN_CLIP,
+                      }
+                    : {
+                        opacity: 1,
+                        clipPath: CENTER_FOLDED_CLIP,
+                      }
+                }
+                style={{ pointerEvents: isPresent ? "auto" : "none" }}
+                transition={
+                  reduce
+                    ? { duration: 0.14, ease: EASE_OUT }
+                    : CENTER_UNFOLD_TRANSITION
+                }
+                className={cn(
+                  "pointer-events-auto relative w-full max-w-[26rem] origin-center overflow-hidden rounded-[30px] border border-border bg-background will-change-[clip-path]",
+                  className,
+                )}
+              >
+                {children}
+
+                {showCloseButton ? (
+                  <motion.button
+                    type="button"
+                    aria-label={closeButtonLabel}
+                    onClick={() => context.setOpen(false)}
+                    initial={
+                      reduce
+                        ? { opacity: 0 }
+                        : { opacity: 0, scale: 0.8 }
+                    }
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{
+                      opacity: 0,
+                      scale: reduce ? 1 : 0.88,
+                      transition: { duration: 0.1, ease: EASE_OUT },
+                    }}
+                    transition={{
+                      delay: reduce ? 0 : 0.16,
+                      duration: reduce ? 0.12 : 0.2,
+                      ease: EASE_OUT,
+                    }}
+                    className="absolute right-4 top-4 inline-flex h-8 w-8 items-center justify-center rounded-full bg-foreground/[0.05] text-muted-foreground transition-colors hover:bg-foreground/[0.08] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <X className="h-4 w-4" aria-hidden="true" />
+                  </motion.button>
+                ) : null}
+              </motion.div>
+            </div>
+          </div>
+            </div>
+          )}
+        </PresencePointerGate>
+      ) : null}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/components/motion/popover-morph.tsx
+++ b/components/motion/popover-morph.tsx
@@ -15,7 +15,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { SPRING_PANEL } from "@/lib/ease";
+import { EASE_OUT, SPRING_PANEL } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 
 type Side = "top" | "bottom";
@@ -149,6 +149,10 @@ function clipHidden(side: Side, align: Align, radius: number) {
 }
 const clipShown = (radius: number) => `inset(0% 0% 0% 0% round ${radius}px)`;
 
+// Preserve the original spring character on the wrapper, but tween the complex
+// clip-path so it cannot snap when the spring resolves its final distance.
+const MORPH_CLIP_TRANSITION = { duration: 0.32, ease: EASE_OUT } as const;
+
 export interface MorphPopoverContentProps {
   children: ReactNode;
   side?: Side;
@@ -178,21 +182,25 @@ export function MorphPopoverContent({
   const marginStyle =
     side === "bottom" ? { marginTop: sideOffset } : { marginBottom: sideOffset };
 
-  // Close animates with the same spring as open, so it morphs back to the
-  // corner instead of snapping shut.
+  // Both directions travel between the exact same hidden/show states. Exit
+  // targets "hidden" directly instead of introducing separate choreography.
   const wrap = reduce
     ? undefined
     : {
-        hidden: { opacity: 0, scale: 0.96 },
+        hidden: { opacity: 0, scale: 0.96, transition: SPRING_PANEL },
         show: { opacity: 1, scale: 1, transition: SPRING_PANEL },
-        exit: { opacity: 0, scale: 0.96, transition: SPRING_PANEL },
       };
   const clip = reduce
     ? undefined
     : {
-        hidden: { clipPath: clipHidden(side, align, radius) },
-        show: { clipPath: clipShown(radius), transition: SPRING_PANEL },
-        exit: { clipPath: clipHidden(side, align, radius), transition: SPRING_PANEL },
+        hidden: {
+          clipPath: clipHidden(side, align, radius),
+          transition: MORPH_CLIP_TRANSITION,
+        },
+        show: {
+          clipPath: clipShown(radius),
+          transition: MORPH_CLIP_TRANSITION,
+        },
       };
 
   return (
@@ -204,7 +212,7 @@ export function MorphPopoverContent({
           variants={wrap}
           initial={reduce ? { opacity: 0 } : "hidden"}
           animate={reduce ? { opacity: 1 } : "show"}
-          exit={reduce ? { opacity: 0 } : "exit"}
+          exit={reduce ? { opacity: 0 } : "hidden"}
           transition={reduce ? { duration: 0.12 } : undefined}
           style={{ transformOrigin: originFor(side, align), ...marginStyle }}
           className={cn(

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -190,6 +190,11 @@ export const previews: Record<string, ComponentType> = {
   "motion/morphing-modal": dynamic(() =>
     import("./motion/morphing-modal.preview").then((m) => m.MorphingModalPreview),
   ),
+  "motion/center-morph-modal": dynamic(() =>
+    import("./motion/center-morph-modal.preview").then(
+      (m) => m.CenterMorphModalPreview,
+    ),
+  ),
   "motion/text-reveal": dynamic(() =>
     import("./motion/text-reveal.preview").then((m) => m.TextRevealPreview),
   ),

--- a/components/previews/motion/center-morph-modal.preview.tsx
+++ b/components/previews/motion/center-morph-modal.preview.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { ArrowUpRight, Check } from "lucide-react";
+import {
+  CenterMorphModal,
+  CenterMorphModalContent,
+  CenterMorphModalTrigger,
+} from "@/components/motion/center-morph-modal";
+
+export function CenterMorphModalPreview() {
+  return (
+    <div className="flex min-h-[420px] w-full items-center justify-center">
+      <CenterMorphModal>
+        <CenterMorphModalTrigger>
+          <button
+            type="button"
+            className="inline-flex h-10 items-center justify-center rounded-full bg-foreground px-5 text-sm font-medium text-background press focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            Open modal
+          </button>
+        </CenterMorphModalTrigger>
+
+        <CenterMorphModalContent
+          ariaLabel="beUI Pro"
+          ariaDescribedBy="center-morph-pro-description"
+        >
+          <div className="p-7 sm:p-8">
+            <p className="text-sm font-medium text-muted-foreground">
+              beUI Pro
+            </p>
+            <h2 className="mt-5 max-w-xs pr-8 text-2xl font-medium tracking-tight text-foreground">
+              Ship the whole experience.
+            </h2>
+            <p
+              id="center-morph-pro-description"
+              className="mt-3 text-sm leading-relaxed text-muted-foreground"
+            >
+              Go beyond individual components with premium animated sections
+              and complete Next.js templates.
+            </p>
+
+            <div className="mt-7 space-y-3 border-y border-border py-5">
+              {[
+                "Premium animated sections",
+                "Complete Next.js templates",
+                "Editable source and private registry",
+              ].map((feature) => (
+                <div
+                  key={feature}
+                  className="flex items-center gap-3 text-sm text-foreground"
+                >
+                  <Check
+                    className="h-4 w-4 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <span>{feature}</span>
+                </div>
+              ))}
+            </div>
+
+            <a
+              href="https://pro.beui.dev/?utm_source=beui&utm_medium=component_preview&utm_campaign=center_morph_modal"
+              target="_blank"
+              rel="noreferrer"
+              className="mt-7 inline-flex h-11 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-sm font-medium text-background press focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            >
+              Explore beUI Pro
+              <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </div>
+        </CenterMorphModalContent>
+      </CenterMorphModal>
+    </div>
+  );
+}

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -25,6 +25,10 @@ const COMPONENT_DATES = {
   "motion/tooltip": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
   "motion/popover": { publishedAt: "2026-07-07", updatedAt: "2026-07-13" },
   "motion/morphing-modal": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "motion/center-morph-modal": {
+    publishedAt: "2026-07-21",
+    updatedAt: "2026-07-21",
+  },
   "motion/text-animation": { publishedAt: "2026-05-17", updatedAt: "2026-06-28" },
   "motion/number": { publishedAt: "2026-05-17", updatedAt: "2026-06-28" },
   "motion/animated-badge": { publishedAt: "2026-06-05", updatedAt: "2026-06-10" },

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -23,7 +23,7 @@ const COMPONENT_DATES = {
   "motion/preview-rail": { publishedAt: "2026-07-11", updatedAt: "2026-07-11" },
   "motion/dock": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
   "motion/tooltip": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
-  "motion/popover": { publishedAt: "2026-07-07", updatedAt: "2026-07-13" },
+  "motion/popover": { publishedAt: "2026-07-07", updatedAt: "2026-07-21" },
   "motion/morphing-modal": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
   "motion/center-morph-modal": {
     publishedAt: "2026-07-21",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -320,6 +320,22 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/morphing-modal.tsx",
       },
       {
+        slug: "center-morph-modal",
+        name: "Center Morph Modal",
+        description:
+          "A composable modal whose full-size surface unfolds from its exact center toward every edge, then folds back the same way with an inset close control.",
+        file: "components/motion/center-morph-modal.tsx",
+        badge: "new",
+        launchedAt: "2026-07-21",
+        keywords: [
+          "react morph modal",
+          "center expanding modal",
+          "animated modal react",
+          "framer motion modal",
+          "radial modal animation",
+        ],
+      },
+      {
         slug: "text-animation",
         name: "Text Animation",
         description: "Animated text primitives for reveal sequences, shimmer loading states and letter-cascade swaps.",

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -6,6 +6,11 @@ import type { ReactElement } from "react";
 import { AnimatedBadge } from "@/components/motion/animated-badge";
 import { BloomMenu } from "@/components/motion/bloom-menu";
 import { Button } from "@/components/motion/button";
+import {
+  CenterMorphModal,
+  CenterMorphModalContent,
+  CenterMorphModalTrigger,
+} from "@/components/motion/center-morph-modal";
 import { Checkbox } from "@/components/motion/checkbox";
 import { Input } from "@/components/motion/input";
 import { Parallax } from "@/components/motion/parallax";
@@ -31,6 +36,19 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
   ["Button disabled", () => <Button disabled>Subscribe</Button>],
   ["Button ripple", () => <Button ripple>Subscribe</Button>],
   ["BloomMenu", () => <BloomMenu />],
+  [
+    "CenterMorphModal",
+    () => (
+      <CenterMorphModal>
+        <CenterMorphModalTrigger>
+          <button type="button">Open profile</button>
+        </CenterMorphModalTrigger>
+        <CenterMorphModalContent ariaLabel="Profile details">
+          <p>Profile details</p>
+        </CenterMorphModalContent>
+      </CenterMorphModal>
+    ),
+  ],
   [
     "Switch",
     () => (

--- a/tests/center-morph-modal.test.tsx
+++ b/tests/center-morph-modal.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import {
+  CenterMorphModal,
+  CenterMorphModalContent,
+  CenterMorphModalTrigger,
+} from "@/components/motion/center-morph-modal";
+
+afterEach(cleanup);
+
+function TestModal() {
+  return (
+    <CenterMorphModal>
+      <CenterMorphModalTrigger>
+        <button type="button">Open profile</button>
+      </CenterMorphModalTrigger>
+      <CenterMorphModalContent ariaLabel="Profile">
+        <p>Profile content</p>
+      </CenterMorphModalContent>
+    </CenterMorphModal>
+  );
+}
+
+describe("CenterMorphModal", () => {
+  test("opens from its trigger and closes from the inset control", () => {
+    const { getByRole, queryByRole } = render(<TestModal />);
+
+    expect(queryByRole("dialog")).toBeNull();
+    const trigger = getByRole("button", { name: "Open profile" });
+    fireEvent.click(trigger);
+    expect(getByRole("dialog", { name: "Profile" })).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: "Close modal" }));
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  test("closes on Escape", () => {
+    const { getByRole } = render(<TestModal />);
+
+    const trigger = getByRole("button", { name: "Open profile" });
+    fireEvent.click(trigger);
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  test("releases pointer events as soon as closing starts", () => {
+    const { getByRole } = render(<TestModal />);
+
+    fireEvent.click(getByRole("button", { name: "Open profile" }));
+    const dialog = getByRole("dialog", { name: "Profile" });
+    const backdrop = getByRole("button", { name: "Dismiss modal" });
+
+    fireEvent.click(getByRole("button", { name: "Close modal" }));
+
+    expect(dialog.style.pointerEvents).toBe("none");
+    expect(backdrop.style.pointerEvents).toBe("none");
+  });
+});


### PR DESCRIPTION
## Summary

- add a composable center morph modal that unfolds outward from a compact center seed
- add the beUI Pro preview, registry metadata, accessibility coverage, and component tests
- make Morph Popover closing follow the same motion path as opening

## Why

The modal needs to feel like one continuous surface emerging from the center rather than layered panels appearing in sequence. The Morph Popover exit also used a separate choreography, which made closing feel disconnected and abrupt compared with opening.

## Validation

- `bunx biome check components/motion/popover-morph.tsx`
- `bun run typecheck`
- `bun test`
- `bun run check:registry`
- `git diff --check`
