### PR TITLE
feat: add animated sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `pull-to-refresh` | `components/motion/pull-to-refresh.tsx` | Native-feeling refresh container with touch and mouse pull resistance, threshold feedback and async refresh handling |
 | `shared-layout-bg` | `components/motion/shared-layout-bg.tsx` | Pill that glides between hovered items via shared layout |
 | `bounce-sidebar` | `components/motion/bounce-sidebar.tsx` | Vertical navigation whose active dot jumps between rows on a curved spring path; controlled/uncontrolled, links or buttons, reduced-motion safe |
-| `animated-sidebar` | `components/motion/animated-sidebar.tsx` | Shadcn-style application sidebar with provider-managed desktop/mobile state, icon or off-canvas collapse, animated content inset, toggle rail, grouped menu primitives, keyboard shortcut and a focus-managed mobile sheet |
+| `animated-sidebar` | `components/motion/animated-sidebar.tsx` | Shadcn-style application sidebar with provider-managed desktop/mobile state, icon or off-canvas collapse, morphing nested-menu primitives, animated content inset, toggle rail, keyboard shortcut and a focus-managed mobile sheet |
 | `preview-rail` | `components/motion/preview-rail.tsx` | Vertical or horizontal navigation ticks that form a pyramid around the hovered item with a gliding preview card |
 | `dock` | `components/motion/dock.tsx` | macOS-style dock with grouped actions and gliding active pill |
 | `tooltip` | `components/motion/tooltip.tsx` | Hover/focus tooltip with blur enter/exit and spring spawn |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `pull-to-refresh` | `components/motion/pull-to-refresh.tsx` | Native-feeling refresh container with touch and mouse pull resistance, threshold feedback and async refresh handling |
 | `shared-layout-bg` | `components/motion/shared-layout-bg.tsx` | Pill that glides between hovered items via shared layout |
 | `bounce-sidebar` | `components/motion/bounce-sidebar.tsx` | Vertical navigation whose active dot jumps between rows on a curved spring path; controlled/uncontrolled, links or buttons, reduced-motion safe |
+| `animated-sidebar` | `components/motion/animated-sidebar.tsx` | Shadcn-style application sidebar with provider-managed desktop/mobile state, icon or off-canvas collapse, animated content inset, toggle rail, grouped menu primitives, keyboard shortcut and a focus-managed mobile sheet |
 | `preview-rail` | `components/motion/preview-rail.tsx` | Vertical or horizontal navigation ticks that form a pyramid around the hovered item with a gliding preview card |
 | `dock` | `components/motion/dock.tsx` | macOS-style dock with grouped actions and gliding active pill |
 | `tooltip` | `components/motion/tooltip.tsx` | Hover/focus tooltip with blur enter/exit and spring spawn |

--- a/components/motion/animated-sidebar.tsx
+++ b/components/motion/animated-sidebar.tsx
@@ -25,7 +25,6 @@ import { SharedLayoutBg } from "@/components/motion/shared-layout-bg";
 import {
   EASE_DRAWER,
   EASE_OUT,
-  EASE_OUT_CSS,
   SPRING_LAYOUT,
 } from "@/lib/ease";
 import { cn } from "@/lib/utils";
