### PR TITLE
feat: add Dia text animation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `popover` | `components/motion/popover.tsx`, `popover-morph.tsx` | Composable popover, two variants. **Gooey** (`Popover`, `PopoverTrigger`, `PopoverContent`, install `@beui/popover`): panel oozes out of the trigger via an SVG goo filter (liquid neck that stretches/pinches) with crisp content fading in on top. **Morph** (`MorphPopover`, `MorphPopoverTrigger`, `MorphPopoverContent`, install `@beui/popover-morph`): panel laid out full size but clipped to the corner nearest the trigger, then unclips as one piece with a drop-shadow that hugs the shape; side/align aware. Both inline-anchored, click trigger, controlled/uncontrolled |
 | `morphing-modal` | `components/motion/morphing-modal.tsx` | Panel that morphs height across inner views with blur cross-fade |
 | `center-morph-modal` | `components/motion/center-morph-modal.tsx` | Composable modal whose full-size surface unfolds from its exact center toward every edge, then folds back the same way with an inset close control |
+| `chromatic-text-reveal` | `components/motion/chromatic-text-reveal.tsx` | Fixed sentence prefix with a cycling final word revealed by a chromatic sweep |
 | `text-reveal` | `components/motion/text-reveal.tsx` | Word or character reveal with spring slide-up and blur |
 | `text-shimmer` | `components/motion/text-shimmer.tsx` | Gradient sweep across text for loading or emphasis |
 | `text-cascade` | `components/motion/text-cascade.tsx` | Letter-by-letter slot roll for standalone text |

--- a/components/app/chrome/site-header.tsx
+++ b/components/app/chrome/site-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowUpRight, Star, SwatchBook } from "lucide-react";
+import { ArrowUpRight, SwatchBook } from "lucide-react";
 import { useMotionValueEvent, useScroll } from "motion/react";
 import Image from "next/image";
 import Link from "next/link";

