### PR TITLE
feat: add liquid morphing reorderable tabs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "ui-components",
@@ -15,7 +16,7 @@
         "lenis": "^1.3.23",
         "lucide-react": "^1.16.0",
         "motion": "^11.15.0",
-        "next": "^15.1.4",
+        "next": "16.3.0",
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -52,77 +53,81 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.7", "@biomejs/cli-darwin-x64": "2.5.7", "@biomejs/cli-linux-arm64": "2.5.7", "@biomejs/cli-linux-arm64-musl": "2.5.7", "@biomejs/cli-linux-x64": "2.5.7", "@biomejs/cli-linux-x64-musl": "2.5.7", "@biomejs/cli-win32-arm64": "2.5.7", "@biomejs/cli-win32-x64": "2.5.7" }, "bin": { "biome": "bin/biome" } }, "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.7", "", { "os": "win32", "cpu": "x64" }, "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.11.1" } }, "sha512-1C0wwHiyMlEdsbrJqff5ORE2PwaXBOam5rMqkZVOReAezd5nt6Tl/WGg28UAo75Ziuwchs0KaF8lvnn2oAtvJA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "@jest/diff-sequences": ["@jest/diff-sequences@30.4.0", "", {}, "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g=="],
 
@@ -146,83 +151,83 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@next/env": ["@next/env@15.5.18", "", {}, "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g=="],
+    "@next/env": ["@next/env@16.3.0", "", {}, "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.18", "", { "os": "linux", "cpu": "x64" }, "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.18", "", { "os": "linux", "cpu": "x64" }, "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.18", "", { "os": "win32", "cpu": "x64" }, "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA=="],
 
     "@paper-design/shaders": ["@paper-design/shaders@0.0.76", "", {}, "sha512-AcNDY4J66YQHUfQYFInkCP7M9VOje0od7wLpOR7LtCmc532opJy6ll+h1W9zBovz8tt9U7OADUmJ/qKEXyOX/A=="],
 
     "@paper-design/shaders-react": ["@paper-design/shaders-react@0.0.76", "", { "dependencies": { "@paper-design/shaders": "0.0.76" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-uPJWrYRf6cJdO2H+fuXlahaqz0QjYglNAyUTaRfIInpzCa/d6guxBIK003soAZQFuQ035yg9FhtfFzKNWm+a5A=="],
 
-    "@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
+    "@shikijs/core": ["@shikijs/core@4.4.2", "", { "dependencies": { "@shikijs/primitive": "4.4.2", "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5", "hast-util-to-html": "^9.0.5" } }, "sha512-StyzbAyxg2/tBGf78gwbBkGyeQ73lf8UiJArFaQhTQIDqQOCKPCQFanvrs4/Yv3Yfyc+ONInJM6K+FMIf+P+kA=="],
 
-    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og=="],
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-MnIkeqWdVPUWsxlx8gKLVCJFTsqrQJgpTPBPpQwaFeJ56lOnJxj5aN2LUFnfxUEcvOQuNocmbaMnVrCEln6rkw=="],
 
-    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g=="],
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-GLhowz1+jixjz+wiZ3wMnOn1jTxiFCGl2PkXufivbnwPHKuyw1AYqu5/hbWhZZ2oAb0NP05WUJhYeigY14drnw=="],
 
-    "@shikijs/langs": ["@shikijs/langs@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ=="],
+    "@shikijs/langs": ["@shikijs/langs@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2" } }, "sha512-8DfeusD+Zdv/eYIDdXyJTUnSMHt+aAWjAOCXV20HNGAHRlInXpG8wh421v6B91WOm9TFwRLN+b/LG5F2NAIojg=="],
 
-    "@shikijs/primitive": ["@shikijs/primitive@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA=="],
+    "@shikijs/primitive": ["@shikijs/primitive@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-l6fQQKsOMlz72n38fztmSgZ76MO6KSWuw8o+GJ+FhmqrpC9pIOJNQNXGgbb5yX2AwpzlEHwsaLPnk/8o4Fm+rA=="],
 
-    "@shikijs/themes": ["@shikijs/themes@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w=="],
+    "@shikijs/themes": ["@shikijs/themes@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2" } }, "sha512-H0CFoL07ddDC2Dd6EdrPYNkRhUR6YCkJlnuYFceYYUJJA5TIm2b5B33qqiDYryBExgbKMndFJPb2u1gTuqO37g=="],
 
-    "@shikijs/transformers": ["@shikijs/transformers@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/types": "4.2.0" } }, "sha512-pKrYVNUr1oPjJvs76gkPPirDySx3GKG9O88P2Y3AQ+7AjSFws9Y+Ry/Q/6Yg6QpyigzjdQ6H5JAMNAvLXZ63dw=="],
+    "@shikijs/transformers": ["@shikijs/transformers@4.4.2", "", { "dependencies": { "@shikijs/core": "4.4.2", "@shikijs/types": "4.4.2" } }, "sha512-d81PJ9KkR1tVP95FH/9296HTtDo0mh76wv10u9T1YmsZq/UcXgt0OLdBszfUQ1i+umkRMCjDnFbFZU7/tCODTQ=="],
 
-    "@shikijs/types": ["@shikijs/types@4.2.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw=="],
+    "@shikijs/types": ["@shikijs/types@4.4.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-PFYitV4vpDr/iPCIhnHp+Q4ftic5N5VeNJ3KQ1O8gn3h2ar8qgwMAXF7tq4m1CWaMS60fV4VqF6vfnWH4F7vqQ=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
 
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng=="],
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.3", "", { "os": "android", "cpu": "arm64" }, "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw=="],
 
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ=="],
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw=="],
 
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA=="],
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw=="],
 
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ=="],
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw=="],
 
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA=="],
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3", "", { "os": "linux", "cpu": "arm" }, "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ=="],
 
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg=="],
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w=="],
 
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ=="],
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA=="],
 
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ=="],
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w=="],
 
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg=="],
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img=="],
 
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.0", "", { "dependencies": { "@emnapi/core": "^1.10.0", "@emnapi/runtime": "^1.10.0", "@emnapi/wasi-threads": "^1.2.1", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA=="],
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.3", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ=="],
 
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ=="],
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ=="],
 
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA=="],
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
 
-    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.0", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "postcss": "^8.5.10", "tailwindcss": "4.3.0" } }, "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w=="],
+    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.3", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "postcss": "^8.5.16", "tailwindcss": "4.3.3" } }, "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg=="],
 
-    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.4", "", { "dependencies": { "@tanstack/virtual-core": "3.17.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw=="],
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.9", "", { "dependencies": { "@tanstack/virtual-core": "3.17.7" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ=="],
 
-    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.2", "", {}, "sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA=="],
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.7", "", {}, "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -232,7 +237,7 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+    "@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
 
@@ -246,11 +251,11 @@
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
-    "@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
+    "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
-    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+    "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
-    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
@@ -264,7 +269,7 @@
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
-    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
     "@vercel/analytics": ["@vercel/analytics@1.6.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg=="],
 
@@ -278,13 +283,15 @@
 
     "axe-core": ["axe-core@3.5.6", "", {}, "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA=="],
