### PR TITLE
fix(popover): keep the gooey trigger label visible in Safari

### DIFF
--- a/components/motion/popover.tsx
+++ b/components/motion/popover.tsx
@@ -146,6 +146,37 @@ function clipForProgress(geo: Geo, progress: number, supportsShape: boolean) {
     : insetFor(rect, geo.layerW, geo.layerH);
 }
 
+function roundedRectPath(rect: Rect) {
+  const radius = Math.max(0, Math.min(rect.r, rect.w / 2, rect.h / 2));
+  const n = (value: number) => value.toFixed(3);
+  const x1 = rect.x;
+  const y1 = rect.y;
+  const x2 = rect.x + rect.w;
+  const y2 = rect.y + rect.h;
+  const arc = `A${n(radius)} ${n(radius)} 0 0 1`;
+
+  // A zero radius makes every arc degenerate to a line, so this also draws
+  // plain rectangles.
+  return (
+    `M${n(x1 + radius)} ${n(y1)}` +
+    `H${n(x2 - radius)}${arc} ${n(x2)} ${n(y1 + radius)}` +
+    `V${n(y2 - radius)}${arc} ${n(x2 - radius)} ${n(y2)}` +
+    `H${n(x1 + radius)}${arc} ${n(x1)} ${n(y2 - radius)}` +
+    `V${n(y1 + radius)}${arc} ${n(x1 + radius)} ${n(y1)}Z`
+  );
+}
+
+// The goo layer is portalled above the page, so its copy of the trigger pill
+// would cover the real trigger's label and focus ring. Punching the trigger
+// back out keeps the real one visible and clips the blur to the layer box.
+// This is a clip path rather than a CSS mask on purpose: WebKit silently
+// ignores `mask: url(#id)` pointing at an SVG <mask> element, which left the
+// label hidden behind the goo in Safari.
+function triggerCutout(geo: Geo) {
+  const layer = { x: 0, y: 0, w: geo.layerW, h: geo.layerH, r: 0 };
+  return `path(evenodd, "${roundedRectPath(layer)} ${roundedRectPath(geo.trigger)}")`;
+}
+
 interface PopoverContextValue {
   open: boolean;
   setOpen: (open: boolean) => void;
@@ -482,7 +513,6 @@ export function PopoverContent({ children, className }: PopoverContentProps) {
     triggerMode === "hover"
       ? { onMouseEnter: openHover, onMouseLeave: scheduleClose }
       : {};
-  const maskId = `${gooId}-trigger-cutout`;
 
   // Match the server and first client render, then attach the portal after
   // hydration. This preserves SSR without regenerating the page on the client.
@@ -498,9 +528,7 @@ export function PopoverContent({ children, className }: PopoverContentProps) {
       }}
     >
       {/* Goo filter: blur, sharpen the alpha back into solid shapes, then lay
-          the crisp original on top so blobs merge with liquid edges. The mask
-          removes the real trigger area so this top-layer copy never covers its
-          label or focus ring. */}
+          the crisp original on top so blobs merge with liquid edges. */}
       <svg aria-hidden width="0" height="0" className="absolute">
         <title>Popover visual effects</title>
         <defs>
@@ -518,25 +546,6 @@ export function PopoverContent({ children, className }: PopoverContentProps) {
             />
             <feComposite in="SourceGraphic" in2="goo" operator="atop" />
           </filter>
-          <mask
-            id={maskId}
-            maskUnits="userSpaceOnUse"
-            maskContentUnits="userSpaceOnUse"
-            x={0}
-            y={0}
-            width={geo.layerW}
-            height={geo.layerH}
-          >
-            <rect width={geo.layerW} height={geo.layerH} fill="white" />
-            <rect
-              x={geo.trigger.x}
-              y={geo.trigger.y}
-              width={geo.trigger.w}
-              height={geo.trigger.h}
-              rx={geo.trigger.r}
-              fill="black"
-            />
-          </mask>
         </defs>
       </svg>
 
@@ -550,8 +559,7 @@ export function PopoverContent({ children, className }: PopoverContentProps) {
           width: geo.layerW,
           height: geo.layerH,
           filter: reduce ? undefined : `url(#${gooId})`,
-          mask: `url(#${maskId})`,
-          WebkitMask: `url(#${maskId})`,
+          clipPath: triggerCutout(geo),
         }}
       >
         <div

--- a/tests/popover-portal.test.tsx
+++ b/tests/popover-portal.test.tsx
@@ -67,6 +67,36 @@ describe("portalled popovers", () => {
     });
   });
 