--- a/components/motion/chromatic-text-reveal.tsx
+++ b/components/motion/chromatic-text-reveal.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import {
+  type MotionStyle,
+  motion,
+  type UseInViewOptions,
+  useInView,
+  useReducedMotion,
+} from "motion/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { EASE_IN_OUT, EASE_OUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+const CHROMATIC_PALETTE = [
+  "#60a5fa",
+  "#818cf8",
+  "#c084fc",
+  "#fb7185",
+  "#fbbf24",
+];
+
+const TRAIL_HALF_WIDTH = 14;
+const REVEAL_START = `-${TRAIL_HALF_WIDTH}%`;
+const REVEAL_FINISH = `${100 + TRAIL_HALF_WIDTH}%`;
+
+export type ChromaticTextRevealProps = {
+  /** Sentence fragment that remains fixed while the final word changes. */
+  prefix: string;
+  /** Words revealed one after another after the fixed prefix. */
+  words: string[];
+  /** Colors used along the moving chromatic edge. */
+  colors?: string[];
+  /** Final text color after the sweep passes. */
+  foregroundColor?: string;
+  /** Sweep duration in seconds. */
+  duration?: number;
+  /** Delay before the first sweep, in seconds. */
+  delay?: number;
+  /** Rest after a word finishes revealing, in seconds. */
+  pauseDuration?: number;
+  /** Returns to the first word after the final word. */
+  loop?: boolean;
+  /** Starts when the text enters the viewport. */
+  startOnView?: boolean;
+  /** Only starts on the first viewport entry. */
+  once?: boolean;
+  /** IntersectionObserver root margin used by the viewport trigger. */
+  inViewMargin?: UseInViewOptions["margin"];
+  className?: string;
+};
+
+function composeChromaticGradient(colors: string[], foregroundColor: string) {
+  const palette = colors.length > 0 ? colors : CHROMATIC_PALETTE;
+  const colorStops = palette.map((color, index) => {
+    const offset =
+      palette.length === 1
+        ? 0
+        : -TRAIL_HALF_WIDTH +
+          (index / (palette.length - 1)) * TRAIL_HALF_WIDTH * 2;
+    const operator = offset < 0 ? "-" : "+";
+    const distance = Number(Math.abs(offset).toFixed(2));
+    return `${color} calc(var(--chromatic-sweep) ${operator} ${distance}%)`;
+  });
+
+  return `linear-gradient(90deg, ${foregroundColor} 0%, ${foregroundColor} calc(var(--chromatic-sweep) - ${TRAIL_HALF_WIDTH}%), ${colorStops.join(", ")}, transparent calc(var(--chromatic-sweep) + ${TRAIL_HALF_WIDTH}%), transparent 100%)`;
+}
+
+export function ChromaticTextReveal({
+  prefix,
+  words,
+  colors = CHROMATIC_PALETTE,
+  foregroundColor = "var(--foreground)",
+  duration = 1.2,
+  delay = 0,
+  pauseDuration = 0.8,
+  loop = true,
+  startOnView = true,
+  once = true,
+  inViewMargin,
+  className,
+}: ChromaticTextRevealProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const timerRef = useRef<number | null>(null);
+  const [wordIndex, setWordIndex] = useState(0);
+  const reduceMotion = useReducedMotion();
+  const isInView = useInView(ref, {
+    once,
+    margin: inViewMargin,
+    amount: 0.4,
+  });
+  const shouldReveal = !startOnView || isInView || reduceMotion;
+  const backgroundImage = composeChromaticGradient(colors, foregroundColor);
+  const hasWords = words.length > 0;
+  const activeIndex = hasWords ? wordIndex % words.length : 0;
+  const activeWord = words[activeIndex] ?? "";
+  const sizingWords = Array.from(new Set(words));
+
+  const clearPendingWord = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const scheduleNextWord = useCallback(() => {
+    clearPendingWord();
+    const isLastWord = activeIndex === words.length - 1;
+    if (
+      reduceMotion ||
+      !shouldReveal ||
+      words.length < 2 ||
+      (isLastWord && !loop)
+    ) {
+      return;
+    }
+
+    timerRef.current = window.setTimeout(() => {
+      setWordIndex((index) => (index + 1) % words.length);
+    }, pauseDuration * 1000);
+  }, [
+    activeIndex,
+    clearPendingWord,
+    loop,
+    pauseDuration,
+    reduceMotion,
+    shouldReveal,
+    words.length,
+  ]);
+
+  useEffect(() => clearPendingWord, [clearPendingWord]);
+
+  return (
+    <span ref={ref} className={cn("inline-flex items-baseline", className)}>
+      <span>
+        {prefix}
+        {hasWords ? "\u00A0" : null}
+      </span>
+      {hasWords ? (
+        <span className="relative inline-grid">
+          {sizingWords.map((word) => (
+            <span
+              key={word}
+              aria-hidden
+              className="invisible col-start-1 row-start-1 whitespace-nowrap"
+            >
+              {word}
+            </span>
+          ))}
+          {/* Moving a clipped text gradient defines this effect. Paint
+              containment bounds that deliberate repaint to the active word. */}
+          <motion.span
+            key={`${activeWord}-${activeIndex}`}
+            aria-hidden
+            initial={
+              reduceMotion
+                ? false
+                : {
+                    opacity: 0.56,
+                    filter: "blur(6px)",
+                    transform: "translateY(5px)",
+                  }
+            }
+            animate={{
+              "--chromatic-sweep": shouldReveal
+                ? REVEAL_FINISH
+                : REVEAL_START,
+              opacity: 1,
+              filter: "blur(0px)",
+              transform: "translateY(0px)",
+            }}
+            transition={{
+              "--chromatic-sweep": reduceMotion
+                ? { duration: 0 }
+                : { duration, delay, ease: EASE_IN_OUT },
+              opacity: reduceMotion
+                ? { duration: 0 }
+                : { duration: 0.28, ease: EASE_OUT },
+              filter: reduceMotion
+                ? { duration: 0 }
+                : { duration: 0.36, ease: EASE_OUT },
+              transform: reduceMotion
+                ? { duration: 0 }
+                : { duration: 0.36, ease: EASE_OUT },
+            }}
+            onAnimationComplete={scheduleNextWord}
+            className="absolute start-0 top-0 whitespace-nowrap bg-clip-text text-transparent [background-image:var(--chromatic-gradient)] [contain:paint]"
+            style={{
+              "--chromatic-sweep": reduceMotion
+                ? REVEAL_FINISH
+                : REVEAL_START,
+              "--chromatic-gradient": backgroundImage,
+              backgroundSize: "100% 100%",
+              backgroundRepeat: "no-repeat",
+            } as MotionStyle}
+          >
+            {activeWord}
+          </motion.span>
+          <span className="sr-only">{activeWord}</span>
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -90,6 +90,11 @@ export const previews: Record<string, ComponentType> = {
   "motion/text-shimmer": dynamic(() =>
     import("./motion/text-shimmer.preview").then((m) => m.TextShimmerPreview),
   ),
+  "motion/chromatic-text-reveal": dynamic(() =>
+    import("./motion/chromatic-text-reveal.preview").then(
+      (m) => m.ChromaticTextRevealPreview,
+    ),
+  ),
   "motion/number": dynamic(() =>
     import("./motion/number.preview").then((m) => m.NumberPreview),
   ),

--- a/components/previews/motion/chromatic-text-reveal.preview.tsx
+++ b/components/previews/motion/chromatic-text-reveal.preview.tsx
@@ -1,0 +1,12 @@
+import { ChromaticTextReveal } from "@/components/motion/chromatic-text-reveal";
+
+export function ChromaticTextRevealPreview() {
+  return (
+    <ChromaticTextReveal
+      prefix="Motion that feels"
+      words={["natural.", "intentional.", "alive."]}
+      startOnView={false}
+      className="text-4xl font-medium tracking-[-0.04em] text-foreground sm:text-5xl"
+    />
+  );
+}

--- a/components/previews/motion/text-animation.preview.tsx
+++ b/components/previews/motion/text-animation.preview.tsx
@@ -2,17 +2,24 @@
 
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useState } from "react";
+import { ChromaticTextReveal } from "@/components/motion/chromatic-text-reveal";
 import { TextReveal } from "@/components/motion/text-reveal";
 import { TextShimmer } from "@/components/motion/text-shimmer";
 import { EASE_OUT } from "@/lib/ease";
 
+const variants = ["chromatic", "reveal", "shimmer"] as const;
+
 export function TextAnimationPreview() {
-  const [variant, setVariant] = useState<"reveal" | "shimmer">("reveal");
+  const [variant, setVariant] =
+    useState<(typeof variants)[number]>("chromatic");
 
   useEffect(() => {
     const id = window.setInterval(() => {
-      setVariant((currentVariant) => currentVariant === "reveal" ? "shimmer" : "reveal");
-    }, 3000);
+      setVariant((currentVariant) => {
+        const index = variants.indexOf(currentVariant);
+        return variants[(index + 1) % variants.length];
+      });
+    }, 3200);
     return () => window.clearInterval(id);
   }, []);
 
@@ -34,6 +41,13 @@ export function TextAnimationPreview() {
               blur={6}
               yOffset="18%"
               className="text-balance text-3xl font-semibold tracking-tight text-foreground"
+            />
+          ) : variant === "chromatic" ? (
+            <ChromaticTextReveal
+              prefix="Motion that feels"
+              words={["natural.", "intentional.", "alive."]}
+              startOnView={false}
+              className="text-3xl font-semibold tracking-tight"
             />
           ) : (
             <TextShimmer duration={1.8} className="text-xl font-semibold">

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -30,7 +30,7 @@ const COMPONENT_DATES = {
     publishedAt: "2026-07-21",
     updatedAt: "2026-07-21",
   },
-  "motion/text-animation": { publishedAt: "2026-05-17", updatedAt: "2026-06-28" },
+  "motion/text-animation": { publishedAt: "2026-05-17", updatedAt: "2026-07-25" },
   "motion/number": { publishedAt: "2026-05-17", updatedAt: "2026-06-28" },
   "motion/animated-badge": { publishedAt: "2026-06-05", updatedAt: "2026-06-10" },
   "motion/action-swap": { publishedAt: "2026-06-10", updatedAt: "2026-06-28" },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -356,13 +356,28 @@ export const registry: CategoryEntry[] = [
       {
         slug: "text-animation",
         name: "Text Animation",
-        description: "Animated text primitives for reveal sequences, shimmer loading states and letter-cascade swaps.",
+        description:
+          "Animated text primitives for spring reveals, chromatic sweeps, shimmer loading states and letter-cascade swaps.",
         file: "components/motion/text-reveal.tsx",
+        badge: "new",
+        launchedAt: "2026-07-25",
         extraFiles: [
+          "components/motion/chromatic-text-reveal.tsx",
           "components/motion/text-shimmer.tsx",
           "components/motion/text-cascade.tsx",
         ],
         examples: [
+          {
+            slug: "chromatic-reveal",
+            name: "Dia Text Animation",
+            description:
+              "A Dia-inspired text effect with a fixed sentence prefix and a cycling final word revealed by a colorful sweep.",
+            installSlug: "chromatic-text-reveal",
+            file: "components/motion/chromatic-text-reveal.tsx",
+            previewKey: "motion/chromatic-text-reveal",
+            previewFile:
+              "components/previews/motion/chromatic-text-reveal.preview.tsx",
+          },
           {
             slug: "reveal",
             name: "Text Reveal",

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -13,6 +13,7 @@ import {
   CenterMorphModalTrigger,
 } from "@/components/motion/center-morph-modal";
 import { Checkbox } from "@/components/motion/checkbox";
+import { ChromaticTextReveal } from "@/components/motion/chromatic-text-reveal";
 import { Input } from "@/components/motion/input";
 import { Parallax } from "@/components/motion/parallax";
 import {
@@ -52,6 +53,15 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
           { id: "components", label: "Components" },
           { id: "changelog", label: "Changelog" },
         ]}
+      />
+    ),
+  ],
+  [
+    "ChromaticTextReveal",
+    () => (
+      <ChromaticTextReveal
+        prefix="Make it feel"
+        words={["alive.", "effortless."]}
       />
     ),
   ],

--- a/tests/chromatic-text-reveal.test.tsx
+++ b/tests/chromatic-text-reveal.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { ChromaticTextReveal } from "@/components/motion/chromatic-text-reveal";
+
+afterEach(cleanup);
+
+describe("ChromaticTextReveal", () => {
+  test("renders the fixed prefix and active word as accessible content", () => {
+    const { getByText } = render(
+      <ChromaticTextReveal
+        prefix="Make it feel"
+        words={["alive.", "effortless."]}
+      />,
+    );
+
+    expect(getByText("Make it feel").tagName).toBe("SPAN");
+    expect(getByText("alive.", { selector: "span:not([aria-hidden])" })).toBeTruthy();
+  });
+
+  test("cycles only the final word while keeping the prefix mounted", async () => {
+    const { getByText } = render(
+      <ChromaticTextReveal
+        prefix="Make it feel"
+        words={["alive.", "effortless."]}
+        duration={0.01}
+        pauseDuration={0.01}
+        startOnView={false}
+        loop={false}
+      />,
+    );
+    const prefix = getByText("Make it feel");
+
+    await waitFor(() => {
+      expect(
+        getByText("effortless.", { selector: "span:not([aria-hidden])" }),
+      ).toBeTruthy();
+    });
+    expect(getByText("Make it feel")).toBe(prefix);
+  });
+
+  test("uses custom colors in the reveal gradient", () => {
+    const { getByText } = render(
+      <ChromaticTextReveal
+        prefix="Your"
+        words={["colors."]}
+        colors={["rgb(96, 165, 250)", "rgb(244, 114, 182)"]}
+      />,
+    );
+
+    const text = getByText("colors.", {
+      selector: "span.absolute[aria-hidden]",
+    });
+    const gradient = text.style.getPropertyValue("--chromatic-gradient");
+    expect(gradient).toContain("rgb(96, 165, 250)");
+    expect(gradient).toContain("rgb(244, 114, 182)");
+  });
+
+  test("applies the final text color and custom classes", async () => {
+    const { getByText } = render(
+      <ChromaticTextReveal
+        prefix="Styled"
+        words={["reveal."]}
+        foregroundColor="rgb(10, 20, 30)"
+        duration={0}
+        startOnView={false}
+        className="headline"
+      />,
+    );
+
+    expect(getByText("Styled").parentElement?.classList.contains("headline")).toBe(
+      true,
+    );
+    await waitFor(() => {
+      expect(
+        getByText("reveal.", {
+          selector: "span.absolute[aria-hidden]",
+        }).style.getPropertyValue("--chromatic-gradient"),
+      ).toContain("rgb(10, 20, 30)");
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- adds **Dia Text Animation** as the first example in the Text Animation collection
- keeps the sentence prefix fixed while the final word cycles through a colorful reveal
- reserves the widest word with CSS Grid to prevent layout shift
- includes reduced-motion behavior, accessibility coverage, registry metadata, and a dedicated preview
- publishes the implementation through `@beui/chromatic-text-reveal`

## Why

This gives beUI a polished, Dia-inspired headline treatment for product messaging while keeping the implementation and public API native to the library.

## Validation

- `bun run check`
- `bun test` — 41 passing
- `git diff --check`

Biome reports one existing unrelated warning for the unused `Star` import in `components/app/chrome/site-header.tsx`.