+
     "border-beam": ["border-beam@1.3.0", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-oZSISp3aQau4ASTmzm5pzxeBinO6Fh2HW0gyEixJgtpUZvRiU0vNpP+IwGRrNpIyqPjA7Rf5EBnVqDSJ49cm5w=="],
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001807", "", {}, "sha512-daRXJ9EB/rdRgu7kV+TTl1YUKtlsMWblPl2sLnpg9DZae16QCegol6A1SmCE31Lm9mXC1sRWGt/krouH+/dl7Q=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -318,7 +325,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.21.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q=="],
+    "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
@@ -332,7 +339,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -362,7 +369,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "lenis": ["lenis@1.3.23", "", { "peerDependencies": { "@nuxt/kit": ">=3.0.0", "react": ">=17.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["@nuxt/kit", "react", "vue"] }, "sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg=="],
+    "lenis": ["lenis@1.3.26", "", { "peerDependencies": { "@nuxt/kit": ">=3.0.0", "react": ">=17.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["@nuxt/kit", "react", "vue"] }, "sha512-s/xTCZCxTFvHbAN1OzuhNaN5YPJH2ail0XAkctKW1b+RUAG4nUL5UHLXwNko1h8aEeT2jspBXegMgPJd8zcuag=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -390,7 +397,7 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
-    "lucide-react": ["lucide-react@1.16.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ=="],
+    "lucide-react": ["lucide-react@1.29.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -414,9 +421,9 @@
 
     "motion-utils": ["motion-utils@11.18.1", "", {}, "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
-    "next": ["next@15.5.18", "", { "dependencies": { "@next/env": "15.5.18", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.18", "@next/swc-darwin-x64": "15.5.18", "@next/swc-linux-arm64-gnu": "15.5.18", "@next/swc-linux-arm64-musl": "15.5.18", "@next/swc-linux-x64-gnu": "15.5.18", "@next/swc-linux-x64-musl": "15.5.18", "@next/swc-win32-arm64-msvc": "15.5.18", "@next/swc-win32-x64-msvc": "15.5.18", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ=="],
+    "next": ["next@16.3.0", "", { "dependencies": { "@next/env": "16.3.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.23", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0", "@next/swc-darwin-x64": "16.3.0", "@next/swc-linux-arm64-gnu": "16.3.0", "@next/swc-linux-arm64-musl": "16.3.0", "@next/swc-linux-x64-gnu": "16.3.0", "@next/swc-linux-x64-musl": "16.3.0", "@next/swc-win32-arm64-msvc": "16.3.0", "@next/swc-win32-x64-msvc": "16.3.0", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -426,25 +433,25 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
-    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
-    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
 
-    "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
     "react-docgen-typescript": ["react-docgen-typescript@2.4.0", "", { "peerDependencies": { "typescript": ">= 4.3.x" } }, "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg=="],
 
-    "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-is-18": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
-    "react-is-19": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
+    "react-is-19": ["react-is@19.2.8", "", {}, "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ=="],
 
     "react-tweet": ["react-tweet@3.3.1", "", { "dependencies": { "@swc/helpers": "^0.5.3", "clsx": "^2.0.0", "swr": "^2.2.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-0Gj1YgBTe1K85NBMoWBlUc17Rdc67gIJLlacrVgj+3jWIoXpFfxPdZ1U5OnWkkF9zxhphqs2pY1i//JBfP3Qog=="],
 
@@ -458,11 +465,11 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" } }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
 
-    "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
+    "shiki": ["shiki@4.4.2", "", { "dependencies": { "@shikijs/core": "4.4.2", "@shikijs/engine-javascript": "4.4.2", "@shikijs/engine-oniguruma": "4.4.2", "@shikijs/langs": "4.4.2", "@shikijs/themes": "4.4.2", "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-P8F/dFhRevaw2uSdeIYlq/5SXZNY85DPtmXQ947gD1Zj2JqO5AkNvVVBar0Me9JkFx3uzVud/qOtP5ek9NEQGA=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
@@ -478,11 +485,11 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "swr": ["swr@2.4.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw=="],
+    "swr": ["swr@2.5.0", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-W0GomadRJe9OfzIoRX0kZHhDSaRRfdiOUeH6uazgR05SibBhDNwfdTbhAxmFtObvkf59fFymo22mooKukosvNA=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
-    "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -512,19 +519,19 @@
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
-    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+    "ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" }, "bundled": true }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -542,7 +549,7 @@
 
     "jest-message-util/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
 
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+    "next/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "expect/jest-matcher-utils/jest-diff": ["jest-diff@30.4.1", "", { "dependencies": { "@jest/diff-sequences": "30.4.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.4.1" } }, "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA=="],
 
@@ -556,8 +563,8 @@
 
     "jest-matcher-utils/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
-    "jest-diff/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
+    "jest-diff/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.12", "", {}, "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g=="],
 
-    "jest-matcher-utils/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
+    "jest-matcher-utils/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.12", "", {}, "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g=="],
   }
 }

--- a/components/motion/morphing-tabs.tsx
+++ b/components/motion/morphing-tabs.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { X } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  AnimatePresence,
+  animate as animateValue,
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useSpring,
+  useTransform,
+  type MotionValue,
+} from "motion/react";
 import {
   useCallback,
   useEffect,
@@ -13,7 +22,8 @@ import {
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
-import { EASE_OUT, SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
+import { createPortal } from "react-dom";
+import { EASE_OUT, SPRING_GLIDE, SPRING_PRESS } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 
 export type MorphingTabsItem = {
@@ -49,22 +59,51 @@ export interface MorphingTabsProps {
   classNames?: MorphingTabsClassNames;
 }
 
-type DragState = {
+type DragSession = {
   id: string;
   pointerId: number;
   originX: number;
-  lastX: number;
   startLeft: number;
+  startIndex: number;
+  targetIndex: number;
   moved: boolean;
+  finishing: boolean;
   startOrder: string[];
+  slotLefts: number[];
+};
+
+type SpringTabProps = {
+  id: string;
+  targetLeft: number;
+  dragging: boolean;
+  dragLeft: MotionValue<number>;
+  surfaceLeft: MotionValue<number>;
+  reduce: boolean;
+  active: boolean;
+  anyDragging: boolean;
+  surfaceHost: HTMLDivElement | null;
+  surfaceWidth: number;
+  surfaceClassName?: string;
+  zIndex: number;
+  className: string;
+  children: ReactNode;
+  registerPosition: (id: string, position: MotionValue<number> | null) => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onLostPointerCapture: (event: ReactPointerEvent<HTMLDivElement>) => void;
 };
 
 const DRAG_THRESHOLD = 5;
-const TAB_SURFACE_WIDTH = 176;
-const TAB_SURFACE_RADIUS = 24;
+const TAB_WIDTH = 176;
+const TAB_HEIGHT = 56;
+const TAB_TOP = 24;
+const TAB_RADIUS = 24;
 const RAIL_HEIGHT = 80;
 const SURFACE_INSET = 16;
 const LIQUID_JOIN = 24;
+const PANEL_RADIUS = 28;
 
 function sameOrder(a: string[], b: string[]) {
   return a.length === b.length && a.every((id, index) => id === b[index]);
@@ -74,34 +113,160 @@ function safeId(value: string) {
   return value.replace(/[^a-zA-Z0-9_-]/g, "-");
 }
 
+function moveItem(order: string[], from: number, to: number) {
+  if (from === to) return order.slice();
+  const next = order.slice();
+  const [item] = next.splice(from, 1);
+  next.splice(to, 0, item);
+  return next;
+}
+
 function liquidTabPath(tabLeft: number, surfaceWidth: number) {
   const panelLeft = SURFACE_INSET;
   const panelRight = surfaceWidth - SURFACE_INSET;
-  const tabRight = tabLeft + TAB_SURFACE_WIDTH;
-  const top = RAIL_HEIGHT - 56;
+  const left = Math.max(
+    panelLeft,
+    Math.min(panelRight - TAB_WIDTH, tabLeft),
+  );
+  const right = left + TAB_WIDTH;
+  const top = RAIL_HEIGHT - TAB_HEIGHT;
   const bottom = RAIL_HEIGHT;
-  const leftJoin = Math.max(panelLeft, tabLeft - LIQUID_JOIN);
-  const rightJoin = Math.min(panelRight, tabRight + LIQUID_JOIN);
-  const leftDepth = Math.min(LIQUID_JOIN, tabLeft - leftJoin);
-  const rightDepth = Math.min(LIQUID_JOIN, rightJoin - tabRight);
+  const leftJoin = Math.max(panelLeft, left - LIQUID_JOIN);
+  const rightJoin = Math.min(panelRight, right + LIQUID_JOIN);
+  const leftDepth = Math.min(LIQUID_JOIN, left - leftJoin);
+  const rightDepth = Math.min(LIQUID_JOIN, rightJoin - right);
   const leftControl = leftDepth * 0.55;
   const rightControl = rightDepth * 0.55;
+  const leftPanelRadius = Math.min(PANEL_RADIUS, leftJoin - panelLeft);
+  const rightPanelRadius = Math.min(PANEL_RADIUS, panelRight - rightJoin);
 
   return [
-    `M${panelLeft} ${bottom + 8}`,
-    `V${bottom}`,
+    `M${panelLeft} ${bottom + PANEL_RADIUS}`,
+    `V${bottom + leftPanelRadius}`,
+    `Q${panelLeft} ${bottom} ${panelLeft + leftPanelRadius} ${bottom}`,
     `H${leftJoin}`,
-    `C${leftJoin + leftControl} ${bottom} ${tabLeft} ${bottom - leftDepth + leftControl} ${tabLeft} ${bottom - leftDepth}`,
-    `V${top + TAB_SURFACE_RADIUS}`,
-    `Q${tabLeft} ${top} ${tabLeft + TAB_SURFACE_RADIUS} ${top}`,
-    `H${tabRight - TAB_SURFACE_RADIUS}`,
-    `Q${tabRight} ${top} ${tabRight} ${top + TAB_SURFACE_RADIUS}`,
+    `C${leftJoin + leftControl} ${bottom} ${left} ${bottom - leftDepth + leftControl} ${left} ${bottom - leftDepth}`,
+    `V${top + TAB_RADIUS}`,
+    `Q${left} ${top} ${left + TAB_RADIUS} ${top}`,
+    `H${right - TAB_RADIUS}`,
+    `Q${right} ${top} ${right} ${top + TAB_RADIUS}`,
     `V${bottom - rightDepth}`,
-    `C${tabRight} ${bottom - rightDepth + rightControl} ${rightJoin - rightControl} ${bottom} ${rightJoin} ${bottom}`,
-    `H${panelRight}`,
-    `V${bottom + 8}`,
+    `C${right} ${bottom - rightDepth + rightControl} ${rightJoin - rightControl} ${bottom} ${rightJoin} ${bottom}`,
+    `H${panelRight - rightPanelRadius}`,
+    `Q${panelRight} ${bottom} ${panelRight} ${bottom + rightPanelRadius}`,
+    `V${bottom + PANEL_RADIUS}`,
     "Z",
   ].join(" ");
+}
+
+function SpringTab({
+  id,
+  targetLeft,
+  dragging,
+  dragLeft,
+  surfaceLeft,
+  reduce,
+  active,
+  anyDragging,
+  surfaceHost,
+  surfaceWidth,
+  surfaceClassName,
+  zIndex,
+  className,
+  children,
+  registerPosition,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onPointerCancel,
+  onLostPointerCapture,
+}: SpringTabProps) {
+  const target = useMotionValue(targetLeft);
+  const position = useSpring(target, SPRING_GLIDE);
+  const settledTransform = useTransform(
+    reduce ? target : position,
+    (left) => `translate3d(${left}px, 0, 0)`,
+  );
+  const draggedTransform = useTransform(
+    dragLeft,
+    (left) => `translate3d(${left}px, 0, 0)`,
+  );
+
+  useLayoutEffect(() => {
+    target.set(targetLeft);
+    if (reduce) position.jump(targetLeft);
+  }, [position, reduce, target, targetLeft]);
+
+  useLayoutEffect(() => {
+    registerPosition(id, position);
+    return () => registerPosition(id, null);
+  }, [id, position, registerPosition]);
+
+  const liquidDriver = anyDragging
+    ? dragging
+      ? dragLeft
+      : position
+    : surfaceLeft;
+
+  return (
+    <>
+      {active && surfaceHost && surfaceWidth > SURFACE_INSET * 2
+        ? createPortal(
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              viewBox={`0 0 ${surfaceWidth} ${RAIL_HEIGHT + PANEL_RADIUS}`}
+              preserveAspectRatio="none"
+              className={cn(
+                "pointer-events-none absolute inset-x-0 top-0 h-[108px] w-full text-[#fafaf8]",
+                dragging ? "z-20" : "z-0",
+                surfaceClassName,
+              )}
+            >
+              <LiquidSurfacePath
+                key={
+                  anyDragging
+                    ? dragging
+                      ? "dragged"
+                      : "displaced"
+                    : "idle"
+                }
+                left={liquidDriver}
+                surfaceWidth={surfaceWidth}
+              />
+            </svg>,
+            surfaceHost,
+          )
+        : null}
+      <motion.div
+        style={{
+          zIndex,
+          transform: dragging ? draggedTransform : settledTransform,
+        }}
+        className={className}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerCancel}
+        onLostPointerCapture={onLostPointerCapture}
+      >
+        {children}
+      </motion.div>
+    </>
+  );
+}
+
+function LiquidSurfacePath({
+  left,
+  surfaceWidth,
+}: {
+  left: MotionValue<number>;
+  surfaceWidth: number;
+}) {
+  const path = useTransform(left, (value) =>
+    liquidTabPath(value, surfaceWidth),
+  );
+  return <motion.path d={path} fill="currentColor" />;
 }
 
 export function MorphingTabs({
@@ -115,7 +280,7 @@ export function MorphingTabs({
   className,
   classNames,
 }: MorphingTabsProps) {
-  const reduce = useReducedMotion();
+  const reduce = Boolean(useReducedMotion());
   const uid = useId();
   const itemIds = useMemo(() => items.map((item) => item.id), [items]);
   const itemMap = useMemo(
@@ -132,14 +297,23 @@ export function MorphingTabs({
   const controlled = value !== undefined;
   const currentValue = controlled ? (value ?? null) : internalValue;
 
-  const tabRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const rootRef = useRef<HTMLDivElement | null>(null);
-  const dragRef = useRef<DragState | null>(null);
-  const [draggingId, setDraggingId] = useState<string | null>(null);
-  const [dragOffset, setDragOffset] = useState(0);
-  const [liquidDragLeft, setLiquidDragLeft] = useState<number | null>(null);
+  const railRef = useRef<HTMLDivElement | null>(null);
+  const tabButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const tabPositionRefs = useRef<Record<string, MotionValue<number> | null>>(
+    {},
+  );
+  const dragRef = useRef<DragSession | null>(null);
+  const dragAnimationRef = useRef<ReturnType<typeof animateValue> | null>(null);
+  const surfaceAnimationRef = useRef<ReturnType<typeof animateValue> | null>(
+    null,
+  );
   const [surfaceWidth, setSurfaceWidth] = useState(0);
-  const [settledTabLeft, setSettledTabLeft] = useState(SURFACE_INSET);
+  const [tabGap, setTabGap] = useState(12);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragTargetIndex, setDragTargetIndex] = useState(-1);
+  const dragLeft = useMotionValue(SURFACE_INSET);
+  const surfaceLeft = useMotionValue(SURFACE_INSET);
 
   useEffect(() => {
     setOrder((current) => {
@@ -148,7 +322,6 @@ export function MorphingTabs({
       const retainedSet = new Set(retained);
       const added = itemIds.filter((id) => !retainedSet.has(id));
       const next = [...retained, ...added];
-
       return sameOrder(current, next) ? current : next;
     });
   }, [itemIds]);
@@ -169,30 +342,57 @@ export function MorphingTabs({
       ? itemMap.get(currentValue) ?? null
       : firstEnabledItem;
   const activeId = activeItem?.id ?? null;
-  const activeOrderIndex = activeId ? order.indexOf(activeId) : -1;
+
+  const slotLefts = useMemo(
+    () =>
+      order.map(
+        (_, index) => SURFACE_INSET + index * (TAB_WIDTH + tabGap),
+      ),
+    [order, tabGap],
+  );
+
+  const dragStartIndex = draggingId ? order.indexOf(draggingId) : -1;
+
+  const visualIndexFor = useCallback(
+    (index: number) => {
+      if (dragStartIndex < 0 || dragTargetIndex < 0) return index;
+      if (index === dragStartIndex) return dragTargetIndex;
+
+      if (
+        dragTargetIndex > dragStartIndex &&
+        index > dragStartIndex &&
+        index <= dragTargetIndex
+      ) {
+        return index - 1;
+      }
+      if (
+        dragTargetIndex < dragStartIndex &&
+        index >= dragTargetIndex &&
+        index < dragStartIndex
+      ) {
+        return index + 1;
+      }
+      return index;
+    },
+    [dragStartIndex, dragTargetIndex],
+  );
 
   useLayoutEffect(() => {
     const root = rootRef.current;
-    if (!root) return;
+    const rail = railRef.current;
+    if (!root || !rail) return;
 
     const measure = () => {
       setSurfaceWidth(root.clientWidth);
-      const activeNode = activeId ? tabRefs.current[activeId] : null;
-      if (activeNode && activeOrderIndex >= 0 && liquidDragLeft === null) {
-        setSettledTabLeft(activeNode.offsetLeft);
-      }
+      const nextGap = Number.parseFloat(getComputedStyle(rail).columnGap);
+      if (Number.isFinite(nextGap)) setTabGap(nextGap);
     };
 
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(root);
     return () => observer.disconnect();
-  }, [activeId, activeOrderIndex, liquidDragLeft]);
-
-  const liquidSurfacePath = useMemo(() => {
-    if (!activeItem || surfaceWidth <= SURFACE_INSET * 2) return null;
-    return liquidTabPath(liquidDragLeft ?? settledTabLeft, surfaceWidth);
-  }, [activeItem, liquidDragLeft, settledTabLeft, surfaceWidth]);
+  }, []);
 
   const setActive = useCallback(
     (id: string | null) => {
@@ -210,6 +410,38 @@ export function MorphingTabs({
     }
   }, [currentValue, firstEnabledItem, itemMap, setActive]);
 
+  const activeOrderIndex = activeId ? order.indexOf(activeId) : -1;
+  const activeVisualIndex =
+    activeOrderIndex < 0 ? -1 : visualIndexFor(activeOrderIndex);
+
+  useLayoutEffect(() => {
+    if (
+      !activeId ||
+      activeVisualIndex < 0 ||
+      activeId === draggingId ||
+      !slotLefts[activeVisualIndex]
+    ) {
+      return;
+    }
+
+    surfaceAnimationRef.current?.stop();
+
+    if (draggingId) return;
+
+    surfaceAnimationRef.current = animateValue(
+      surfaceLeft,
+      slotLefts[activeVisualIndex],
+      reduce ? { duration: 0 } : SPRING_GLIDE,
+    );
+  }, [
+    activeId,
+    activeVisualIndex,
+    draggingId,
+    reduce,
+    slotLefts,
+    surfaceLeft,
+  ]);
+
   const commitOrder = useCallback(
     (next: string[], notify: boolean) => {
       orderRef.current = next;
@@ -219,146 +451,225 @@ export function MorphingTabs({
     [onOrderChange],
   );
 
-  const getDropIndex = useCallback((clientX: number, draggedId: string) => {
-    const otherIds = orderRef.current.filter((id) => id !== draggedId);
+  const registerPosition = useCallback(
+    (id: string, position: MotionValue<number> | null) => {
+      tabPositionRefs.current[id] = position;
+    },
+    [],
+  );
 
-    for (let index = 0; index < otherIds.length; index += 1) {
-      const rect = tabRefs.current[otherIds[index]]?.getBoundingClientRect();
-      if (rect && clientX < rect.left + rect.width / 2) return index;
-    }
+  const startDrag = useCallback(
+    (id: string, event: ReactPointerEvent<HTMLDivElement>) => {
+      if (
+        event.button !== 0 ||
+        itemMap.get(id)?.disabled ||
+        dragRef.current
+      ) {
+        return;
+      }
 
-    return otherIds.length;
-  }, []);
+      const startIndex = orderRef.current.indexOf(id);
+      if (startIndex < 0) return;
+      const capturedSlots = orderRef.current.map(
+        (_, index) => SURFACE_INSET + index * (TAB_WIDTH + tabGap),
+      );
+      const startLeft = capturedSlots[startIndex];
+
+      dragAnimationRef.current?.stop();
+      dragAnimationRef.current = null;
+      dragLeft.set(startLeft);
+      dragRef.current = {
+        id,
+        pointerId: event.pointerId,
+        originX: event.clientX,
+        startLeft,
+        startIndex,
+        targetIndex: startIndex,
+        moved: false,
+        finishing: false,
+        startOrder: orderRef.current.slice(),
+        slotLefts: capturedSlots,
+      };
+    },
+    [dragLeft, itemMap, tabGap],
+  );
+
+  const moveDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.finishing || drag.pointerId !== event.pointerId) return;
+
+      const delta = event.clientX - drag.originX;
+      if (!drag.moved && Math.abs(delta) < DRAG_THRESHOLD) return;
+      event.preventDefault();
+
+      if (!drag.moved) {
+        drag.moved = true;
+        event.currentTarget.setPointerCapture(event.pointerId);
+        if (drag.id === activeId) {
+          surfaceAnimationRef.current?.stop();
+          surfaceLeft.set(drag.startLeft);
+        }
+        setDraggingId(drag.id);
+        setDragTargetIndex(drag.startIndex);
+      }
+
+      const minLeft = drag.slotLefts[0];
+      const maxLeft = drag.slotLefts[drag.slotLefts.length - 1];
+      const visualLeft = Math.max(
+        minLeft,
+        Math.min(maxLeft, drag.startLeft + delta),
+      );
+      let targetIndex = drag.startIndex;
+
+      if (visualLeft >= drag.startLeft) {
+        for (
+          let index = drag.startIndex + 1;
+          index < drag.slotLefts.length;
+          index += 1
+        ) {
+          if (visualLeft + TAB_WIDTH / 2 >= drag.slotLefts[index]) {
+            targetIndex = index;
+          }
+        }
+      } else {
+        for (let index = drag.startIndex - 1; index >= 0; index -= 1) {
+          if (visualLeft <= drag.slotLefts[index] + TAB_WIDTH / 2) {
+            targetIndex = index;
+          }
+        }
+      }
+
+      dragLeft.set(visualLeft);
+      if (targetIndex !== drag.targetIndex) {
+        drag.targetIndex = targetIndex;
+        setDragTargetIndex(targetIndex);
+      }
+    },
+    [activeId, dragLeft, surfaceLeft],
+  );
+
+  const finishDrag = useCallback(
+    (pointerId: number) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== pointerId || drag.finishing) return;
+
+      if (!drag.moved) {
+        dragRef.current = null;
+        return;
+      }
+
+      drag.finishing = true;
+      const targetLeft = drag.slotLefts[drag.targetIndex];
+      const controls = animateValue(
+        dragLeft,
+        targetLeft,
+        reduce ? { duration: 0 } : SPRING_GLIDE,
+      );
+      dragAnimationRef.current = controls;
+
+      controls.then(async () => {
+        if (dragAnimationRef.current !== controls) return;
+        const next = moveItem(
+          drag.startOrder,
+          drag.startIndex,
+          drag.targetIndex,
+        );
+
+        if (!reduce) {
+          await new Promise<void>((resolve) => {
+            const startedAt = performance.now();
+            const check = () => {
+              const settled = next.every((id, index) => {
+                if (id === drag.id) return true;
+                const position = tabPositionRefs.current[id];
+                if (!position) return true;
+                return (
+                  Math.abs(position.get() - drag.slotLefts[index]) < 0.5 &&
+                  Math.abs(position.getVelocity()) < 10
+                );
+              });
+
+              if (settled || performance.now() - startedAt > 500) {
+                resolve();
+                return;
+              }
+              requestAnimationFrame(check);
+            };
+            check();
+          });
+        }
+
+        if (dragAnimationRef.current !== controls) return;
+        if (drag.id === activeId) {
+          surfaceLeft.set(targetLeft);
+        } else if (activeId) {
+          const activePosition = tabPositionRefs.current[activeId];
+          if (activePosition) surfaceLeft.set(activePosition.get());
+        }
+        tabPositionRefs.current[drag.id]?.jump(targetLeft);
+        dragAnimationRef.current = null;
+        dragRef.current = null;
+        commitOrder(next, !sameOrder(drag.startOrder, next));
+        setDraggingId(null);
+        setDragTargetIndex(-1);
+      });
+    },
+    [activeId, commitOrder, dragLeft, reduce, surfaceLeft],
+  );
+
+  useEffect(() => {
+    const finishFromWindow = (event: PointerEvent) => {
+      finishDrag(event.pointerId);
+    };
+    window.addEventListener("pointerup", finishFromWindow, true);
+    window.addEventListener("pointercancel", finishFromWindow, true);
+    return () => {
+      window.removeEventListener("pointerup", finishFromWindow, true);
+      window.removeEventListener("pointercancel", finishFromWindow, true);
+    };
+  }, [finishDrag]);
 
   const moveBy = useCallback(
     (id: string, direction: -1 | 1) => {
       const current = orderRef.current;
       const index = current.indexOf(id);
       const nextIndex = index + direction;
-
       if (
-        index === -1 ||
+        index < 0 ||
         nextIndex < 0 ||
         nextIndex >= current.length ||
         itemMap.get(id)?.disabled
       ) {
         return;
       }
-
-      const next = current.slice();
-      [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
-      commitOrder(next, true);
+      commitOrder(moveItem(current, index, nextIndex), true);
     },
     [commitOrder, itemMap],
-  );
-
-  const startDrag = useCallback(
-    (id: string, event: ReactPointerEvent<HTMLDivElement>) => {
-      if (event.button !== 0 || itemMap.get(id)?.disabled) return;
-
-      event.preventDefault();
-      event.currentTarget.setPointerCapture(event.pointerId);
-      dragRef.current = {
-        id,
-        pointerId: event.pointerId,
-        originX: event.clientX,
-        lastX: event.clientX,
-        startLeft: event.currentTarget.offsetLeft,
-        moved: false,
-        startOrder: orderRef.current.slice(),
-      };
-      setDraggingId(id);
-      setDragOffset(0);
-      setLiquidDragLeft(event.currentTarget.offsetLeft);
-      setActive(id);
-    },
-    [itemMap, setActive],
-  );
-
-  const moveDrag = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      const drag = dragRef.current;
-      if (!drag) return;
-
-      const offset = event.clientX - drag.originX;
-      drag.lastX = event.clientX;
-      const nextLiquidLeft = Math.max(
-        SURFACE_INSET,
-        Math.min(
-          surfaceWidth - SURFACE_INSET - TAB_SURFACE_WIDTH,
-          drag.startLeft + event.clientX - drag.originX,
-        ),
-      );
-      setLiquidDragLeft(nextLiquidLeft);
-      if (!drag.moved && Math.abs(offset) < DRAG_THRESHOLD) return;
-      drag.moved = true;
-
-      const current = orderRef.current;
-      const currentIndex = current.indexOf(drag.id);
-
-      const constrainedOffset =
-        current.length <= 1
-          ? 0
-          : currentIndex === 0
-            ? Math.max(0, offset)
-            : currentIndex === current.length - 1
-              ? Math.min(0, offset)
-              : offset;
-
-      setDragOffset(constrainedOffset);
-    },
-    [surfaceWidth],
-  );
-
-  const finishDrag = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      const drag = dragRef.current;
-      if (!drag) return;
-
-      if (event.currentTarget.hasPointerCapture(drag.pointerId)) {
-        event.currentTarget.releasePointerCapture(drag.pointerId);
-      }
-
-      if (drag.moved) {
-        const targetIndex = getDropIndex(drag.lastX, drag.id);
-        const next = drag.startOrder.filter((id) => id !== drag.id);
-        next.splice(targetIndex, 0, drag.id);
-        if (!sameOrder(drag.startOrder, next)) {
-          commitOrder(next, true);
-        }
-      }
-
-      dragRef.current = null;
-      setDraggingId(null);
-      setDragOffset(0);
-      setLiquidDragLeft(null);
-    },
-    [commitOrder, getDropIndex],
   );
 
   const handleTabKeyDown = useCallback(
     (id: string, event: React.KeyboardEvent<HTMLButtonElement>) => {
       const index = orderRef.current.indexOf(id);
-      if (index === -1) return;
+      if (index < 0) return;
 
-      if (event.altKey && (event.key === "ArrowLeft" || event.key === "ArrowRight")) {
+      if (
+        event.altKey &&
+        (event.key === "ArrowLeft" || event.key === "ArrowRight")
+      ) {
         event.preventDefault();
         moveBy(id, event.key === "ArrowLeft" ? -1 : 1);
         return;
       }
-
       if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
 
       event.preventDefault();
       const direction = event.key === "ArrowLeft" ? -1 : 1;
-      const nextIndex = (index + direction + orderRef.current.length) % orderRef.current.length;
+      const nextIndex =
+        (index + direction + orderRef.current.length) % orderRef.current.length;
       const nextId = orderRef.current[nextIndex];
       setActive(nextId);
-      requestAnimationFrame(() => {
-        tabRefs.current[nextId]
-          ?.querySelector<HTMLButtonElement>('[role="tab"]')
-          ?.focus();
-      });
+      requestAnimationFrame(() => tabButtonRefs.current[nextId]?.focus());
     },
     [moveBy, setActive],
   );
@@ -374,155 +685,148 @@ export function MorphingTabs({
         className,
       )}
     >
-      {liquidSurfacePath ? (
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          viewBox={`0 0 ${surfaceWidth} ${RAIL_HEIGHT + 8}`}
-          preserveAspectRatio="none"
-          className={cn(
-            "pointer-events-none absolute inset-x-0 top-0 z-0 h-[88px] w-full text-[#fafaf8]",
-            classNames?.activeTab,
-          )}
-        >
-          <motion.path
-            initial={false}
-            animate={{ d: liquidSurfacePath }}
-            transition={
-              reduce || draggingId ? { duration: 0 } : SPRING_LAYOUT
-            }
-            fill="currentColor"
-          />
-        </svg>
-      ) : null}
       <div className="relative h-20">
         <div
+          ref={railRef}
           role="tablist"
           aria-label={ariaLabel}
           aria-orientation="horizontal"
           className={cn(
-            "relative z-10 flex h-full min-w-0 items-end gap-3 px-4 pt-3 md:gap-4",
+            "relative z-10 flex h-full gap-3 md:gap-4",
             classNames?.rail,
           )}
         >
-          {orderedItems.map((item) => {
+          {orderedItems.map((item, index) => {
             const isActive = item.id === activeId;
             const isDragging = item.id === draggingId;
+            const visualIndex = visualIndexFor(index);
+            const targetLeft = slotLefts[visualIndex] ?? SURFACE_INSET;
             const tabId = `${uid}-tab-${safeId(item.id)}`;
 
             return (
-              <motion.div
+              <SpringTab
                 key={item.id}
-                ref={(node) => {
-                  tabRefs.current[item.id] = node;
-                }}
-                layout={reduce ? false : "position"}
-                transition={
-                  reduce || isDragging ? { duration: 0 } : SPRING_LAYOUT
-                }
-                animate={
-                  reduce
-                    ? {
-                        opacity: item.disabled
-                          ? 0.4
-                          : draggingId && !isDragging
-                            ? 0.72
-                            : 1,
-                      }
-                    : {
-                        x: isDragging ? dragOffset : 0,
-                        opacity: item.disabled
-                          ? 0.4
-                          : draggingId && !isDragging
-                            ? 0.72
-                            : 1,
-                      }
-                }
-                style={{
-                  zIndex: isDragging ? 30 : isActive ? 20 : 1,
-                }}
+                id={item.id}
+                targetLeft={targetLeft}
+                dragging={isDragging}
+                dragLeft={dragLeft}
+                surfaceLeft={surfaceLeft}
+                reduce={reduce}
+                active={isActive}
+                anyDragging={Boolean(draggingId)}
+                surfaceHost={rootRef.current}
+                surfaceWidth={surfaceWidth}
+                surfaceClassName={classNames?.activeTab}
+                zIndex={isDragging ? 30 : isActive ? 20 : 1}
                 className={cn(
-                  "group relative flex h-14 w-44 shrink-0 select-none touch-pan-y items-stretch",
+                  "group absolute left-0 top-0 flex select-none touch-pan-y items-stretch",
                   item.disabled && "cursor-not-allowed",
                   isDragging ? "cursor-grabbing" : "cursor-grab",
                 )}
+                registerPosition={registerPosition}
                 onPointerDown={(event) => startDrag(item.id, event)}
                 onPointerMove={moveDrag}
-                onPointerUp={finishDrag}
-                onPointerCancel={finishDrag}
+                onPointerUp={(event) => finishDrag(event.pointerId)}
+                onPointerCancel={(event) => finishDrag(event.pointerId)}
+                onLostPointerCapture={(event) => finishDrag(event.pointerId)}
               >
-                {!isActive ? (
-                  <span
-                    aria-hidden
-                    className="absolute inset-x-0 bottom-2 top-0 rounded-[1.25rem] bg-transparent transition-colors duration-200 group-hover:bg-white/[0.06]"
-                  />
-                ) : null}
-
-                <button
-                  id={tabId}
-                  type="button"
-                  role="tab"
-                  aria-selected={isActive}
-                  aria-controls={`${uid}-panel`}
-                  aria-disabled={item.disabled || undefined}
-                  tabIndex={isActive ? 0 : -1}
-                  disabled={item.disabled}
-                  onClick={() => setActive(item.id)}
-                  onKeyDown={(event) => handleTabKeyDown(item.id, event)}
-                  className={cn(
-                    "group relative z-10 flex h-full w-full min-w-0 items-center gap-2 overflow-hidden rounded-t-[inherit] px-3 text-left outline-none transition-colors",
-                    isActive
-                      ? "text-[#181818]"
-                      : "pb-2 text-white/70 hover:text-white",
-                    classNames?.tab,
-                  )}
+                <div
+                  style={{
+                    width: TAB_WIDTH,
+                    height: TAB_HEIGHT,
+                    marginTop: TAB_TOP,
+                  }}
+                  className="relative flex items-stretch"
                 >
-                  <span
-                    aria-hidden
-                    className={cn(
-                      "pointer-events-none absolute inset-x-1 top-1 opacity-0 transition-opacity group-focus-visible:opacity-100",
-                      isActive
-                        ? "bottom-0 rounded-t-[1.25rem] border-x-2 border-t-2 border-black/20"
-                        : "bottom-2 rounded-[1rem] border-2 border-white/60",
-                    )}
-                  />
-                  {item.icon ? (
+                  {!isActive ? (
                     <span
                       aria-hidden
-                      className={cn("grid size-8 shrink-0 place-items-center", classNames?.icon)}
-                    >
-                      {item.icon}
-                    </span>
+                      className={cn(
+                        "absolute inset-x-0 bottom-2 top-0 rounded-[1.25rem] transition-colors duration-200",
+                        isDragging
+                          ? "bg-[#3a3a3a]"
+                          : "bg-transparent group-hover:bg-white/[0.06]",
+                      )}
+                    />
                   ) : null}
-                  <span
-                    className={cn(
-                      "min-w-0 truncate whitespace-nowrap text-base font-medium leading-none tracking-[-0.025em]",
-                      classNames?.label,
-                    )}
-                  >
-                    {item.label}
-                  </span>
-                </button>
 
-                {onClose ? (
                   <button
-                    type="button"
-                    aria-label={`Close ${item.label}`}
-                    onPointerDown={(event) => event.stopPropagation()}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onClose(item.id);
+                    ref={(node) => {
+                      tabButtonRefs.current[item.id] = node;
                     }}
+                    id={tabId}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-controls={`${uid}-panel`}
+                    aria-disabled={item.disabled || undefined}
+                    tabIndex={isActive ? 0 : -1}
+                    disabled={item.disabled}
+                    onClick={() => {
+                      const drag = dragRef.current;
+                      if (drag?.id === item.id && drag.moved) return;
+                      setActive(item.id);
+                    }}
+                    onKeyDown={(event) => handleTabKeyDown(item.id, event)}
                     className={cn(
-                      "absolute right-2 top-1/2 z-20 grid size-6 -translate-y-1/2 place-items-center rounded-full text-[#9aa0a8] transition-colors hover:bg-black/[0.06] hover:text-[#4b5563] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current",
-                      !isActive && "top-[calc(50%-4px)] text-white/45 hover:bg-white/[0.08] hover:text-white/80",
-                      classNames?.close,
+                      "group relative z-10 flex h-full w-full min-w-0 items-center gap-2 overflow-hidden rounded-t-[1.5rem] px-3 text-left outline-none transition-colors",
+                      isActive
+                        ? "text-[#181818]"
+                        : "pb-2 text-white/70 hover:text-white",
+                      classNames?.tab,
                     )}
                   >
-                    <X aria-hidden className="size-3.5 stroke-[1.5]" />
+                    <span
+                      aria-hidden
+                      className={cn(
+                        "pointer-events-none absolute inset-x-1 top-1 opacity-0 transition-opacity group-focus-visible:opacity-100",
+                        isActive
+                          ? "bottom-0 rounded-t-[1.25rem] border-x-2 border-t-2 border-black/20"
+                          : "bottom-2 rounded-[1rem] border-2 border-white/60",
+                      )}
+                    />
+                    {item.icon ? (
+                      <span
+                        aria-hidden
+                        className={cn(
+                          "grid size-8 shrink-0 place-items-center",
+                          classNames?.icon,
+                        )}
+                      >
+                        {item.icon}
+                      </span>
+                    ) : null}
+                    <span
+                      className={cn(
+                        "min-w-0 truncate whitespace-nowrap text-base font-medium leading-none tracking-[-0.025em]",
+                        classNames?.label,
+                      )}
+                    >
+                      {item.label}
+                    </span>
                   </button>
-                ) : null}
-              </motion.div>
+
+                  {onClose ? (
+                    <button
+                      type="button"
+                      aria-label={`Close ${item.label}`}
+                      onPointerDown={(event) => event.stopPropagation()}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onClose(item.id);
+                      }}
+                      className={cn(
+                        "absolute right-2 top-1/2 z-20 grid size-6 -translate-y-1/2 place-items-center rounded-full text-[#9aa0a8] transition-colors hover:bg-black/[0.06] hover:text-[#4b5563] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current",
+                        !isActive &&
+                          "top-[calc(50%-4px)] text-white/45 hover:bg-white/[0.08] hover:text-white/80",
+                        classNames?.close,
+                      )}
+                    >
+                      <X aria-hidden className="size-3.5 stroke-[1.5]" />
+                    </button>
+                  ) : null}
+                </div>
+              </SpringTab>
             );
           })}
         </div>
@@ -533,7 +837,7 @@ export function MorphingTabs({
         role="tabpanel"
         aria-labelledby={`${uid}-tab-${safeId(activeId ?? "empty")}`}
         className={cn(
-          "relative z-20 mx-4 min-h-64 overflow-hidden rounded-b-[1.75rem] bg-[#fafaf8] text-[#181818]",
+          "relative z-20 mx-4 min-h-64 overflow-hidden rounded-[1.75rem] bg-[#fafaf8] text-[#181818]",
           classNames?.content,
         )}
       >
@@ -541,11 +845,18 @@ export function MorphingTabs({
           {activeItem ? (
             <motion.div
               key={activeItem.id}
-              initial={reduce ? { opacity: 0 } : { opacity: 0, y: 8, filter: "blur(6px)" }}
+              initial={
+                reduce
+                  ? { opacity: 0 }
+                  : { opacity: 0, y: 8, filter: "blur(6px)" }
+              }
               animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
               exit={
                 reduce
-                  ? { opacity: 0, transition: { duration: 0.08, ease: EASE_OUT } }
+                  ? {
+                      opacity: 0,
+                      transition: { duration: 0.08, ease: EASE_OUT },
+                    }
                   : {
                       opacity: 0,
                       y: -5,
@@ -553,7 +864,11 @@ export function MorphingTabs({
                       transition: { duration: 0.12, ease: EASE_OUT },
                     }
               }
-              transition={reduce ? { duration: 0.12, ease: EASE_OUT } : SPRING_PRESS}
+              transition={
+                reduce
+                  ? { duration: 0.12, ease: EASE_OUT }
+                  : SPRING_PRESS
+              }
               className="min-h-64"
             >
               {activeItem.content}

--- a/components/motion/morphing-tabs.tsx
+++ b/components/motion/morphing-tabs.tsx
@@ -692,7 +692,7 @@ export function MorphingTabs({
           aria-label={ariaLabel}
           aria-orientation="horizontal"
           className={cn(
-            "relative z-10 flex h-full gap-3 md:gap-4",
+            "relative z-30 flex h-full gap-3 md:gap-4",
             classNames?.rail,
           )}
         >

--- a/components/motion/morphing-tabs.tsx
+++ b/components/motion/morphing-tabs.tsx
@@ -1,0 +1,566 @@
+"use client";
+
+import { X } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+import { EASE_OUT, SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+export type MorphingTabsItem = {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  content: ReactNode;
+  disabled?: boolean;
+};
+
+export type MorphingTabsClassNames = {
+  root?: string;
+  rail?: string;
+  tab?: string;
+  activeTab?: string;
+  icon?: string;
+  label?: string;
+  close?: string;
+  content?: string;
+};
+
+export interface MorphingTabsProps {
+  items: MorphingTabsItem[];
+  value?: string | null;
+  defaultValue?: string | null;
+  onValueChange?: (id: string | null) => void;
+  /** Called once after a pointer drag or keyboard reorder completes. */
+  onOrderChange?: (ids: string[]) => void;
+  /** Enables the close affordance on every tab when provided. */
+  onClose?: (id: string) => void;
+  ariaLabel?: string;
+  className?: string;
+  classNames?: MorphingTabsClassNames;
+}
+
+type DragState = {
+  id: string;
+  pointerId: number;
+  originX: number;
+  lastX: number;
+  startLeft: number;
+  moved: boolean;
+  startOrder: string[];
+};
+
+const DRAG_THRESHOLD = 5;
+const TAB_SURFACE_WIDTH = 176;
+const TAB_SURFACE_RADIUS = 24;
+const RAIL_HEIGHT = 80;
+const SURFACE_INSET = 16;
+const LIQUID_JOIN = 24;
+
+function sameOrder(a: string[], b: string[]) {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
+
+function safeId(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+function liquidTabPath(tabLeft: number, surfaceWidth: number) {
+  const panelLeft = SURFACE_INSET;
+  const panelRight = surfaceWidth - SURFACE_INSET;
+  const tabRight = tabLeft + TAB_SURFACE_WIDTH;
+  const top = RAIL_HEIGHT - 56;
+  const bottom = RAIL_HEIGHT;
+  const leftJoin = Math.max(panelLeft, tabLeft - LIQUID_JOIN);
+  const rightJoin = Math.min(panelRight, tabRight + LIQUID_JOIN);
+  const leftDepth = Math.min(LIQUID_JOIN, tabLeft - leftJoin);
+  const rightDepth = Math.min(LIQUID_JOIN, rightJoin - tabRight);
+  const leftControl = leftDepth * 0.55;
+  const rightControl = rightDepth * 0.55;
+
+  return [
+    `M${panelLeft} ${bottom + 8}`,
+    `V${bottom}`,
+    `H${leftJoin}`,
+    `C${leftJoin + leftControl} ${bottom} ${tabLeft} ${bottom - leftDepth + leftControl} ${tabLeft} ${bottom - leftDepth}`,
+    `V${top + TAB_SURFACE_RADIUS}`,
+    `Q${tabLeft} ${top} ${tabLeft + TAB_SURFACE_RADIUS} ${top}`,
+    `H${tabRight - TAB_SURFACE_RADIUS}`,
+    `Q${tabRight} ${top} ${tabRight} ${top + TAB_SURFACE_RADIUS}`,
+    `V${bottom - rightDepth}`,
+    `C${tabRight} ${bottom - rightDepth + rightControl} ${rightJoin - rightControl} ${bottom} ${rightJoin} ${bottom}`,
+    `H${panelRight}`,
+    `V${bottom + 8}`,
+    "Z",
+  ].join(" ");
+}
+
+export function MorphingTabs({
+  items,
+  value,
+  defaultValue,
+  onValueChange,
+  onOrderChange,
+  onClose,
+  ariaLabel = "Tabs",
+  className,
+  classNames,
+}: MorphingTabsProps) {
+  const reduce = useReducedMotion();
+  const uid = useId();
+  const itemIds = useMemo(() => items.map((item) => item.id), [items]);
+  const itemMap = useMemo(
+    () => new Map(items.map((item) => [item.id, item])),
+    [items],
+  );
+  const [order, setOrder] = useState(itemIds);
+  const orderRef = useRef(order);
+  orderRef.current = order;
+
+  const [internalValue, setInternalValue] = useState<string | null>(
+    defaultValue ?? itemIds[0] ?? null,
+  );
+  const controlled = value !== undefined;
+  const currentValue = controlled ? (value ?? null) : internalValue;
+
+  const tabRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragOffset, setDragOffset] = useState(0);
+  const [liquidDragLeft, setLiquidDragLeft] = useState<number | null>(null);
+  const [surfaceWidth, setSurfaceWidth] = useState(0);
+  const [settledTabLeft, setSettledTabLeft] = useState(SURFACE_INSET);
+
+  useEffect(() => {
+    setOrder((current) => {
+      const available = new Set(itemIds);
+      const retained = current.filter((id) => available.has(id));
+      const retainedSet = new Set(retained);
+      const added = itemIds.filter((id) => !retainedSet.has(id));
+      const next = [...retained, ...added];
+
+      return sameOrder(current, next) ? current : next;
+    });
+  }, [itemIds]);
+
+  const orderedItems = useMemo(
+    () =>
+      order.flatMap((id) => {
+        const item = itemMap.get(id);
+        return item ? [item] : [];
+      }),
+    [itemMap, order],
+  );
+
+  const firstEnabledItem =
+    orderedItems.find((item) => !item.disabled) ?? orderedItems[0] ?? null;
+  const activeItem =
+    currentValue && itemMap.has(currentValue)
+      ? itemMap.get(currentValue) ?? null
+      : firstEnabledItem;
+  const activeId = activeItem?.id ?? null;
+  const activeOrderIndex = activeId ? order.indexOf(activeId) : -1;
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const measure = () => {
+      setSurfaceWidth(root.clientWidth);
+      const activeNode = activeId ? tabRefs.current[activeId] : null;
+      if (activeNode && activeOrderIndex >= 0 && liquidDragLeft === null) {
+        setSettledTabLeft(activeNode.offsetLeft);
+      }
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, [activeId, activeOrderIndex, liquidDragLeft]);
+
+  const liquidSurfacePath = useMemo(() => {
+    if (!activeItem || surfaceWidth <= SURFACE_INSET * 2) return null;
+    return liquidTabPath(liquidDragLeft ?? settledTabLeft, surfaceWidth);
+  }, [activeItem, liquidDragLeft, settledTabLeft, surfaceWidth]);
+
+  const setActive = useCallback(
+    (id: string | null) => {
+      if (id && itemMap.get(id)?.disabled) return;
+      if (!controlled) setInternalValue(id);
+      onValueChange?.(id);
+    },
+    [controlled, itemMap, onValueChange],
+  );
+
+  useEffect(() => {
+    if (currentValue && itemMap.has(currentValue)) return;
+    if (firstEnabledItem && firstEnabledItem.id !== currentValue) {
+      setActive(firstEnabledItem.id);
+    }
+  }, [currentValue, firstEnabledItem, itemMap, setActive]);
+
+  const commitOrder = useCallback(
+    (next: string[], notify: boolean) => {
+      orderRef.current = next;
+      setOrder((current) => (sameOrder(current, next) ? current : next));
+      if (notify) onOrderChange?.(next);
+    },
+    [onOrderChange],
+  );
+
+  const getDropIndex = useCallback((clientX: number, draggedId: string) => {
+    const otherIds = orderRef.current.filter((id) => id !== draggedId);
+
+    for (let index = 0; index < otherIds.length; index += 1) {
+      const rect = tabRefs.current[otherIds[index]]?.getBoundingClientRect();
+      if (rect && clientX < rect.left + rect.width / 2) return index;
+    }
+
+    return otherIds.length;
+  }, []);
+
+  const moveBy = useCallback(
+    (id: string, direction: -1 | 1) => {
+      const current = orderRef.current;
+      const index = current.indexOf(id);
+      const nextIndex = index + direction;
+
+      if (
+        index === -1 ||
+        nextIndex < 0 ||
+        nextIndex >= current.length ||
+        itemMap.get(id)?.disabled
+      ) {
+        return;
+      }
+
+      const next = current.slice();
+      [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+      commitOrder(next, true);
+    },
+    [commitOrder, itemMap],
+  );
+
+  const startDrag = useCallback(
+    (id: string, event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || itemMap.get(id)?.disabled) return;
+
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      dragRef.current = {
+        id,
+        pointerId: event.pointerId,
+        originX: event.clientX,
+        lastX: event.clientX,
+        startLeft: event.currentTarget.offsetLeft,
+        moved: false,
+        startOrder: orderRef.current.slice(),
+      };
+      setDraggingId(id);
+      setDragOffset(0);
+      setLiquidDragLeft(event.currentTarget.offsetLeft);
+      setActive(id);
+    },
+    [itemMap, setActive],
+  );
+
+  const moveDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+
+      const offset = event.clientX - drag.originX;
+      drag.lastX = event.clientX;
+      const nextLiquidLeft = Math.max(
+        SURFACE_INSET,
+        Math.min(
+          surfaceWidth - SURFACE_INSET - TAB_SURFACE_WIDTH,
+          drag.startLeft + event.clientX - drag.originX,
+        ),
+      );
+      setLiquidDragLeft(nextLiquidLeft);
+      if (!drag.moved && Math.abs(offset) < DRAG_THRESHOLD) return;
+      drag.moved = true;
+
+      const current = orderRef.current;
+      const currentIndex = current.indexOf(drag.id);
+
+      const constrainedOffset =
+        current.length <= 1
+          ? 0
+          : currentIndex === 0
+            ? Math.max(0, offset)
+            : currentIndex === current.length - 1
+              ? Math.min(0, offset)
+              : offset;
+
+      setDragOffset(constrainedOffset);
+    },
+    [surfaceWidth],
+  );
+
+  const finishDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+
+      if (event.currentTarget.hasPointerCapture(drag.pointerId)) {
+        event.currentTarget.releasePointerCapture(drag.pointerId);
+      }
+
+      if (drag.moved) {
+        const targetIndex = getDropIndex(drag.lastX, drag.id);
+        const next = drag.startOrder.filter((id) => id !== drag.id);
+        next.splice(targetIndex, 0, drag.id);
+        if (!sameOrder(drag.startOrder, next)) {
+          commitOrder(next, true);
+        }
+      }
+
+      dragRef.current = null;
+      setDraggingId(null);
+      setDragOffset(0);
+      setLiquidDragLeft(null);
+    },
+    [commitOrder, getDropIndex],
+  );
+
+  const handleTabKeyDown = useCallback(
+    (id: string, event: React.KeyboardEvent<HTMLButtonElement>) => {
+      const index = orderRef.current.indexOf(id);
+      if (index === -1) return;
+
+      if (event.altKey && (event.key === "ArrowLeft" || event.key === "ArrowRight")) {
+        event.preventDefault();
+        moveBy(id, event.key === "ArrowLeft" ? -1 : 1);
+        return;
+      }
+
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+
+      event.preventDefault();
+      const direction = event.key === "ArrowLeft" ? -1 : 1;
+      const nextIndex = (index + direction + orderRef.current.length) % orderRef.current.length;
+      const nextId = orderRef.current[nextIndex];
+      setActive(nextId);
+      requestAnimationFrame(() => {
+        tabRefs.current[nextId]
+          ?.querySelector<HTMLButtonElement>('[role="tab"]')
+          ?.focus();
+      });
+    },
+    [moveBy, setActive],
+  );
+
+  if (!orderedItems.length) return null;
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn(
+        "relative isolate min-w-0 overflow-hidden rounded-[2rem] bg-[#292929] text-white",
+        classNames?.root,
+        className,
+      )}
+    >
+      {liquidSurfacePath ? (
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          viewBox={`0 0 ${surfaceWidth} ${RAIL_HEIGHT + 8}`}
+          preserveAspectRatio="none"
+          className={cn(
+            "pointer-events-none absolute inset-x-0 top-0 z-0 h-[88px] w-full text-[#fafaf8]",
+            classNames?.activeTab,
+          )}
+        >
+          <motion.path
+            initial={false}
+            animate={{ d: liquidSurfacePath }}
+            transition={
+              reduce || draggingId ? { duration: 0 } : SPRING_LAYOUT
+            }
+            fill="currentColor"
+          />
+        </svg>
+      ) : null}
+      <div className="relative h-20">
+        <div
+          role="tablist"
+          aria-label={ariaLabel}
+          aria-orientation="horizontal"
+          className={cn(
+            "relative z-10 flex h-full min-w-0 items-end gap-3 px-4 pt-3 md:gap-4",
+            classNames?.rail,
+          )}
+        >
+          {orderedItems.map((item) => {
+            const isActive = item.id === activeId;
+            const isDragging = item.id === draggingId;
+            const tabId = `${uid}-tab-${safeId(item.id)}`;
+
+            return (
+              <motion.div
+                key={item.id}
+                ref={(node) => {
+                  tabRefs.current[item.id] = node;
+                }}
+                layout={reduce ? false : "position"}
+                transition={
+                  reduce || isDragging ? { duration: 0 } : SPRING_LAYOUT
+                }
+                animate={
+                  reduce
+                    ? {
+                        opacity: item.disabled
+                          ? 0.4
+                          : draggingId && !isDragging
+                            ? 0.72
+                            : 1,
+                      }
+                    : {
+                        x: isDragging ? dragOffset : 0,
+                        opacity: item.disabled
+                          ? 0.4
+                          : draggingId && !isDragging
+                            ? 0.72
+                            : 1,
+                      }
+                }
+                style={{
+                  zIndex: isDragging ? 30 : isActive ? 20 : 1,
+                }}
+                className={cn(
+                  "group relative flex h-14 w-44 shrink-0 select-none touch-pan-y items-stretch",
+                  item.disabled && "cursor-not-allowed",
+                  isDragging ? "cursor-grabbing" : "cursor-grab",
+                )}
+                onPointerDown={(event) => startDrag(item.id, event)}
+                onPointerMove={moveDrag}
+                onPointerUp={finishDrag}
+                onPointerCancel={finishDrag}
+              >
+                {!isActive ? (
+                  <span
+                    aria-hidden
+                    className="absolute inset-x-0 bottom-2 top-0 rounded-[1.25rem] bg-transparent transition-colors duration-200 group-hover:bg-white/[0.06]"
+                  />
+                ) : null}
+
+                <button
+                  id={tabId}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  aria-controls={`${uid}-panel`}
+                  aria-disabled={item.disabled || undefined}
+                  tabIndex={isActive ? 0 : -1}
+                  disabled={item.disabled}
+                  onClick={() => setActive(item.id)}
+                  onKeyDown={(event) => handleTabKeyDown(item.id, event)}
+                  className={cn(
+                    "group relative z-10 flex h-full w-full min-w-0 items-center gap-2 overflow-hidden rounded-t-[inherit] px-3 text-left outline-none transition-colors",
+                    isActive
+                      ? "text-[#181818]"
+                      : "pb-2 text-white/70 hover:text-white",
+                    classNames?.tab,
+                  )}
+                >
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "pointer-events-none absolute inset-x-1 top-1 opacity-0 transition-opacity group-focus-visible:opacity-100",
+                      isActive
+                        ? "bottom-0 rounded-t-[1.25rem] border-x-2 border-t-2 border-black/20"
+                        : "bottom-2 rounded-[1rem] border-2 border-white/60",
+                    )}
+                  />
+                  {item.icon ? (
+                    <span
+                      aria-hidden
+                      className={cn("grid size-8 shrink-0 place-items-center", classNames?.icon)}
+                    >
+                      {item.icon}
+                    </span>
+                  ) : null}
+                  <span
+                    className={cn(
+                      "min-w-0 truncate whitespace-nowrap text-base font-medium leading-none tracking-[-0.025em]",
+                      classNames?.label,
+                    )}
+                  >
+                    {item.label}
+                  </span>
+                </button>
+
+                {onClose ? (
+                  <button
+                    type="button"
+                    aria-label={`Close ${item.label}`}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onClose(item.id);
+                    }}
+                    className={cn(
+                      "absolute right-2 top-1/2 z-20 grid size-6 -translate-y-1/2 place-items-center rounded-full text-[#9aa0a8] transition-colors hover:bg-black/[0.06] hover:text-[#4b5563] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current",
+                      !isActive && "top-[calc(50%-4px)] text-white/45 hover:bg-white/[0.08] hover:text-white/80",
+                      classNames?.close,
+                    )}
+                  >
+                    <X aria-hidden className="size-3.5 stroke-[1.5]" />
+                  </button>
+                ) : null}
+              </motion.div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div
+        id={`${uid}-panel`}
+        role="tabpanel"
+        aria-labelledby={`${uid}-tab-${safeId(activeId ?? "empty")}`}
+        className={cn(
+          "relative z-20 mx-4 min-h-64 overflow-hidden rounded-b-[1.75rem] bg-[#fafaf8] text-[#181818]",
+          classNames?.content,
+        )}
+      >
+        <AnimatePresence mode="popLayout" initial={false}>
+          {activeItem ? (
+            <motion.div
+              key={activeItem.id}
+              initial={reduce ? { opacity: 0 } : { opacity: 0, y: 8, filter: "blur(6px)" }}
+              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+              exit={
+                reduce
+                  ? { opacity: 0, transition: { duration: 0.08, ease: EASE_OUT } }
+                  : {
+                      opacity: 0,
+                      y: -5,
+                      filter: "blur(5px)",
+                      transition: { duration: 0.12, ease: EASE_OUT },
+                    }
+              }
+              transition={reduce ? { duration: 0.12, ease: EASE_OUT } : SPRING_PRESS}
+              className="min-h-64"
+            >
+              {activeItem.content}
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/components/previews/blocks/morphing-tabs.preview.tsx
+++ b/components/previews/blocks/morphing-tabs.preview.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { MorphingTabs, type MorphingTabsItem } from "@/components/motion/morphing-tabs";
+
+const ROOM_CONTENT: Record<string, { eyebrow: string; title: string; detail: string; accent: string }> = {
+  "room-2": {
+    eyebrow: "quiet focus",
+    title: "Room 2",
+    detail: "A small space for the work that needs a little more air around it.",
+    accent: "#db5b2f",
+  },
+  general: {
+    eyebrow: "shared space",
+    title: "General",
+    detail: "The common room for notes, links and the ideas that are still finding their shape.",
+    accent: "#1bb273",
+  },
+  archive: {
+    eyebrow: "kept close",
+    title: "Archive",
+    detail: "Past rooms stay available without competing with the conversations in motion.",
+    accent: "#7a6de2",
+  },
+};
+
+function RoomPanel({ id }: { id: string }) {
+  const room = ROOM_CONTENT[id];
+
+  return (
+    <div className="relative min-h-64 overflow-hidden bg-[radial-gradient(circle_at_1px_1px,#dfe2e3_1px,transparent_1.5px)] bg-[size:4.8rem_4.8rem] px-7 py-8 md:px-12 md:py-10">
+      <div className="relative max-w-xl">
+        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-black/40">
+          {room.eyebrow}
+        </p>
+        <h3 className="mt-3 text-3xl font-light tracking-[-0.055em] text-[#151515] md:text-5xl">
+          {room.title}
+        </h3>
+        <p className="mt-4 max-w-md text-sm leading-6 text-black/55 md:text-base">
+          {room.detail}
+        </p>
+        <div className="mt-8 flex items-center gap-3 text-xs font-medium text-black/50">
+          <span className="size-2 rounded-full" style={{ backgroundColor: room.accent }} />
+          drag the active room to reorder
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function MorphingTabsPreview() {
+  const initialItems = useMemo<MorphingTabsItem[]>(
+    () =>
+      Object.keys(ROOM_CONTENT).map((id) => ({
+        id,
+        label: ROOM_CONTENT[id].title,
+        content: <RoomPanel id={id} />,
+      })),
+    [],
+  );
+  const [items, setItems] = useState(initialItems);
+  const [value, setValue] = useState<string | null>("room-2");
+
+  return (
+    <div className="flex w-full min-w-0 items-center justify-center bg-[#242424] p-3 md:p-8">
+      <MorphingTabs
+        items={items}
+        value={value}
+        onValueChange={setValue}
+        onOrderChange={(ids) => {
+          setItems((current) => {
+            const byId = new Map(current.map((item) => [item.id, item]));
+            return ids.flatMap((id) => {
+              const item = byId.get(id);
+              return item ? [item] : [];
+            });
+          });
+        }}
+        onClose={(id) => {
+          setItems((current) => {
+            const next = current.filter((item) => item.id !== id);
+            if (id === value) setValue(next[0]?.id ?? null);
+            return next;
+          });
+        }}
+        ariaLabel="Rooms"
+        className="w-full max-w-5xl"
+      />
+    </div>
+  );
+}

--- a/components/previews/blocks/morphing-tabs.preview.tsx
+++ b/components/previews/blocks/morphing-tabs.preview.tsx
@@ -41,7 +41,7 @@ function RoomPanel({ id }: { id: string }) {
         </p>
         <div className="mt-8 flex items-center gap-3 text-xs font-medium text-black/50">
           <span className="size-2 rounded-full" style={{ backgroundColor: room.accent }} />
-          drag the active room to reorder
+          drag any room to reorder
         </div>
       </div>
     </div>

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -170,6 +170,9 @@ export const previews: Record<string, ComponentType> = {
   "blocks/expandable-tabs": dynamic(() =>
     import("./blocks/expandable-tabs.preview").then((m) => m.ExpandableTabsPreview),
   ),
+  "blocks/morphing-tabs": dynamic(() =>
+    import("./blocks/morphing-tabs.preview").then((m) => m.MorphingTabsPreview),
+  ),
   "blocks/swipeable-list": dynamic(() =>
     import("./blocks/swipeable-list.preview").then((m) => m.SwipeableListPreview),
   ),

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -129,6 +129,7 @@ const COMPONENT_DATES = {
   "blocks/expandable-action-bar": { publishedAt: "2026-06-05", updatedAt: "2026-06-22" },
   "blocks/overflow-actions": { publishedAt: "2026-06-19", updatedAt: "2026-06-28" },
   "blocks/expandable-tabs": { publishedAt: "2026-06-14", updatedAt: "2026-06-28" },
+  "blocks/morphing-tabs": { publishedAt: "2026-08-06", updatedAt: "2026-08-06" },
   "blocks/swipeable-list": { publishedAt: "2026-06-15", updatedAt: "2026-06-28" },
   "blocks/file-upload": { publishedAt: "2026-06-18", updatedAt: "2026-07-30" },
   "blocks/prediction-market": { publishedAt: "2026-06-18", updatedAt: "2026-06-21" },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1468,6 +1468,21 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/expandable-tabs.tsx",
       },
       {
+        slug: "morphing-tabs",
+        name: "Morphing Tabs",
+        description: "Reorderable tabs whose selected item grows into a white content surface, with the active shape gliding as tabs move and a shared morph between rooms.",
+        file: "components/motion/morphing-tabs.tsx",
+        badge: "new",
+        launchedAt: "2026-08-06",
+        keywords: [
+          "reorderable tabs react",
+          "drag tabs react",
+          "morphing tabs component",
+          "animated tab panel",
+          "shared layout tabs",
+        ],
+      },
+      {
         slug: "swipeable-list",
         name: "Swipeable List",
         description: "Mobile-style list rows that swipe left or right to reveal contextual action buttons.",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lenis": "^1.3.23",
     "lucide-react": "^1.16.0",
     "motion": "^11.15.0",
-    "next": "^15.1.4",
+    "next": "16.3.0",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,7 +3,7 @@ import { type NextFetchEvent, type NextRequest, NextResponse } from "next/server
 /**
  * Registry installs happen via the shadcn CLI fetching `/r/{slug}.json`. That
  * request is headless (no browser, no gtag), and the route is force-static so
- * no per-request handler runs. Middleware runs on every request even for
+ * no per-request handler runs. Proxy runs on every matching request even for
  * static assets, so we tag installs here and report them to GA4 server-side
  * via the Measurement Protocol, keeping the route on the CDN.
  */
@@ -12,7 +12,7 @@ export const config = { matcher: "/r/:path*" };
 const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 const GA_SECRET = process.env.GA_API_SECRET;
 
-export function middleware(req: NextRequest, event: NextFetchEvent) {
+export function proxy(req: NextRequest, event: NextFetchEvent) {
   const pass = NextResponse.next();
 
   const { pathname } = req.nextUrl;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -33,7 +33,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "build/types/**/*.ts"
+    "build/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "examples/shadcn-vite-install",


### PR DESCRIPTION
## What changed

- add a new liquid morphing tabs block with equal-size tabs merged into the content surface
- support click selection and pointer/keyboard reordering
- rebuild drag behavior around fixed slots and spring physics for symmetric, interruptible movement
- move adjacent tabs at the 50% overlap threshold and keep the active liquid surface attached during reordering
- add the public preview, registry metadata, launch date, and install wiring
- upgrade the site to Next.js 16.3 and migrate `middleware.ts` to the `proxy.ts` convention

## Why

The block provides a polished, reusable tab interaction where the selected tab feels physically joined to its panel while tabs can be reordered without text drift, detached corners, or asymmetric drag jitter.

## Validation

- `bun run check`
- `bunx next typegen`
- `bun test` — 174 passing tests
- repeated browser drag checks in both directions, selection after reorder, 50% crossover behavior, and selected-surface alignment
