### PR TITLE
fix: export button link from base registry

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <title>beUI</title>
     <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
         <path d="M12 3c7.2 0 9 1.8 9 9s-1.8 9-9 9s-9-1.8-9-9s1.8-9 9-9"/>
         <path d="M8 13.5a2.5 2.5 0 1 0 5 0a2.5 2.5 0 1 0-5 0"/>

--- a/components/motion/button/base.tsx
+++ b/components/motion/button/base.tsx
@@ -2,9 +2,9 @@
 
 import {
   AnimatePresence,
+  type HTMLMotionProps,
   motion,
   useReducedMotion,
-  type HTMLMotionProps,
 } from "motion/react";
 import {
   forwardRef,
@@ -15,8 +15,8 @@ import {
   useState,
 } from "react";
 import { EASE_OUT, SPRING_PRESS } from "@/lib/ease";
-import { cn } from "@/lib/utils";
 import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
+import { cn } from "@/lib/utils";
 
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "outline";
 export type ButtonSize = "sm" | "md" | "lg" | "icon";
@@ -30,6 +30,16 @@ export interface ButtonProps extends Omit<
   pressScale?: number;
   /** Spawn a Material-style ripple from the press point. Off by default. */
   ripple?: boolean;
+  children?: ReactNode;
+}
+
+export interface ButtonLinkProps extends Omit<
+  HTMLMotionProps<"a">,
+  "children"
+> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  pressScale?: number;
   children?: ReactNode;
 }
 
@@ -138,6 +148,42 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ) : null}
         {children}
       </motion.button>
+    );
+  },
+);
+
+export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
+  function ButtonLink(
+    {
+      variant = "primary",
+      size = "md",
+      pressScale = 0.93,
+      className,
+      children,
+      ...rest
+    },
+    ref,
+  ) {
+    const reduce = useReducedMotion();
+    const canHover = useHoverCapable();
+
+    return (
+      <motion.a
+        ref={ref}
+        whileTap={reduce ? undefined : { scale: pressScale }}
+        whileHover={reduce || !canHover ? undefined : { scale: 1.02 }}
+        transition={SPRING_PRESS}
+        className={cn(
+          "inline-flex items-center justify-center font-medium select-none",
+          "transition-colors",
+          VARIANT_CLASS[variant],
+          SIZE_CLASS[size],
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </motion.a>
     );
   },
 );

--- a/components/motion/button/index.tsx
+++ b/components/motion/button/index.tsx
@@ -1,8 +1,11 @@
-export { Button } from "./base";
-export type { ButtonProps, ButtonVariant, ButtonSize } from "./base";
-
-export { StatefulButton } from "./stateful";
-export type { StatefulButtonProps, ButtonState } from "./stateful";
-
-export { MagneticButton } from "./magnetic";
+export type {
+  ButtonLinkProps,
+  ButtonProps,
+  ButtonSize,
+  ButtonVariant,
+} from "./base";
+export { Button, ButtonLink } from "./base";
 export type { MagneticButtonProps } from "./magnetic";
+export { MagneticButton } from "./magnetic";
+export type { ButtonState, StatefulButtonProps } from "./stateful";
+export { StatefulButton } from "./stateful";


### PR DESCRIPTION
## What changed

- add `ButtonLink` and its props to the separate `button-base` registry item
- re-export the link API from the local button barrel
- add an accessible title to the public logo asset

## Why

The separate `button-base` registry item should support both animated button controls and anchor CTAs without restoring the retired aggregate `button` item.

## Validation

- `bun run typecheck`
- `bun run check:registry`
- Biome check on the changed Button files
- fresh Next.js `npx shadcn add` smoke test followed by `tsc --noEmit`