+  // The goo layer paints above the page, so the trigger has to be cut back out
+  // of it. WebKit ignores `mask: url(#id)` that points at an SVG <mask>
+  // element, which hid the trigger's label behind the goo in Safari. Keep the
+  // cutout a clip path.
+  test("Gooey cuts the trigger out with a clip path, not an SVG mask", async () => {
+    const { getByRole } = render(
+      <Popover>
+        <PopoverTrigger>
+          <button type="button">Open Gooey</button>
+        </PopoverTrigger>
+        <PopoverContent>Gooey actions</PopoverContent>
+      </Popover>,
+    );
+    setTriggerRect(getByRole("button", { name: "Open Gooey" }));
+    fireEvent(window, new Event("resize"));
+
+    const gooLayer = await waitFor(() => {
+      const layer = document.querySelector<HTMLElement>(
+        '[data-popover-portal] div[aria-hidden="true"]',
+      );
+      // Two subpaths: the layer box, then the trigger that even-odd knocks out.
+      expect(layer?.style.clipPath).toStartWith("path(evenodd,");
+      expect(layer?.style.clipPath.match(/M/g)).toHaveLength(2);
+      return layer as HTMLElement;
+    });
+
+    expect(gooLayer.getAttribute("style")).not.toContain("mask");
+    expect(document.querySelector("[data-popover-portal] mask")).toBeNull();
+  });
+
   test("Morph escapes clipping and tracks the trigger in viewport coordinates", async () => {
     const { getByRole, getByText } = render(
       <div style={{ overflow: "hidden" }}>


### PR DESCRIPTION
**tl;dr**

- **Motivation:** In Safari, the Gooey Popover trigger loses its label. The button renders as an empty pill, before and after you open the panel. The goo layer covers it, because the cutout that should keep the trigger clear relies on a CSS mask that WebKit ignores.
- **Outcome:** The trigger keeps its label in Safari. Chrome does not change.

## The failure

iPadOS 26.4 Safari, `/components/motion/popover`, panel open. Both triggers render as empty pills on `main`.

![Gooey Popover in iPadOS Safari, before and after this change](https://raw.githubusercontent.com/l4u532/ui-components/pr-142-assets/safari-popover-trigger.png)

## The cause

`PopoverContent` renders the goo layer in a portal on `document.body` at `z-[9999]`, so the layer paints above the real trigger. The layer holds its own copy of the trigger pill, which the goo filter needs as a shape to merge the neck into. An SVG `<mask>` then removed the trigger area again, so the copy never covered the real button.

WebKit does not apply a CSS mask that points at an SVG `<mask>` element. It parses the value and keeps it as the computed style, then renders the element unmasked. The trigger area was therefore never cut out, and the opaque goo pill hid the button label.

I probed this on iPadOS 26.4 Safari with a minimal page:

| Declaration | Safari 26.4 | Chrome |
|---|---|---|
| `mask: url(#m)` at an SVG `<mask>` | ignored | applied |
| `-webkit-mask-image: url(#m)` | ignored | applied |
| same mask, declared in a sized `<svg>` | ignored | applied |
| `clip-path: url(#c)` at an SVG `<clipPath>` | applied | applied |
| `filter: url(#f)` | applied | applied |
| `clip-path: path(evenodd, ...)` | applied | applied |

The size of the host `<svg>` is not the trigger. Filters and `clipPath` references from the same 0 by 0 `<svg>` work in both engines. Only the mask reference fails.

## The fix

The cutout becomes an even-odd clip path: the layer box, then the trigger rounded rectangle that even-odd knocks out. `clip-path: path()` is supported in Safari 13.1+, Chrome 88+ and Firefox 63+, so one code path serves every engine and the `<mask>` element is gone.

Clipping keeps the previous behaviour, because a clip path and a mask both apply after the filter. The clip also bounds the blur to the layer box, which the mask region did before.

## Test plan

- `bun test`: 195 pass. The new case in `tests/popover-portal.test.tsx` asserts the goo layer carries a two-subpath even-odd clip path and no mask. It fails on `main` and passes here.
- `bun run check`: typecheck, lint and registry validation pass. The two biome infos are pre-existing and come from `biome.json`.
- iPadOS 26.4 Safari, `/components/motion/popover`: before this change both triggers render as empty pills. After it, "Edit profile" and "Hover me" stay readable, closed and open. Checked `side="bottom"` and `side="top"`.
- Chrome 151, same page, `main` against this branch. The rendering is the same. In the closed state no channel differs. In the settled open state 21 channels out of 1.93M differ, by at most 2 of 255, which is antialiasing along the goo edge.

  ![Gooey Popover in Chrome, before and after this change](https://raw.githubusercontent.com/l4u532/ui-components/pr-142-assets/chrome-popover-unchanged.png)

- Chrome 151 behaviour, run on `main` and on this branch with the same result, no console errors: click opens the panel and sets `aria-expanded`, the panel content shows, the trigger label stays hit-testable at its centre, the panel input accepts typing, Escape closes, an outside click closes, and hover opens the `side="top"` popover.