@@ -41,6 +40,26 @@ const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 const PANEL_TRANSITION = {
   duration: 0.36,
   ease: EASE_DRAWER,
+} as const;
+
+// The desktop rail is one surface changing shape, so a lightly underdamped
+// spring makes the width settle without scaling or stretching its contents.
+const SIDEBAR_MORPH_TRANSITION = {
+  type: "spring",
+  stiffness: 380,
+  damping: 28,
+  mass: 0.75,
+} as const;
+
+const LABEL_ENTER_TRANSITION = {
+  duration: 0.2,
+  delay: 0.08,
+  ease: EASE_OUT,
+} as const;
+
+const LABEL_EXIT_TRANSITION = {
+  duration: 0.12,
+  ease: EASE_OUT,
 } as const;
 
 const REDUCED_TRANSITION = {
@@ -453,15 +472,13 @@ export const AnimatedSidebar = forwardRef<HTMLElement, AnimatedSidebarProps>(
         data-collapsible={collapsible}
         data-variant={variant}
         data-side={side}
-        style={{
-          ...style,
-          width,
-          transitionDuration: context.reduce ? "0ms" : "280ms",
-          transitionProperty: "width",
-          transitionTimingFunction: EASE_OUT_CSS,
-        }}
+        animate={{ width }}
+        transition={
+          context.reduce ? { duration: 0 } : SIDEBAR_MORPH_TRANSITION
+        }
+        style={style}
         className={cn(
-          "group/sidebar relative hidden h-auto shrink-0 md:block",
+          "group/sidebar relative hidden h-auto shrink-0 md:block will-change-[width]",
           "peer",
           side === "right" && "order-last",
           className,
@@ -833,7 +850,11 @@ export function AnimatedSidebarMenuButton({
           x: panel.collapsed ? -4 : 0,
         }}
         transition={
-          context.reduce ? REDUCED_TRANSITION : PANEL_TRANSITION
+          context.reduce
+            ? REDUCED_TRANSITION
+            : panel.collapsed
+              ? LABEL_EXIT_TRANSITION
+              : LABEL_ENTER_TRANSITION
         }
         aria-hidden={panel.collapsed}
         className={cn(
@@ -852,11 +873,10 @@ export function AnimatedSidebarMenuButton({
   );
 
   const interactiveClassName = cn(
-    "relative flex min-h-9 w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-xl px-2.5 text-left text-sm font-medium outline-none",
+    "relative flex min-h-9 w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-xl px-3 text-left text-sm font-medium outline-none",
     "text-muted-foreground transition-colors hover:text-foreground",
     "focus-visible:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring",
     isActive && "text-foreground",
-    panel.collapsed && "justify-center px-0",
     disabled && "cursor-not-allowed opacity-40",
     className,
   );

--- a/components/motion/animated-sidebar.tsx
+++ b/components/motion/animated-sidebar.tsx
@@ -1,0 +1,895 @@
+"use client";
+
+import {
+  type HTMLMotionProps,
+  motion,
+  useReducedMotion,
+} from "motion/react";
+import {
+  type ButtonHTMLAttributes,
+  type CSSProperties,
+  createContext,
+  forwardRef,
+  type HTMLAttributes,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { createPortal } from "react-dom";
+import { SharedLayoutBg } from "@/components/motion/shared-layout-bg";
+import {
+  EASE_DRAWER,
+  EASE_OUT,
+  EASE_OUT_CSS,
+  SPRING_LAYOUT,
+} from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+type SidebarState = "expanded" | "collapsed";
+type SidebarSide = "left" | "right";
+type SidebarVariant = "sidebar" | "floating" | "inset";
+type SidebarCollapsible = "offcanvas" | "icon" | "none";
+
+const MOBILE_QUERY = "(max-width: 767px)";
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+const PANEL_TRANSITION = {
+  duration: 0.36,
+  ease: EASE_DRAWER,
+} as const;
+
+const REDUCED_TRANSITION = {
+  duration: 0.16,
+  ease: EASE_OUT,
+} as const;
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function subscribeToMobileQuery(callback: () => void) {
+  const query = window.matchMedia(MOBILE_QUERY);
+  query.addEventListener("change", callback);
+  return () => query.removeEventListener("change", callback);
+}
+
+function getMobileSnapshot() {
+  return window.matchMedia(MOBILE_QUERY).matches;
+}
+
+function getServerMobileSnapshot() {
+  return false;
+}
+
+function useIsMobile() {
+  return useSyncExternalStore(
+    subscribeToMobileQuery,
+    getMobileSnapshot,
+    getServerMobileSnapshot,
+  );
+}
+
+interface AnimatedSidebarContextValue {
+  isMobile: boolean;
+  layoutId: string;
+  open: boolean;
+  openMobile: boolean;
+  reduce: boolean;
+  setOpen: (open: boolean) => void;
+  setOpenMobile: (open: boolean) => void;
+  state: SidebarState;
+  toggleSidebar: () => void;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+}
+
+const AnimatedSidebarContext =
+  createContext<AnimatedSidebarContextValue | null>(null);
+
+interface AnimatedSidebarPanelContextValue {
+  collapsed: boolean;
+  collapsible: SidebarCollapsible;
+  side: SidebarSide;
+}
+
+const AnimatedSidebarPanelContext =
+  createContext<AnimatedSidebarPanelContextValue | null>(null);
+
+export function useAnimatedSidebar() {
+  const context = useContext(AnimatedSidebarContext);
+  if (!context) {
+    throw new Error(
+      "useAnimatedSidebar must be used inside AnimatedSidebarProvider.",
+    );
+  }
+  return context;
+}
+
+function useAnimatedSidebarPanel() {
+  const context = useContext(AnimatedSidebarPanelContext);
+  if (!context) {
+    throw new Error(
+      "Animated Sidebar parts must be used inside AnimatedSidebar.",
+    );
+  }
+  return context;
+}
+
+type SidebarProviderStyle = CSSProperties & {
+  "--sidebar-width"?: string;
+  "--sidebar-width-icon"?: string;
+  "--sidebar-width-mobile"?: string;
+};
+
+export interface AnimatedSidebarProviderProps
+  extends HTMLAttributes<HTMLDivElement> {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  openMobile?: boolean;
+  defaultOpenMobile?: boolean;
+  onOpenMobileChange?: (open: boolean) => void;
+  style?: SidebarProviderStyle;
+}
+
+export function AnimatedSidebarProvider({
+  children,
+  open,
+  defaultOpen = true,
+  onOpenChange,
+  openMobile,
+  defaultOpenMobile = false,
+  onOpenMobileChange,
+  className,
+  style,
+  ...props
+}: AnimatedSidebarProviderProps) {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const [internalOpenMobile, setInternalOpenMobile] =
+    useState(defaultOpenMobile);
+  const isMobile = useIsMobile();
+  const reduce = useReducedMotion() ?? false;
+  const generatedId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const desktopOpen = open ?? internalOpen;
+  const mobileOpen = openMobile ?? internalOpenMobile;
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (open === undefined) setInternalOpen(nextOpen);
+      onOpenChange?.(nextOpen);
+    },
+    [onOpenChange, open],
+  );
+
+  const setOpenMobile = useCallback(
+    (nextOpen: boolean) => {
+      if (openMobile === undefined) setInternalOpenMobile(nextOpen);
+      onOpenMobileChange?.(nextOpen);
+    },
+    [onOpenMobileChange, openMobile],
+  );
+
+  const toggleSidebar = useCallback(() => {
+    if (isMobile) setOpenMobile(!mobileOpen);
+    else setOpen(!desktopOpen);
+  }, [desktopOpen, isMobile, mobileOpen, setOpen, setOpenMobile]);
+
+  useEffect(() => {
+    const handleShortcut = (event: KeyboardEvent) => {
+      if (
+        event.key.toLowerCase() === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener("keydown", handleShortcut);
+    return () => window.removeEventListener("keydown", handleShortcut);
+  }, [toggleSidebar]);
+
+  return (
+    <AnimatedSidebarContext.Provider
+      value={{
+        isMobile,
+        layoutId: `${generatedId}-active`,
+        open: desktopOpen,
+        openMobile: mobileOpen,
+        reduce,
+        setOpen,
+        setOpenMobile,
+        state: desktopOpen ? "expanded" : "collapsed",
+        toggleSidebar,
+        triggerRef,
+      }}
+    >
+      <div
+        {...props}
+        data-slot="sidebar-wrapper"
+        data-state={desktopOpen ? "expanded" : "collapsed"}
+        style={{
+          "--sidebar-width": "16rem",
+          "--sidebar-width-icon": "4.25rem",
+          "--sidebar-width-mobile": "18rem",
+          ...style,
+        }}
+        className={cn(
+          "group/sidebar-wrapper flex min-h-svh w-full min-w-0",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </AnimatedSidebarContext.Provider>
+  );
+}
+
+function MobileSidebar({
+  ariaLabel,
+  children,
+  className,
+  side,
+}: {
+  ariaLabel: string;
+  children: ReactNode;
+  className?: string;
+  side: SidebarSide;
+}) {
+  const context = useAnimatedSidebar();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!context.openMobile) return;
+
+    const body = document.body;
+    const scrollY = window.scrollY;
+    const previousBodyStyles = {
+      left: body.style.left,
+      overflow: body.style.overflow,
+      position: body.style.position,
+      right: body.style.right,
+      top: body.style.top,
+    };
+
+    body.style.position = "fixed";
+    body.style.top = `-${scrollY}px`;
+    body.style.left = "0";
+    body.style.right = "0";
+    body.style.overflow = "hidden";
+
+    const focusFrame = requestAnimationFrame(() => {
+      const firstFocusable =
+        panelRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      (firstFocusable ?? panelRef.current)?.focus({ preventScroll: true });
+    });
+
+    return () => {
+      cancelAnimationFrame(focusFrame);
+      body.style.position = previousBodyStyles.position;
+      body.style.top = previousBodyStyles.top;
+      body.style.left = previousBodyStyles.left;
+      body.style.right = previousBodyStyles.right;
+      body.style.overflow = previousBodyStyles.overflow;
+      window.scrollTo(0, scrollY);
+      context.triggerRef.current?.focus({ preventScroll: true });
+    };
+  }, [context.openMobile, context.triggerRef]);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      className={cn(
+        "pointer-events-none fixed inset-0 z-50 md:hidden",
+        context.openMobile ? "visible" : "invisible",
+      )}
+    >
+      <motion.button
+        type="button"
+        aria-label="Close sidebar"
+        tabIndex={context.openMobile ? 0 : -1}
+        initial={false}
+        animate={{ opacity: context.openMobile ? 1 : 0 }}
+        transition={
+          context.reduce ? REDUCED_TRANSITION : PANEL_TRANSITION
+        }
+        onClick={() => context.setOpenMobile(false)}
+        className={cn(
+          "absolute inset-0 bg-black/40",
+          context.openMobile
+            ? "pointer-events-auto"
+            : "pointer-events-none",
+        )}
+      />
+
+      <motion.div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        aria-hidden={!context.openMobile}
+        inert={!context.openMobile}
+        tabIndex={-1}
+        data-mobile="true"
+        data-state={context.openMobile ? "expanded" : "collapsed"}
+        data-side={side}
+        initial={false}
+        animate={{
+          opacity: context.reduce
+            ? context.openMobile
+              ? 1
+              : 0
+            : 1,
+          x: context.reduce
+            ? 0
+            : context.openMobile
+              ? "0%"
+              : side === "left"
+                ? "-100%"
+                : "100%",
+        }}
+        transition={
+          context.reduce ? REDUCED_TRANSITION : PANEL_TRANSITION
+        }
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            context.setOpenMobile(false);
+            return;
+          }
+
+          if (event.key !== "Tab") return;
+          const focusable = panelRef.current
+            ? Array.from(
+                panelRef.current.querySelectorAll<HTMLElement>(
+                  FOCUSABLE_SELECTOR,
+                ),
+              )
+            : [];
+
+          if (focusable.length === 0) {
+            event.preventDefault();
+            panelRef.current?.focus();
+            return;
+          }
+
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }}
+        className={cn(
+          "pointer-events-auto absolute inset-y-0 flex h-dvh w-(--sidebar-width-mobile) max-w-[88vw] flex-col overflow-hidden",
+          "border-border bg-background shadow-2xl will-change-transform",
+          side === "left" ? "left-0 border-r" : "right-0 border-l",
+          !context.openMobile && "pointer-events-none",
+          className,
+        )}
+      >
+        <AnimatedSidebarPanelContext.Provider
+          value={{ collapsed: false, collapsible: "none", side }}
+        >
+          {children}
+        </AnimatedSidebarPanelContext.Provider>
+      </motion.div>
+    </div>,
+    document.body,
+  );
+}
+
+export interface AnimatedSidebarProps
+  extends Omit<HTMLMotionProps<"aside">, "children"> {
+  children?: ReactNode;
+  side?: SidebarSide;
+  variant?: SidebarVariant;
+  collapsible?: SidebarCollapsible;
+  ariaLabel?: string;
+  panelClassName?: string;
+}
+
+export const AnimatedSidebar = forwardRef<HTMLElement, AnimatedSidebarProps>(
+  function AnimatedSidebar(
+    {
+      side = "left",
+      variant = "sidebar",
+      collapsible = "icon",
+      ariaLabel = "Sidebar",
+      children,
+      className,
+      panelClassName,
+      style,
+      ...props
+    },
+    forwardedRef,
+  ) {
+    const context = useAnimatedSidebar();
+    const collapsed = collapsible !== "none" && !context.open;
+    const offcanvas = collapsed && collapsible === "offcanvas";
+    const width = offcanvas
+      ? "0px"
+      : collapsed
+        ? "var(--sidebar-width-icon)"
+        : "var(--sidebar-width)";
+
+    if (context.isMobile) {
+      return (
+        <MobileSidebar
+          ariaLabel={ariaLabel}
+          className={className}
+          side={side}
+        >
+          {children}
+        </MobileSidebar>
+      );
+    }
+
+    return (
+      <motion.aside
+        {...props}
+        ref={forwardedRef}
+        initial={false}
+        aria-label={ariaLabel}
+        data-slot="sidebar"
+        data-state={collapsed ? "collapsed" : "expanded"}
+        data-collapsible={collapsible}
+        data-variant={variant}
+        data-side={side}
+        style={{
+          ...style,
+          width,
+          transitionDuration: context.reduce ? "0ms" : "280ms",
+          transitionProperty: "width",
+          transitionTimingFunction: EASE_OUT_CSS,
+        }}
+        className={cn(
+          "group/sidebar relative hidden h-auto shrink-0 md:block",
+          "peer",
+          side === "right" && "order-last",
+          className,
+        )}
+      >
+        <motion.div
+          initial={false}
+          animate={{
+            opacity: offcanvas ? 0 : 1,
+            x: offcanvas ? (side === "left" ? "-100%" : "100%") : "0%",
+          }}
+          transition={
+            context.reduce ? REDUCED_TRANSITION : PANEL_TRANSITION
+          }
+          className={cn(
+            "sticky top-0 flex h-svh w-full flex-col overflow-hidden bg-background",
+            variant === "sidebar" &&
+              (side === "left" ? "border-border border-r" : "border-border border-l"),
+            variant === "floating" &&
+              "m-2 h-[calc(100svh-1rem)] rounded-2xl border border-border shadow-sm",
+            variant === "inset" && "m-2 h-[calc(100svh-1rem)] rounded-2xl",
+            panelClassName,
+          )}
+        >
+          <AnimatedSidebarPanelContext.Provider
+            value={{ collapsed, collapsible, side }}
+          >
+            {children}
+          </AnimatedSidebarPanelContext.Provider>
+        </motion.div>
+      </motion.aside>
+    );
+  },
+);
+
+export interface AnimatedSidebarTriggerProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const AnimatedSidebarTrigger = forwardRef<
+  HTMLButtonElement,
+  AnimatedSidebarTriggerProps
+>(function AnimatedSidebarTrigger(
+  { className, onClick, type = "button", ...props },
+  forwardedRef,
+) {
+  const context = useAnimatedSidebar();
+  const expanded = context.isMobile ? context.openMobile : context.open;
+
+  return (
+    <button
+      {...props}
+      ref={(node) => {
+        context.triggerRef.current = node;
+        if (typeof forwardedRef === "function") forwardedRef(node);
+        else if (forwardedRef) forwardedRef.current = node;
+      }}
+      type={type}
+      aria-label={props["aria-label"] ?? "Toggle sidebar"}
+      aria-expanded={expanded}
+      data-slot="sidebar-trigger"
+      data-state={expanded ? "expanded" : "collapsed"}
+      onClick={(event) => {
+        onClick?.(event);
+        if (!event.defaultPrevented) context.toggleSidebar();
+      }}
+      className={cn(
+        "inline-flex size-10 shrink-0 items-center justify-center rounded-xl outline-none",
+        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className,
+      )}
+    />
+  );
+});
+
+export interface AnimatedSidebarCloseProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const AnimatedSidebarClose = forwardRef<
+  HTMLButtonElement,
+  AnimatedSidebarCloseProps
+>(function AnimatedSidebarClose(
+  { className, onClick, type = "button", ...props },
+  forwardedRef,
+) {
+  const context = useAnimatedSidebar();
+
+  return (
+    <button
+      {...props}
+      ref={forwardedRef}
+      type={type}
+      aria-label={props["aria-label"] ?? "Close sidebar"}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        if (context.isMobile) context.setOpenMobile(false);
+        else context.setOpen(false);
+      }}
+      className={cn(
+        "inline-flex size-10 shrink-0 items-center justify-center rounded-xl outline-none",
+        "focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+    />
+  );
+});
+
+export interface AnimatedSidebarRailProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const AnimatedSidebarRail = forwardRef<
+  HTMLButtonElement,
+  AnimatedSidebarRailProps
+>(function AnimatedSidebarRail(
+  { className, onClick, type = "button", ...props },
+  forwardedRef,
+) {
+  const context = useAnimatedSidebar();
+  const panel = useAnimatedSidebarPanel();
+
+  return (
+    <button
+      {...props}
+      ref={forwardedRef}
+      type={type}
+      data-side={panel.side}
+      aria-label={props["aria-label"] ?? "Toggle sidebar"}
+      title="Toggle sidebar"
+      tabIndex={-1}
+      onClick={(event) => {
+        onClick?.(event);
+        if (!event.defaultPrevented) context.toggleSidebar();
+      }}
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 outline-none md:block",
+        "after:absolute after:inset-y-0 after:left-1/2 after:w-px after:bg-transparent after:transition-colors hover:after:bg-border",
+        "data-[side=right]:right-0 data-[side=right]:translate-x-1/2 data-[side=left]:left-full",
+        className,
+      )}
+    />
+  );
+});
+
+export interface AnimatedSidebarInsetProps
+  extends HTMLMotionProps<"main"> {}
+
+export const AnimatedSidebarInset = forwardRef<
+  HTMLElement,
+  AnimatedSidebarInsetProps
+>(function AnimatedSidebarInset({ className, ...props }, forwardedRef) {
+  return (
+    <motion.main
+      {...props}
+      ref={forwardedRef}
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex min-h-svh min-w-0 flex-1 flex-col bg-background",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-2xl md:peer-data-[variant=inset]:shadow-sm",
+        className,
+      )}
+    />
+  );
+});
+
+export const AnimatedSidebarHeader = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function AnimatedSidebarHeader({ className, ...props }, forwardedRef) {
+  return (
+    <div
+      {...props}
+      ref={forwardedRef}
+      data-slot="sidebar-header"
+      className={cn("flex shrink-0 flex-col gap-2 p-3", className)}
+    />
+  );
+});
+
+export const AnimatedSidebarContent = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function AnimatedSidebarContent({ className, ...props }, forwardedRef) {
+  return (
+    <div
+      {...props}
+      ref={forwardedRef}
+      data-slot="sidebar-content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-2 py-2",
+        className,
+      )}
+    />
+  );
+});
+
+export const AnimatedSidebarFooter = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function AnimatedSidebarFooter({ className, ...props }, forwardedRef) {
+  return (
+    <div
+      {...props}
+      ref={forwardedRef}
+      data-slot="sidebar-footer"
+      className={cn(
+        "flex shrink-0 flex-col gap-2 border-border border-t p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]",
+        className,
+      )}
+    />
+  );
+});
+
+export const AnimatedSidebarGroup = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function AnimatedSidebarGroup({ className, ...props }, forwardedRef) {
+  return (
+    <div
+      {...props}
+      ref={forwardedRef}
+      data-slot="sidebar-group"
+      className={cn("flex w-full min-w-0 flex-col px-1 py-1.5", className)}
+    />
+  );
+});
+
+export const AnimatedSidebarGroupLabel = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function AnimatedSidebarGroupLabel(
+  { children, className, ...props },
+  forwardedRef,
+) {
+  const { collapsed } = useAnimatedSidebarPanel();
+
+  return (
+    <div
+      {...props}
+      ref={forwardedRef}
+      aria-hidden={collapsed}
+      data-slot="sidebar-group-label"
+      className={cn(
+        "mb-1 h-7 overflow-hidden px-2 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground transition-opacity",
+        collapsed ? "opacity-0" : "opacity-100",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+});
+
+export const AnimatedSidebarGroupContent = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function AnimatedSidebarGroupContent(
+  { className, ...props },
+  forwardedRef,
+) {
+  return (
+    <div
+      {...props}
+      ref={forwardedRef}
+      data-slot="sidebar-group-content"
+      className={cn("w-full min-w-0", className)}
+    />
+  );
+});
+
+export const AnimatedSidebarMenu = forwardRef<
+  HTMLUListElement,
+  HTMLAttributes<HTMLUListElement>
+>(function AnimatedSidebarMenu(
+  { children, className, ...props },
+  forwardedRef,
+) {
+  return (
+    <SharedLayoutBg
+      {...props}
+      ref={forwardedRef as React.Ref<HTMLElement>}
+      as="ul"
+      inset={0}
+      pillClassName="rounded-xl bg-muted/70"
+      data-slot="sidebar-menu"
+      className={cn("flex w-full min-w-0 list-none flex-col gap-0.5", className)}
+    >
+      {children}
+    </SharedLayoutBg>
+  );
+});
+
+export const AnimatedSidebarMenuItem = forwardRef<
+  HTMLLIElement,
+  HTMLAttributes<HTMLLIElement>
+>(function AnimatedSidebarMenuItem({ className, ...props }, forwardedRef) {
+  return (
+    <li
+      {...props}
+      ref={forwardedRef}
+      data-slot="sidebar-menu-item"
+      className={cn("relative", className)}
+    />
+  );
+});
+
+export interface AnimatedSidebarMenuButtonProps {
+  children: ReactNode;
+  icon?: ReactNode;
+  badge?: ReactNode;
+  href?: string;
+  isActive?: boolean;
+  disabled?: boolean;
+  closeOnSelect?: boolean;
+  target?: "_blank" | "_self" | "_parent" | "_top";
+  rel?: string;
+  onSelect?: () => void;
+  className?: string;
+}
+
+export function AnimatedSidebarMenuButton({
+  children,
+  icon,
+  badge,
+  href,
+  isActive = false,
+  disabled = false,
+  closeOnSelect = true,
+  target,
+  rel,
+  onSelect,
+  className,
+}: AnimatedSidebarMenuButtonProps) {
+  const context = useAnimatedSidebar();
+  const panel = useAnimatedSidebarPanel();
+  const textLabel = typeof children === "string" ? children : undefined;
+
+  const select = (
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ) => {
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+    onSelect?.();
+    if (context.isMobile && closeOnSelect) context.setOpenMobile(false);
+  };
+
+  const content = (
+    <>
+      {isActive ? (
+        <motion.span
+          layoutId={context.layoutId}
+          transition={context.reduce ? { duration: 0 } : SPRING_LAYOUT}
+          className="absolute inset-0 rounded-xl bg-muted"
+        />
+      ) : null}
+      {icon ? (
+        <span
+          aria-hidden="true"
+          className="relative z-10 grid size-5 shrink-0 place-items-center"
+        >
+          {icon}
+        </span>
+      ) : null}
+      <motion.span
+        initial={false}
+        animate={{
+          opacity: panel.collapsed ? 0 : 1,
+          x: panel.collapsed ? -4 : 0,
+        }}
+        transition={
+          context.reduce ? REDUCED_TRANSITION : PANEL_TRANSITION
+        }
+        aria-hidden={panel.collapsed}
+        className={cn(
+          "relative z-10 min-w-0 flex-1 truncate",
+          panel.collapsed && "pointer-events-none",
+        )}
+      >
+        {children}
+      </motion.span>
+      {badge && !panel.collapsed ? (
+        <span className="relative z-10 shrink-0 text-xs text-muted-foreground">
+          {badge}
+        </span>
+      ) : null}
+    </>
+  );
+
+  const interactiveClassName = cn(
+    "relative flex min-h-9 w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-xl px-2.5 text-left text-sm font-medium outline-none",
+    "text-muted-foreground transition-colors hover:text-foreground",
+    "focus-visible:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring",
+    isActive && "text-foreground",
+    panel.collapsed && "justify-center px-0",
+    disabled && "cursor-not-allowed opacity-40",
+    className,
+  );
+
+  return href ? (
+    <a
+      href={href}
+      target={target}
+      rel={
+        rel ??
+        (target === "_blank" ? "noreferrer noopener" : undefined)
+      }
+      aria-current={isActive ? "page" : undefined}
+      aria-disabled={disabled || undefined}
+      aria-label={panel.collapsed ? textLabel : undefined}
+      title={panel.collapsed ? textLabel : undefined}
+      tabIndex={disabled ? -1 : undefined}
+      onClick={select}
+      className={interactiveClassName}
+    >
+      {content}
+    </a>
+  ) : (
+    <button
+      type="button"
+      disabled={disabled}
+      aria-current={isActive ? "page" : undefined}
+      aria-label={panel.collapsed ? textLabel : undefined}
+      title={panel.collapsed ? textLabel : undefined}
+      onClick={select}
+      className={interactiveClassName}
+    >
+      {content}
+    </button>
+  );
+}

--- a/components/motion/animated-sidebar.tsx
+++ b/components/motion/animated-sidebar.tsx
@@ -29,6 +29,7 @@ import {
   EASE_DRAWER,
   EASE_OUT,
   SPRING_LAYOUT,
+  SPRING_PRESS,
 } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 
@@ -951,7 +952,7 @@ export function AnimatedSidebarMenuSubButton({
   );
 
   return href ? (
-    <a
+    <motion.a
       href={href}
       target={target}
       rel={
@@ -962,20 +963,24 @@ export function AnimatedSidebarMenuSubButton({
       aria-disabled={disabled || undefined}
       tabIndex={disabled ? -1 : undefined}
       onClick={select}
+      whileTap={context.reduce || disabled ? undefined : { scale: 0.98 }}
+      transition={SPRING_PRESS}
       className={interactiveClassName}
     >
       {content}
-    </a>
+    </motion.a>
   ) : (
-    <button
+    <motion.button
       type="button"
       disabled={disabled}
       aria-current={isActive ? "page" : undefined}
       onClick={select}
+      whileTap={context.reduce || disabled ? undefined : { scale: 0.98 }}
+      transition={SPRING_PRESS}
       className={interactiveClassName}
     >
       {content}
-    </button>
+    </motion.button>
   );
 }
 
@@ -1002,7 +1007,7 @@ export function AnimatedSidebarMenuButton({
   isActive = false,
   ariaExpanded,
   disabled = false,
-  closeOnSelect = true,
+  closeOnSelect,
   target,
   rel,
   onSelect,
@@ -1020,7 +1025,11 @@ export function AnimatedSidebarMenuButton({
       return;
     }
     onSelect?.();
-    if (context.isMobile && closeOnSelect) context.setOpenMobile(false);
+    const shouldCloseOnSelect =
+      closeOnSelect ?? ariaExpanded === undefined;
+    if (context.isMobile && shouldCloseOnSelect) {
+      context.setOpenMobile(false);
+    }
   };
 
   const content = (
@@ -1094,7 +1103,7 @@ export function AnimatedSidebarMenuButton({
   );
 
   return href ? (
-    <a
+    <motion.a
       href={href}
       target={target}
       rel={
@@ -1108,12 +1117,14 @@ export function AnimatedSidebarMenuButton({
       title={panel.collapsed ? textLabel : undefined}
       tabIndex={disabled ? -1 : undefined}
       onClick={select}
+      whileTap={context.reduce || disabled ? undefined : { scale: 0.98 }}
+      transition={SPRING_PRESS}
       className={interactiveClassName}
     >
       {content}
-    </a>
+    </motion.a>
   ) : (
-    <button
+    <motion.button
       type="button"
       disabled={disabled}
       aria-current={isActive ? "page" : undefined}
@@ -1121,9 +1132,11 @@ export function AnimatedSidebarMenuButton({
       aria-label={panel.collapsed ? textLabel : undefined}
       title={panel.collapsed ? textLabel : undefined}
       onClick={select}
+      whileTap={context.reduce || disabled ? undefined : { scale: 0.98 }}
+      transition={SPRING_PRESS}
       className={interactiveClassName}
     >
       {content}
-    </button>
+    </motion.button>
   );
 }

--- a/components/motion/animated-sidebar.tsx
+++ b/components/motion/animated-sidebar.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { ChevronRight } from "lucide-react";
 import {
+  AnimatePresence,
   type HTMLMotionProps,
   motion,
   useReducedMotion,
+  type Variants,
 } from "motion/react";
 import {
   type ButtonHTMLAttributes,
@@ -61,6 +64,48 @@ const LABEL_EXIT_TRANSITION = {
   duration: 0.12,
   ease: EASE_OUT,
 } as const;
+
+const SUBMENU_TRANSITION = {
+  duration: 0.18,
+  ease: EASE_OUT,
+} as const;
+
+const SUBMENU_VARIANTS: Variants = {
+  closed: {
+    opacity: 0,
+    clipPath: "inset(0 0 100% 0 round 8px)",
+    transition: {
+      duration: 0.14,
+      ease: EASE_OUT,
+      staggerChildren: 0.025,
+      staggerDirection: -1,
+    },
+  },
+  open: {
+    opacity: 1,
+    clipPath: "inset(0 0 0% 0 round 8px)",
+    transition: {
+      duration: 0.2,
+      delayChildren: 0.035,
+      ease: EASE_OUT,
+      staggerChildren: 0.045,
+    },
+  },
+};
+
+const SUBMENU_ITEM_VARIANTS: Variants = {
+  closed: {
+    opacity: 0,
+    y: -6,
+    filter: "blur(3px)",
+  },
+  open: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: SUBMENU_TRANSITION,
+  },
+};
 
 const REDUCED_TRANSITION = {
   duration: 0.16,
@@ -762,6 +807,7 @@ export const AnimatedSidebarMenu = forwardRef<
       as="ul"
       inset={0}
       pillClassName="rounded-xl bg-muted/70"
+      pillContainerClassName="inset-y-auto top-0 h-9"
       data-slot="sidebar-menu"
       className={cn("flex w-full min-w-0 list-none flex-col gap-0.5", className)}
     >
@@ -772,17 +818,166 @@ export const AnimatedSidebarMenu = forwardRef<
 
 export const AnimatedSidebarMenuItem = forwardRef<
   HTMLLIElement,
-  HTMLAttributes<HTMLLIElement>
+  HTMLMotionProps<"li">
 >(function AnimatedSidebarMenuItem({ className, ...props }, forwardedRef) {
   return (
-    <li
+    <motion.li
       {...props}
       ref={forwardedRef}
+      layout="position"
+      transition={SPRING_LAYOUT}
       data-slot="sidebar-menu-item"
       className={cn("relative", className)}
     />
   );
 });
+
+export interface AnimatedSidebarMenuSubProps
+  extends Omit<HTMLMotionProps<"ul">, "children"> {
+  open: boolean;
+  children?: ReactNode;
+}
+
+export const AnimatedSidebarMenuSub = forwardRef<
+  HTMLUListElement,
+  AnimatedSidebarMenuSubProps
+>(function AnimatedSidebarMenuSub(
+  { open, children, className, ...props },
+  forwardedRef,
+) {
+  const context = useAnimatedSidebar();
+  const panel = useAnimatedSidebarPanel();
+
+  return (
+    <AnimatePresence initial={false} mode="popLayout">
+      {open && !panel.collapsed ? (
+        <motion.ul
+          {...props}
+          ref={forwardedRef}
+          key="sidebar-submenu"
+          variants={context.reduce ? undefined : SUBMENU_VARIANTS}
+          initial={context.reduce ? false : "closed"}
+          animate={context.reduce ? { opacity: 1 } : "open"}
+          exit={context.reduce ? { opacity: 0 } : "closed"}
+          transition={context.reduce ? { duration: 0.12 } : undefined}
+          data-slot="sidebar-menu-sub"
+          className={cn(
+            "relative mt-1 ml-5 flex min-w-0 flex-col gap-0.5 border-border border-l pl-3",
+            className,
+          )}
+        >
+          {children}
+        </motion.ul>
+      ) : null}
+    </AnimatePresence>
+  );
+});
+
+export const AnimatedSidebarMenuSubItem = forwardRef<
+  HTMLLIElement,
+  HTMLMotionProps<"li">
+>(function AnimatedSidebarMenuSubItem(
+  { className, ...props },
+  forwardedRef,
+) {
+  return (
+    <motion.li
+      {...props}
+      ref={forwardedRef}
+      variants={SUBMENU_ITEM_VARIANTS}
+      data-slot="sidebar-menu-sub-item"
+      className={cn("relative min-w-0", className)}
+    />
+  );
+});
+
+export interface AnimatedSidebarMenuSubButtonProps {
+  children: ReactNode;
+  icon?: ReactNode;
+  href?: string;
+  isActive?: boolean;
+  disabled?: boolean;
+  closeOnSelect?: boolean;
+  target?: "_blank" | "_self" | "_parent" | "_top";
+  rel?: string;
+  onSelect?: () => void;
+  className?: string;
+}
+
+export function AnimatedSidebarMenuSubButton({
+  children,
+  icon,
+  href,
+  isActive = false,
+  disabled = false,
+  closeOnSelect = true,
+  target,
+  rel,
+  onSelect,
+  className,
+}: AnimatedSidebarMenuSubButtonProps) {
+  const context = useAnimatedSidebar();
+
+  const select = (
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ) => {
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+    onSelect?.();
+    if (context.isMobile && closeOnSelect) context.setOpenMobile(false);
+  };
+
+  const content = (
+    <>
+      <span
+        aria-hidden="true"
+        className="grid size-4 shrink-0 place-items-center"
+      >
+        {icon ?? <span className="size-1 rounded-full bg-current" />}
+      </span>
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+    </>
+  );
+
+  const interactiveClassName = cn(
+    "flex min-h-8 w-full min-w-0 items-center gap-2 rounded-lg px-2 text-left text-xs outline-none",
+    "text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground",
+    "focus-visible:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring",
+    isActive && "bg-muted/70 text-foreground",
+    disabled && "cursor-not-allowed opacity-40",
+    className,
+  );
+
+  return href ? (
+    <a
+      href={href}
+      target={target}
+      rel={
+        rel ??
+        (target === "_blank" ? "noreferrer noopener" : undefined)
+      }
+      aria-current={isActive ? "page" : undefined}
+      aria-disabled={disabled || undefined}
+      tabIndex={disabled ? -1 : undefined}
+      onClick={select}
+      className={interactiveClassName}
+    >
+      {content}
+    </a>
+  ) : (
+    <button
+      type="button"
+      disabled={disabled}
+      aria-current={isActive ? "page" : undefined}
+      onClick={select}
+      className={interactiveClassName}
+    >
+      {content}
+    </button>
+  );
+}
 
 export interface AnimatedSidebarMenuButtonProps {
   children: ReactNode;
@@ -790,6 +985,7 @@ export interface AnimatedSidebarMenuButtonProps {
   badge?: ReactNode;
   href?: string;
   isActive?: boolean;
+  ariaExpanded?: boolean;
   disabled?: boolean;
   closeOnSelect?: boolean;
   target?: "_blank" | "_self" | "_parent" | "_top";
@@ -804,6 +1000,7 @@ export function AnimatedSidebarMenuButton({
   badge,
   href,
   isActive = false,
+  ariaExpanded,
   disabled = false,
   closeOnSelect = true,
   target,
@@ -869,6 +1066,21 @@ export function AnimatedSidebarMenuButton({
           {badge}
         </span>
       ) : null}
+      {ariaExpanded !== undefined ? (
+        <motion.span
+          aria-hidden="true"
+          initial={false}
+          animate={{
+            opacity: panel.collapsed ? 0 : 1,
+            rotate: ariaExpanded ? 90 : 0,
+            x: panel.collapsed ? 4 : 0,
+          }}
+          transition={context.reduce ? { duration: 0 } : SPRING_LAYOUT}
+          className="relative z-10 grid size-4 shrink-0 place-items-center text-muted-foreground"
+        >
+          <ChevronRight className="size-3.5" />
+        </motion.span>
+      ) : null}
     </>
   );
 
@@ -890,6 +1102,7 @@ export function AnimatedSidebarMenuButton({
         (target === "_blank" ? "noreferrer noopener" : undefined)
       }
       aria-current={isActive ? "page" : undefined}
+      aria-expanded={ariaExpanded}
       aria-disabled={disabled || undefined}
       aria-label={panel.collapsed ? textLabel : undefined}
       title={panel.collapsed ? textLabel : undefined}
@@ -904,6 +1117,7 @@ export function AnimatedSidebarMenuButton({
       type="button"
       disabled={disabled}
       aria-current={isActive ? "page" : undefined}
+      aria-expanded={ariaExpanded}
       aria-label={panel.collapsed ? textLabel : undefined}
       title={panel.collapsed ? textLabel : undefined}
       onClick={select}

--- a/components/motion/shared-layout-bg.tsx
+++ b/components/motion/shared-layout-bg.tsx
@@ -2,6 +2,7 @@
 
 import {
   AnimatePresence,
+  type HTMLMotionProps,
   motion,
   useReducedMotion,
   type Variants,
@@ -9,18 +10,24 @@ import {
 import {
   Children,
   cloneElement,
+  forwardRef,
+  type HTMLAttributes,
   isValidElement,
-  useId,
-  useState,
+  type MouseEvent,
   type ReactElement,
   type ReactNode,
+  type Ref,
+  useId,
+  useState,
 } from "react";
 import { SPRING_LAYOUT } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 
-export interface SharedLayoutBgProps {
+export interface SharedLayoutBgProps
+  extends Omit<HTMLAttributes<HTMLElement>, "children"> {
   children: ReactNode;
-  className?: string;
+  /** Semantic container used for the children. */
+  as?: "div" | "ul";
   /** Tailwind class applied to the moving pill. Defaults to a subtle foreground tint. */
   pillClassName?: string;
   /** Horizontal inset of the pill relative to each row (px). Default 20. */
@@ -40,65 +47,99 @@ const reducedVariants: Variants = {
   exit: (isActive: boolean) => (!isActive ? { opacity: 0 } : {}),
 };
 
-export function SharedLayoutBg({
-  children,
-  className,
-  pillClassName,
-  inset = 20,
-}: SharedLayoutBgProps) {
+export const SharedLayoutBg = forwardRef<HTMLElement, SharedLayoutBgProps>(
+  function SharedLayoutBg(
+    {
+      children,
+      as = "div",
+      className,
+      onMouseLeave,
+      pillClassName,
+      inset = 20,
+      ...props
+    },
+    forwardedRef,
+  ) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const uid = useId();
   const reduce = useReducedMotion();
 
-  return (
+    const renderedChildren = Children.toArray(children)
+      .filter(isValidElement)
+      .map((child, index) => {
+        const el = child as ReactElement<{
+          className?: string;
+          onMouseEnter?: () => void;
+          children?: ReactNode;
+        }>;
+        const childKey = el.key ? String(el.key) : `item-${index}`;
+        return cloneElement(
+          el,
+          {
+            key: childKey,
+            className: cn("relative", el.props.className),
+            onMouseEnter: () => {
+              el.props.onMouseEnter?.();
+              setActiveId(childKey);
+            },
+          },
+          <>
+            <AnimatePresence custom={activeId !== null}>
+              {activeId !== null ? (
+                <motion.div
+                  variants={reduce ? reducedVariants : variants}
+                  initial="initial"
+                  animate="animate"
+                  exit="exit"
+                  custom={activeId !== null}
+                  className="pointer-events-none absolute inset-y-0"
+                  style={{ left: -inset, right: -inset }}
+                >
+                  {activeId === childKey ? (
+                    <motion.div
+                      layoutId={`shared-bg-${uid}`}
+                      transition={reduce ? { duration: 0 } : SPRING_LAYOUT}
+                      className={cn(
+                        "pointer-events-none h-full w-full rounded-2xl bg-primary/[0.06]",
+                        pillClassName,
+                      )}
+                    />
+                  ) : null}
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
+            <div className="relative z-10">{el.props.children}</div>
+          </>,
+        );
+      });
+
+    const handleMouseLeave = (event: MouseEvent<HTMLElement>) => {
+      setActiveId(null);
+      onMouseLeave?.(event);
+    };
+
     // layoutRoot scopes the pill's layout projection to this list, so fixed or
     // scrolled ancestors can't smear scroll offsets into its movement.
-    <motion.div
-      layoutRoot
-      onMouseLeave={() => setActiveId(null)}
-      className={cn("flex w-full flex-col", className)}
-    >
-      {Children.toArray(children)
-        .filter(isValidElement)
-        .map((child, index) => {
-          const el = child as ReactElement<{ className?: string; onMouseEnter?: () => void; children?: ReactNode }>;
-          const childKey = el.key ? String(el.key) : `item-${index}`;
-          return cloneElement(
-            el,
-            {
-              key: childKey,
-              className: cn("relative", el.props.className),
-              onMouseEnter: () => setActiveId(childKey),
-            },
-            <>
-              <AnimatePresence custom={activeId !== null}>
-                {activeId !== null ? (
-                  <motion.div
-                    variants={reduce ? reducedVariants : variants}
-                    initial="initial"
-                    animate="animate"
-                    exit="exit"
-                    custom={activeId !== null}
-                    className="pointer-events-none absolute inset-y-0"
-                    style={{ left: -inset, right: -inset }}
-                  >
-                    {activeId === childKey ? (
-                      <motion.div
-                        layoutId={`shared-bg-${uid}`}
-                        transition={reduce ? { duration: 0 } : SPRING_LAYOUT}
-                        className={cn(
-                          "pointer-events-none h-full w-full rounded-2xl bg-primary/[0.06]",
-                          pillClassName,
-                        )}
-                      />
-                    ) : null}
-                  </motion.div>
-                ) : null}
-              </AnimatePresence>
-              <div className="relative z-10">{el.props.children}</div>
-            </>
-          );
-        })}
-    </motion.div>
-  );
-}
+    return as === "ul" ? (
+      <motion.ul
+        {...(props as HTMLMotionProps<"ul">)}
+        ref={forwardedRef as Ref<HTMLUListElement>}
+        layoutRoot
+        onMouseLeave={handleMouseLeave}
+        className={cn("flex w-full flex-col", className)}
+      >
+        {renderedChildren}
+      </motion.ul>
+    ) : (
+      <motion.div
+        {...(props as HTMLMotionProps<"div">)}
+        ref={forwardedRef as Ref<HTMLDivElement>}
+        layoutRoot
+        onMouseLeave={handleMouseLeave}
+        className={cn("flex w-full flex-col", className)}
+      >
+        {renderedChildren}
+      </motion.div>
+    );
+  },
+);

--- a/components/motion/shared-layout-bg.tsx
+++ b/components/motion/shared-layout-bg.tsx
@@ -32,6 +32,8 @@ export interface SharedLayoutBgProps
   pillClassName?: string;
   /** Horizontal inset of the pill relative to each row (px). Default 20. */
   inset?: number;
+  /** Optional positioning override for the pill wrapper inside each item. */
+  pillContainerClassName?: string;
 }
 
 const variants: Variants = {
@@ -55,6 +57,7 @@ export const SharedLayoutBg = forwardRef<HTMLElement, SharedLayoutBgProps>(
       className,
       onMouseLeave,
       pillClassName,
+      pillContainerClassName,
       inset = 20,
       ...props
     },
@@ -92,7 +95,10 @@ export const SharedLayoutBg = forwardRef<HTMLElement, SharedLayoutBgProps>(
                   animate="animate"
                   exit="exit"
                   custom={activeId !== null}
-                  className="pointer-events-none absolute inset-y-0"
+                  className={cn(
+                    "pointer-events-none absolute inset-y-0",
+                    pillContainerClassName,
+                  )}
                   style={{ left: -inset, right: -inset }}
                 >
                   {activeId === childKey ? (

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -183,6 +183,11 @@ export const previews: Record<string, ComponentType> = {
       (m) => m.BounceSidebarPreview,
     ),
   ),
+  "motion/animated-sidebar": dynamic(() =>
+    import("./motion/animated-sidebar.preview").then(
+      (m) => m.AnimatedSidebarPreview,
+    ),
+  ),
   "motion/preview-rail": dynamic(() =>
     import("./motion/preview-rail.preview").then(
       (m) => m.PreviewRailPreview,

--- a/components/previews/motion/animated-sidebar.preview.tsx
+++ b/components/previews/motion/animated-sidebar.preview.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import {
+  Building2,
+  ChevronRight,
+  ChevronsUpDown,
+  CircleUserRound,
+  Command,
+  Inbox,
+  LayoutGrid,
+  ListTodo,
+  Menu,
+  NotebookTabs,
+  Search,
+  Sparkles,
+  Target,
+  Workflow,
+  X,
+} from "lucide-react";
+import { useState } from "react";
+import {
+  AnimatedSidebar,
+  AnimatedSidebarClose,
+  AnimatedSidebarContent,
+  AnimatedSidebarFooter,
+  AnimatedSidebarGroup,
+  AnimatedSidebarGroupContent,
+  AnimatedSidebarGroupLabel,
+  AnimatedSidebarHeader,
+  AnimatedSidebarInset,
+  AnimatedSidebarMenu,
+  AnimatedSidebarMenuButton,
+  AnimatedSidebarMenuItem,
+  AnimatedSidebarProvider,
+  AnimatedSidebarRail,
+  AnimatedSidebarTrigger,
+} from "@/components/motion/animated-sidebar";
+import {
+  NotificationStack,
+  type NotificationStackItem,
+} from "@/components/motion/notification-stack";
+
+const destinations = [
+  { label: "People", icon: CircleUserRound },
+  { label: "Companies", icon: Building2 },
+  { label: "Opportunities", icon: Target },
+  { label: "Tasks", icon: ListTodo },
+  { label: "Notes", icon: NotebookTabs },
+  { label: "Workflows", icon: Workflow },
+  { label: "Dashboard", icon: LayoutGrid },
+];
+
+const notifications: NotificationStackItem[] = [
+  {
+    id: "mention",
+    title: "You have 3 new mentions",
+    description: "Design review · 2m",
+  },
+  {
+    id: "sync",
+    title: "Workspace sync complete",
+    description: "24 contacts updated",
+  },
+];
+
+export function AnimatedSidebarPreview() {
+  const [active, setActive] = useState("People");
+
+  return (
+    <div className="w-full px-0 py-2 sm:p-3">
+      <AnimatedSidebarProvider className="h-[820px] min-h-0 overflow-hidden rounded-2xl border border-foreground/[0.08] bg-background">
+        <AnimatedSidebar
+          ariaLabel="Solace workspace"
+          collapsible="icon"
+          className="min-h-0"
+          panelClassName="h-full border-foreground/[0.08]"
+        >
+          <AnimatedSidebarHeader className="p-3 pb-2">
+            <div className="flex min-h-11 items-center gap-3 overflow-hidden px-1">
+              <div className="grid size-9 shrink-0 place-items-center rounded-xl bg-foreground text-background">
+                <Command aria-hidden="true" className="size-4" />
+              </div>
+              <button
+                type="button"
+                className="flex min-w-0 flex-1 items-center gap-2 rounded-lg text-left outline-none focus-visible:ring-2 focus-visible:ring-ring group-data-[state=collapsed]/sidebar:hidden"
+              >
+                <span className="truncate text-sm font-semibold text-foreground">
+                  Acme Inc
+                </span>
+                <ChevronsUpDown
+                  aria-hidden="true"
+                  className="size-3.5 shrink-0 text-muted-foreground"
+                />
+              </button>
+              <AnimatedSidebarClose className="ml-auto text-muted-foreground hover:bg-muted md:hidden">
+                <X aria-hidden="true" className="size-4" />
+              </AnimatedSidebarClose>
+            </div>
+          </AnimatedSidebarHeader>
+
+          <AnimatedSidebarContent className="px-2 pt-1">
+            <AnimatedSidebarGroup className="pb-2">
+              <AnimatedSidebarGroupContent>
+                <AnimatedSidebarMenu>
+                  <AnimatedSidebarMenuItem>
+                    <AnimatedSidebarMenuButton
+                      icon={<Search className="size-4" />}
+                      onSelect={() => setActive("Search")}
+                    >
+                      Search
+                    </AnimatedSidebarMenuButton>
+                  </AnimatedSidebarMenuItem>
+                  <AnimatedSidebarMenuItem>
+                    <AnimatedSidebarMenuButton
+                      icon={<Sparkles className="size-4" />}
+                      onSelect={() => setActive("AI Assistant")}
+                    >
+                      AI Assistant
+                    </AnimatedSidebarMenuButton>
+                  </AnimatedSidebarMenuItem>
+                  <AnimatedSidebarMenuItem>
+                    <AnimatedSidebarMenuButton
+                      icon={<Inbox className="size-4" />}
+                      badge="4"
+                      onSelect={() => setActive("Inbox")}
+                    >
+                      Inbox
+                    </AnimatedSidebarMenuButton>
+                  </AnimatedSidebarMenuItem>
+                </AnimatedSidebarMenu>
+              </AnimatedSidebarGroupContent>
+            </AnimatedSidebarGroup>
+
+            <AnimatedSidebarGroup className="pt-1">
+              <AnimatedSidebarGroupLabel>
+                Workspaces
+              </AnimatedSidebarGroupLabel>
+              <AnimatedSidebarGroupContent>
+                <AnimatedSidebarMenu>
+                  {destinations.map(({ label, icon: Icon }) => (
+                    <AnimatedSidebarMenuItem key={label}>
+                      <AnimatedSidebarMenuButton
+                        isActive={active === label}
+                        icon={<Icon className="size-4" />}
+                        onSelect={() => setActive(label)}
+                      >
+                        {label}
+                      </AnimatedSidebarMenuButton>
+                    </AnimatedSidebarMenuItem>
+                  ))}
+                </AnimatedSidebarMenu>
+              </AnimatedSidebarGroupContent>
+            </AnimatedSidebarGroup>
+          </AnimatedSidebarContent>
+
+          <AnimatedSidebarFooter className="gap-3 border-none p-2.5">
+            <div className="group-data-[state=collapsed]/sidebar:hidden">
+              <NotificationStack
+                items={notifications}
+                maxVisible={2}
+                className="max-w-none rounded-2xl"
+                classNames={{
+                  card:
+                    " px-3 shadow-none",
+                  content: "gap-1 py-3",
+                  title: "text-xs",
+                  description: "text-[10px]",
+                  footer: "mt-1 min-h-8",
+                  count:
+                    "size-6 bg-foreground text-[10px] text-background shadow-none dark:bg-foreground",
+                }}
+              />
+            </div>
+
+            <button
+              type="button"
+              className="flex min-h-11 w-full items-center gap-3 overflow-hidden rounded-xl p-1 text-left outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring group-data-[state=collapsed]/sidebar:justify-center"
+            >
+              <span className="grid size-9 shrink-0 place-items-center rounded-full bg-[#d5ff66] text-xs font-semibold text-[#172000]">
+                AS
+              </span>
+              <span className="min-w-0 flex-1 group-data-[state=collapsed]/sidebar:hidden">
+                <span className="block truncate text-sm font-medium text-foreground">
+                  Ava Stone
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  ava@solace.app
+                </span>
+              </span>
+              <ChevronRight
+                aria-hidden="true"
+                className="size-4 shrink-0 text-muted-foreground group-data-[state=collapsed]/sidebar:hidden"
+              />
+            </button>
+          </AnimatedSidebarFooter>
+
+          <AnimatedSidebarRail />
+        </AnimatedSidebar>
+
+        <AnimatedSidebarInset className="min-h-0 bg-background">
+          <header className="flex h-16 shrink-0 items-center gap-3 border-border border-b px-4">
+            <AnimatedSidebarTrigger className="text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
+              <Menu aria-hidden="true" className="size-4" />
+            </AnimatedSidebarTrigger>
+            <div className="h-5 w-px bg-border" />
+            <p className="text-sm font-medium text-foreground">{active}</p>
+          </header>
+
+          <div className="flex min-h-0 flex-1 flex-col justify-between overflow-hidden p-5 sm:p-7">
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">
+                Wednesday, July 29
+              </p>
+              <h3 className="mt-2 max-w-md text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+                Good morning, Ava.
+              </h3>
+              <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+                Your workspace stays in place while the navigation folds down
+                to a focused icon rail.
+              </p>
+            </div>
+
+            <div className="flex items-end justify-between border-border border-t pt-4">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                  Active view
+                </p>
+                <p className="mt-1 text-sm font-medium text-foreground">
+                  {active}
+                </p>
+              </div>
+              <p className="hidden text-xs text-muted-foreground sm:block">
+                Press ⌘B to toggle
+              </p>
+            </div>
+          </div>
+        </AnimatedSidebarInset>
+      </AnimatedSidebarProvider>
+    </div>
+  );
+}

--- a/components/previews/motion/animated-sidebar.preview.tsx
+++ b/components/previews/motion/animated-sidebar.preview.tsx
@@ -9,8 +9,8 @@ import {
   Inbox,
   LayoutGrid,
   ListTodo,
-  Menu,
   NotebookTabs,
+  PanelLeft,
   Search,
   Sparkles,
   Target,
@@ -35,10 +35,6 @@ import {
   AnimatedSidebarRail,
   AnimatedSidebarTrigger,
 } from "@/components/motion/animated-sidebar";
-import {
-  NotificationStack,
-  type NotificationStackItem,
-} from "@/components/motion/notification-stack";
 
 const destinations = [
   { label: "People", icon: CircleUserRound },
@@ -50,25 +46,12 @@ const destinations = [
   { label: "Dashboard", icon: LayoutGrid },
 ];
 
-const notifications: NotificationStackItem[] = [
-  {
-    id: "mention",
-    title: "You have 3 new mentions",
-    description: "Design review · 2m",
-  },
-  {
-    id: "sync",
-    title: "Workspace sync complete",
-    description: "24 contacts updated",
-  },
-];
-
 export function AnimatedSidebarPreview() {
   const [active, setActive] = useState("People");
 
   return (
     <div className="w-full px-0 py-2 sm:p-3">
-      <AnimatedSidebarProvider className="h-[820px] min-h-0 overflow-hidden rounded-2xl border border-foreground/[0.08] bg-background">
+      <AnimatedSidebarProvider className="h-[720px] min-h-0 overflow-hidden rounded-2xl border border-foreground/[0.08] bg-background">
         <AnimatedSidebar
           ariaLabel="Solace workspace"
           collapsible="icon"
@@ -76,8 +59,8 @@ export function AnimatedSidebarPreview() {
           panelClassName="h-full border-foreground/[0.08]"
         >
           <AnimatedSidebarHeader className="p-3 pb-2">
-            <div className="flex min-h-11 items-center gap-3 overflow-hidden px-1">
-              <div className="grid size-9 shrink-0 place-items-center rounded-xl bg-foreground text-background">
+            <div className="flex min-h-11 items-center gap-3 overflow-hidden px-2">
+              <div className="grid size-7 shrink-0 place-items-center rounded-lg bg-foreground text-background">
                 <Command aria-hidden="true" className="size-4" />
               </div>
               <button
@@ -153,28 +136,11 @@ export function AnimatedSidebarPreview() {
             </AnimatedSidebarGroup>
           </AnimatedSidebarContent>
 
-          <AnimatedSidebarFooter className="gap-3 border-none p-2.5">
-            <div className="group-data-[state=collapsed]/sidebar:hidden">
-              <NotificationStack
-                items={notifications}
-                maxVisible={2}
-                className="max-w-none rounded-2xl"
-                classNames={{
-                  card:
-                    " px-3 shadow-none",
-                  content: "gap-1 py-3",
-                  title: "text-xs",
-                  description: "text-[10px]",
-                  footer: "mt-1 min-h-8",
-                  count:
-                    "size-6 bg-foreground text-[10px] text-background shadow-none dark:bg-foreground",
-                }}
-              />
-            </div>
+          <AnimatedSidebarFooter className="gap-3 border-none p-3">
 
             <button
               type="button"
-              className="flex min-h-11 w-full items-center gap-3 overflow-hidden rounded-xl p-1 text-left outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring group-data-[state=collapsed]/sidebar:justify-center"
+              className="flex min-h-11 w-full items-center gap-3 overflow-hidden rounded-xl p-1 text-left outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
             >
               <span className="grid size-9 shrink-0 place-items-center rounded-full bg-[#d5ff66] text-xs font-semibold text-[#172000]">
                 AS
@@ -200,7 +166,7 @@ export function AnimatedSidebarPreview() {
         <AnimatedSidebarInset className="min-h-0 bg-background">
           <header className="flex h-16 shrink-0 items-center gap-3 border-border border-b px-4">
             <AnimatedSidebarTrigger className="text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
-              <Menu aria-hidden="true" className="size-4" />
+              <PanelLeft aria-hidden="true" className="size-4" />
             </AnimatedSidebarTrigger>
             <div className="h-5 w-px bg-border" />
             <p className="text-sm font-medium text-foreground">{active}</p>

--- a/components/previews/motion/animated-sidebar.preview.tsx
+++ b/components/previews/motion/animated-sidebar.preview.tsx
@@ -31,23 +31,55 @@ import {
   AnimatedSidebarMenu,
   AnimatedSidebarMenuButton,
   AnimatedSidebarMenuItem,
+  AnimatedSidebarMenuSub,
+  AnimatedSidebarMenuSubButton,
+  AnimatedSidebarMenuSubItem,
   AnimatedSidebarProvider,
   AnimatedSidebarRail,
   AnimatedSidebarTrigger,
 } from "@/components/motion/animated-sidebar";
 
 const destinations = [
-  { label: "People", icon: CircleUserRound },
-  { label: "Companies", icon: Building2 },
-  { label: "Opportunities", icon: Target },
-  { label: "Tasks", icon: ListTodo },
-  { label: "Notes", icon: NotebookTabs },
-  { label: "Workflows", icon: Workflow },
-  { label: "Dashboard", icon: LayoutGrid },
-];
+  {
+    label: "People",
+    icon: CircleUserRound,
+    children: ["All people", "Recent activity", "Segments"],
+  },
+  {
+    label: "Companies",
+    icon: Building2,
+  },
+  {
+    label: "Opportunities",
+    icon: Target,
+    children: ["Pipeline", "Forecast", "Closed deals"],
+  },
+  {
+    label: "Tasks",
+    icon: ListTodo,
+  },
+  {
+    label: "Notes",
+    icon: NotebookTabs,
+  },
+  {
+    label: "Workflows",
+    icon: Workflow,
+    children: ["Automations", "Runs", "Templates"],
+  },
+  {
+    label: "Dashboard",
+    icon: LayoutGrid,
+  },
+] satisfies {
+  label: string;
+  icon: typeof CircleUserRound;
+  children?: string[];
+}[];
 
 export function AnimatedSidebarPreview() {
   const [active, setActive] = useState("People");
+  const [openSection, setOpenSection] = useState<string | null>(null);
 
   return (
     <div className="w-full px-0 py-2 sm:p-3">
@@ -120,15 +152,43 @@ export function AnimatedSidebarPreview() {
               </AnimatedSidebarGroupLabel>
               <AnimatedSidebarGroupContent>
                 <AnimatedSidebarMenu>
-                  {destinations.map(({ label, icon: Icon }) => (
+                  {destinations.map(({ label, icon: Icon, children }) => (
                     <AnimatedSidebarMenuItem key={label}>
                       <AnimatedSidebarMenuButton
-                        isActive={active === label}
+                        isActive={
+                          active === label ||
+                          children?.includes(active) === true
+                        }
+                        ariaExpanded={
+                          children ? openSection === label : undefined
+                        }
                         icon={<Icon className="size-4" />}
-                        onSelect={() => setActive(label)}
+                        onSelect={() => {
+                          setActive(label);
+                          setOpenSection((current) => {
+                            if (!children) return null;
+                            return current === label ? null : label;
+                          });
+                        }}
                       >
                         {label}
                       </AnimatedSidebarMenuButton>
+                      {children ? (
+                        <AnimatedSidebarMenuSub
+                          open={openSection === label}
+                        >
+                          {children.map((child) => (
+                            <AnimatedSidebarMenuSubItem key={child}>
+                              <AnimatedSidebarMenuSubButton
+                                isActive={active === child}
+                                onSelect={() => setActive(child)}
+                              >
+                                {child}
+                              </AnimatedSidebarMenuSubButton>
+                            </AnimatedSidebarMenuSubItem>
+                          ))}
+                        </AnimatedSidebarMenuSub>
+                      ) : null}
                     </AnimatedSidebarMenuItem>
                   ))}
                 </AnimatedSidebarMenu>

--- a/components/previews/motion/animated-sidebar.preview.tsx
+++ b/components/previews/motion/animated-sidebar.preview.tsx
@@ -164,9 +164,11 @@ export function AnimatedSidebarPreview() {
                         }
                         icon={<Icon className="size-4" />}
                         onSelect={() => {
-                          setActive(label);
                           setOpenSection((current) => {
-                            if (!children) return null;
+                            if (!children) {
+                              setActive(label);
+                              return null;
+                            }
                             return current === label ? null : label;
                           });
                         }}

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -24,7 +24,7 @@ const COMPONENT_DATES = {
   "motion/bounce-sidebar": { publishedAt: "2026-07-22", updatedAt: "2026-07-22" },
   "motion/animated-sidebar": {
     publishedAt: "2026-07-29",
-    updatedAt: "2026-07-29",
+    updatedAt: "2026-07-30",
   },
   "motion/preview-rail": { publishedAt: "2026-07-11", updatedAt: "2026-07-11" },
   "motion/dock": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -20,8 +20,12 @@ const COMPONENT_DATES = {
   "motion/radio": { publishedAt: "2026-06-23", updatedAt: "2026-07-13" },
   "motion/bottom-sheet": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
   "motion/pull-to-refresh": { publishedAt: "2026-07-17", updatedAt: "2026-07-17" },
-  "motion/shared-layout-bg": { publishedAt: "2026-05-17", updatedAt: "2026-06-22" },
+  "motion/shared-layout-bg": { publishedAt: "2026-05-17", updatedAt: "2026-07-29" },
   "motion/bounce-sidebar": { publishedAt: "2026-07-22", updatedAt: "2026-07-22" },
+  "motion/animated-sidebar": {
+    publishedAt: "2026-07-29",
+    updatedAt: "2026-07-29",
+  },
   "motion/preview-rail": { publishedAt: "2026-07-11", updatedAt: "2026-07-11" },
   "motion/dock": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
   "motion/tooltip": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -267,6 +267,25 @@ export const registry: CategoryEntry[] = [
         ],
       },
       {
+        slug: "animated-sidebar",
+        name: "Animated Sidebar",
+        description:
+          "A composable application sidebar that folds into an animated icon rail on desktop and becomes a focus-managed sheet on mobile.",
+        file: "components/motion/animated-sidebar.tsx",
+        badge: "new",
+        launchedAt: "2026-07-29",
+        keywords: [
+          "animated sidebar react",
+          "mobile sidebar",
+          "responsive sidebar",
+          "collapsible sidebar",
+          "icon sidebar",
+          "sidebar drawer",
+          "composable sidebar",
+          "accessible navigation menu",
+        ],
+      },
+      {
         slug: "preview-rail",
         name: "Preview Rail",
         description: "Codex app-inspired navigation rail with compact ticks that form a hover pyramid and reveal a floating destination preview.",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -270,7 +270,7 @@ export const registry: CategoryEntry[] = [
         slug: "animated-sidebar",
         name: "Animated Sidebar",
         description:
-          "A composable application sidebar that folds into an animated icon rail on desktop and becomes a focus-managed sheet on mobile.",
+          "A composable application sidebar with morphing nested navigation that folds into an animated icon rail on desktop and becomes a focus-managed sheet on mobile.",
         file: "components/motion/animated-sidebar.tsx",
         badge: "new",
         launchedAt: "2026-07-29",
@@ -282,6 +282,7 @@ export const registry: CategoryEntry[] = [
           "icon sidebar",
           "sidebar drawer",
           "composable sidebar",
+          "nested sidebar navigation",
           "accessible navigation menu",
         ],
       },

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -4,6 +4,12 @@ import { axe } from "jest-axe";
 import type { ReactElement } from "react";
 
 import { AnimatedBadge } from "@/components/motion/animated-badge";
+import {
+  AnimatedSidebar,
+  AnimatedSidebarContent,
+  AnimatedSidebarProvider,
+  AnimatedSidebarTrigger,
+} from "@/components/motion/animated-sidebar";
 import { BloomMenu } from "@/components/motion/bloom-menu";
 import { BounceSidebar } from "@/components/motion/bounce-sidebar";
 import { Button } from "@/components/motion/button";
@@ -16,12 +22,12 @@ import { Checkbox } from "@/components/motion/checkbox";
 import { ChromaticTextReveal } from "@/components/motion/chromatic-text-reveal";
 import { CommandPalette } from "@/components/motion/command-palette";
 import { Input } from "@/components/motion/input";
+import {
+  ROUNDS as KNOCKOUT_WHEEL_ROUNDS,
+  KnockoutWheel,
+} from "@/components/motion/knockout-wheel";
 import { Marquee } from "@/components/motion/marquee";
 import { MorphingModal } from "@/components/motion/morphing-modal";
-import {
-  KnockoutWheel,
-  ROUNDS as KNOCKOUT_WHEEL_ROUNDS,
-} from "@/components/motion/knockout-wheel";
 import { Parallax } from "@/components/motion/parallax";
 import {
   Popover,
@@ -103,6 +109,21 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
     ),
   ],
   ["AnimatedBadge", () => <AnimatedBadge status="success">Live</AnimatedBadge>],
+  [
+    "AnimatedSidebar expanded",
+    () => (
+      <AnimatedSidebarProvider>
+        <AnimatedSidebar ariaLabel="Workspace navigation">
+          <AnimatedSidebarContent>
+            <a href="/overview">Overview</a>
+          </AnimatedSidebarContent>
+        </AnimatedSidebar>
+        <div>
+          <AnimatedSidebarTrigger>Toggle</AnimatedSidebarTrigger>
+        </div>
+      </AnimatedSidebarProvider>
+    ),
+  ],
   [
     "Popover",
     () => (

--- a/tests/animated-sidebar.test.tsx
+++ b/tests/animated-sidebar.test.tsx
@@ -170,6 +170,13 @@ describe("AnimatedSidebar", () => {
 
     fireEvent.click(trigger);
     fireEvent.click(getByRole("button", { name: "Projects" }));
+    expect(dialog.getAttribute("data-state")).toBe("expanded");
+
+    fireEvent.click(
+      within(dialog).getByRole("button", {
+        name: "Active projects",
+      }),
+    );
     expect(dialog.getAttribute("data-state")).toBe("collapsed");
     expect(dialog.hasAttribute("inert")).toBe(true);
     expect(document.body.style.position).toBe("");

--- a/tests/animated-sidebar.test.tsx
+++ b/tests/animated-sidebar.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  within,
+} from "@testing-library/react";
+import { useState } from "react";
 import {
   AnimatedSidebar,
   AnimatedSidebarClose,
@@ -8,6 +14,9 @@ import {
   AnimatedSidebarMenu,
   AnimatedSidebarMenuButton,
   AnimatedSidebarMenuItem,
+  AnimatedSidebarMenuSub,
+  AnimatedSidebarMenuSubButton,
+  AnimatedSidebarMenuSubItem,
   AnimatedSidebarProvider,
   AnimatedSidebarTrigger,
 } from "@/components/motion/animated-sidebar";
@@ -42,6 +51,8 @@ function SidebarExample({
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }) {
+  const [projectsOpen, setProjectsOpen] = useState(false);
+
   return (
     <AnimatedSidebarProvider open={open} onOpenChange={onOpenChange}>
       <AnimatedSidebar ariaLabel="Workspace navigation">
@@ -54,7 +65,19 @@ function SidebarExample({
               </AnimatedSidebarMenuButton>
             </AnimatedSidebarMenuItem>
             <AnimatedSidebarMenuItem>
-              <AnimatedSidebarMenuButton>Projects</AnimatedSidebarMenuButton>
+              <AnimatedSidebarMenuButton
+                ariaExpanded={projectsOpen}
+                onSelect={() => setProjectsOpen((current) => !current)}
+              >
+                Projects
+              </AnimatedSidebarMenuButton>
+              <AnimatedSidebarMenuSub open={projectsOpen}>
+                <AnimatedSidebarMenuSubItem>
+                  <AnimatedSidebarMenuSubButton>
+                    Active projects
+                  </AnimatedSidebarMenuSubButton>
+                </AnimatedSidebarMenuSubItem>
+              </AnimatedSidebarMenuSub>
             </AnimatedSidebarMenuItem>
           </AnimatedSidebarMenu>
         </AnimatedSidebarContent>
@@ -111,6 +134,22 @@ describe("AnimatedSidebar", () => {
     expect(
       getByLabelText("Workspace navigation").getAttribute("data-state"),
     ).toBe("expanded");
+  });
+
+  test("reveals nested navigation from its parent item", () => {
+    const { getByRole, queryByRole } = render(<SidebarExample />);
+    const projects = getByRole("button", { name: "Projects" });
+
+    expect(queryByRole("button", { name: "Active projects" })).toBeNull();
+
+    fireEvent.click(projects);
+    expect(projects.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      getByRole("button", { name: "Active projects" }),
+    ).toBeTruthy();
+
+    fireEvent.click(projects);
+    expect(projects.getAttribute("aria-expanded")).toBe("false");
   });
 
   test("uses a dismissible sheet only on mobile", () => {

--- a/tests/animated-sidebar.test.tsx
+++ b/tests/animated-sidebar.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import {
+  AnimatedSidebar,
+  AnimatedSidebarClose,
+  AnimatedSidebarContent,
+  AnimatedSidebarInset,
+  AnimatedSidebarMenu,
+  AnimatedSidebarMenuButton,
+  AnimatedSidebarMenuItem,
+  AnimatedSidebarProvider,
+  AnimatedSidebarTrigger,
+} from "@/components/motion/animated-sidebar";
+
+const originalMatchMedia = window.matchMedia;
+
+afterEach(() => {
+  cleanup();
+  window.matchMedia = originalMatchMedia;
+});
+
+function useMobileViewport() {
+  window.matchMedia = (query: string) =>
+    ({
+      matches:
+        query.includes("prefers-reduced-motion") ||
+        query.includes("max-width"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}
+
+function SidebarExample({
+  open,
+  onOpenChange,
+}: {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  return (
+    <AnimatedSidebarProvider open={open} onOpenChange={onOpenChange}>
+      <AnimatedSidebar ariaLabel="Workspace navigation">
+        <AnimatedSidebarContent>
+          <AnimatedSidebarClose>Close</AnimatedSidebarClose>
+          <AnimatedSidebarMenu>
+            <AnimatedSidebarMenuItem>
+              <AnimatedSidebarMenuButton isActive>
+                Overview
+              </AnimatedSidebarMenuButton>
+            </AnimatedSidebarMenuItem>
+            <AnimatedSidebarMenuItem>
+              <AnimatedSidebarMenuButton>Projects</AnimatedSidebarMenuButton>
+            </AnimatedSidebarMenuItem>
+          </AnimatedSidebarMenu>
+        </AnimatedSidebarContent>
+      </AnimatedSidebar>
+      <AnimatedSidebarInset>
+        <AnimatedSidebarTrigger>Toggle</AnimatedSidebarTrigger>
+      </AnimatedSidebarInset>
+    </AnimatedSidebarProvider>
+  );
+}
+
+describe("AnimatedSidebar", () => {
+  test("collapses to an icon sidebar in uncontrolled mode", () => {
+    const { getByLabelText, getByRole } = render(<SidebarExample />);
+    const sidebar = getByLabelText("Workspace navigation");
+
+    expect(sidebar.getAttribute("data-state")).toBe("expanded");
+    fireEvent.click(getByRole("button", { name: "Toggle sidebar" }));
+
+    expect(sidebar.getAttribute("data-state")).toBe("collapsed");
+    expect(sidebar.getAttribute("data-collapsible")).toBe("icon");
+  });
+
+  test("respects controlled desktop state", () => {
+    const onOpenChange = mock(() => {});
+    const { getByLabelText, getByRole } = render(
+      <SidebarExample open={false} onOpenChange={onOpenChange} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Toggle sidebar" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(
+      getByLabelText("Workspace navigation").getAttribute("data-state"),
+    ).toBe("collapsed");
+  });
+
+  test("toggles with the platform keyboard shortcut", () => {
+    const { getByLabelText } = render(<SidebarExample />);
+    const sidebar = getByLabelText("Workspace navigation");
+
+    fireEvent.keyDown(window, { key: "b", metaKey: true });
+    expect(sidebar.getAttribute("data-state")).toBe("collapsed");
+
+    fireEvent.keyDown(window, { key: "b", ctrlKey: true });
+    expect(sidebar.getAttribute("data-state")).toBe("expanded");
+  });
+
+  test("keeps desktop navigation selections open", () => {
+    const { getByLabelText, getByRole } = render(<SidebarExample />);
+
+    fireEvent.click(getByRole("button", { name: "Projects" }));
+
+    expect(
+      getByLabelText("Workspace navigation").getAttribute("data-state"),
+    ).toBe("expanded");
+  });
+
+  test("uses a dismissible sheet only on mobile", () => {
+    useMobileViewport();
+    const { getByRole } = render(<SidebarExample />);
+    const trigger = getByRole("button", { name: "Toggle sidebar" });
+
+    fireEvent.click(trigger);
+    const dialog = getByRole("dialog", { name: "Workspace navigation" });
+    expect(dialog.getAttribute("data-mobile")).toBe("true");
+    expect(dialog.getAttribute("data-state")).toBe("expanded");
+    expect(document.body.style.position).toBe("fixed");
+
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Close sidebar" }),
+    );
+    expect(dialog.getAttribute("data-state")).toBe("collapsed");
+
+    fireEvent.click(trigger);
+    fireEvent.click(getByRole("button", { name: "Projects" }));
+    expect(dialog.getAttribute("data-state")).toBe("collapsed");
+    expect(dialog.hasAttribute("inert")).toBe(true);
+    expect(document.body.style.position).toBe("");
+  });
+});


### PR DESCRIPTION
## What changed

- add a composable Animated Sidebar with desktop icon-rail collapse and a focus-managed mobile sheet
- morph the desktop sidebar width with a spring while keeping icons aligned and labels unstretched
- add shared-layout hover and active backgrounds, a panel-style toggle icon, profile footer, and reference-aligned preview styling
- add composable nested navigation primitives with parent-only carets, top-origin morphing, staggered submenu items, and collapsed-rail handling
- update registry metadata, component dates, agent documentation, and focused sidebar tests

## Why

The sidebar needed to behave like a true application sidebar rather than a drawer, with polished open/close motion, stable icon alignment, mobile support, and production-ready nested navigation.

## Validation

- `bun run check`
- `bun test` — 64 passing
- `git diff --check`
- visual verification in the local component preview