### PR TITLE
fix: point Tyler Gibbs testimonial at his current avatar

### DIFF
--- a/components/app/landing/testimonials-data.ts
+++ b/components/app/landing/testimonials-data.ts
@@ -128,7 +128,7 @@ export const TESTIMONIALS = [
       name: "Tyler Gibbs",
       username: "Tylerbryy",
       avatar:
-        "https://pbs.twimg.com/profile_images/2068918593962536960/gmAsn6Nj_normal.jpg",
+        "https://pbs.twimg.com/profile_images/2077596476687998978/WvlUT0v1_normal.jpg",
       verified: true,
     },
   },


### PR DESCRIPTION
## Issue

The Tyler Gibbs testimonial on the landing page renders a broken-image icon instead of an avatar.

`TestimonialCard` hotlinks the author's `pbs.twimg.com` profile image. Twitter mints a new profile-image path whenever a user changes their picture and lets the old path 404 — Tyler changed his, so the stored URL

```
https://pbs.twimg.com/profile_images/2068918593962536960/gmAsn6Nj_normal.jpg
```

now returns 404 in every size variant (`_normal`, `_bigger`, `_200x200`, bare). The card renders `<img>` with no error fallback, so the dead URL shows as the browser's broken-image glyph next to the name and handle.

## Fix

Point the entry at his current avatar (`2077596476687998978/WvlUT0v1`). Verified 200 both as stored (`_normal`) and as rendered — `TestimonialCard` rewrites `_normal` → `_bigger`.

## Checks

- Swept every avatar URL in `testimonials-data.ts` on `main` in its rendered form; Tyler's is the only dead one.
- `bun run typecheck` and `bun run lint` clean (lint's 3 `noImgElement` warnings in `attachment-upload.tsx` are pre-existing and untouched).

## Not done

No `onError` fallback in `TestimonialCard` — it would make the card a client component for a failure mode that has hit once. Worth adding if a second avatar rots. Migrating avatars to `unavatar.io` was considered and dropped: it 403'd on one handle during testing and adds ~1s per image.

<img width="360" height="177" alt="Screenshot 2026-07-31 at 7 52 33 PM" src="https://github.com/user-attachments/assets/96535cc6-2452-45b1-89bc-6229c1ab2a4d" />
