### PR TITLE
fix(bottom-sheet): dismiss on Escape and keep the title selectable

### DIFF
--- a/components/motion/bottom-sheet.tsx
+++ b/components/motion/bottom-sheet.tsx
@@ -7,7 +7,7 @@ import {
   useDragControls,
   useReducedMotion,
 } from "motion/react";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { EASE_DRAWER } from "@/lib/ease";
 import { cn } from "@/lib/utils";
@@ -48,6 +48,9 @@ export function BottomSheet({
   const sheetRef = useRef<HTMLDivElement>(null);
   const reduce = useReducedMotion();
   const heightRef = useRef(0);
+  const uid = useId();
+  const titleId = `${uid}-title`;
+  const descriptionId = `${uid}-description`;
 
   useEffect(() => {
     setMounted(true);
@@ -77,7 +80,17 @@ export function BottomSheet({
     body.style.left = "0";
     body.style.right = "0";
     body.style.overflow = "hidden";
+
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onOpenChange(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+
     return () => {
+      window.removeEventListener("keydown", onKey);
       body.style.position = prev.position;
       body.style.top = prev.top;
       body.style.left = prev.left;
@@ -85,7 +98,7 @@ export function BottomSheet({
       body.style.overflow = prev.overflow;
       window.scrollTo(0, scrollY);
     };
-  }, [open]);
+  }, [open, onOpenChange]);
 
   const onDragEnd = (_: unknown, info: PanInfo) => {
     const velocity = info.velocity.y;
@@ -169,22 +182,33 @@ export function BottomSheet({
             )}
             role="dialog"
             aria-modal="true"
-            aria-label={title}
+            aria-labelledby={title ? titleId : undefined}
+            aria-describedby={description ? descriptionId : undefined}
+            aria-label={title ? undefined : "Bottom sheet"}
           >
-            <div
-              onPointerDown={(e) => dragControls.start(e)}
-              className="flex cursor-grab touch-none flex-col items-center px-4 pb-2 pt-3 active:cursor-grabbing"
-            >
-              <div className="h-1.5 w-10 rounded-full bg-muted-foreground/40" />
+            <div className="flex flex-col items-center px-4 pb-2 pt-3">
+              {/* Drag only the pill so the title and description stay selectable. */}
+              <div
+                onPointerDown={(event) => dragControls.start(event)}
+                className="flex cursor-grab touch-none items-center justify-center py-1 active:cursor-grabbing"
+              >
+                <div className="h-1.5 w-10 rounded-full bg-muted-foreground/40" />
+              </div>
               {title || description ? (
-                <div className="mt-3 w-full">
+                <div className="mt-2 w-full">
                   {title ? (
-                    <h2 className="text-base font-semibold text-foreground">
+                    <h2
+                      id={titleId}
+                      className="text-base font-semibold text-foreground"
+                    >
                       {title}
                     </h2>
                   ) : null}
                   {description ? (
-                    <p className="mt-0.5 text-sm text-muted-foreground">
+                    <p
+                      id={descriptionId}
+                      className="mt-0.5 text-sm text-muted-foreground"
+                    >
                       {description}
                     </p>
                   ) : null}

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -19,7 +19,7 @@ const COMPONENT_DATES = {
   "motion/combobox": { publishedAt: "2026-08-11", updatedAt: "2026-08-11" },
   "motion/checkbox": { publishedAt: "2026-06-23", updatedAt: "2026-07-01" },
   "motion/radio": { publishedAt: "2026-06-23", updatedAt: "2026-07-13" },
-  "motion/bottom-sheet": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "motion/bottom-sheet": { publishedAt: "2026-05-17", updatedAt: "2026-08-15" },
   "motion/pull-to-refresh": { publishedAt: "2026-07-17", updatedAt: "2026-07-17" },
   "motion/shared-layout-bg": { publishedAt: "2026-05-17", updatedAt: "2026-07-29" },
   "motion/bounce-sidebar": { publishedAt: "2026-07-22", updatedAt: "2026-07-22" },

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/motion/animated-sidebar";
 import { AttachmentUpload } from "@/components/motion/attachment-upload";
 import { BloomMenu } from "@/components/motion/bloom-menu";
+import { BottomSheet } from "@/components/motion/bottom-sheet";
 import { BounceSidebar } from "@/components/motion/bounce-sidebar";
 import { Button } from "@/components/motion/button";
 import {
@@ -641,6 +642,19 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
       <PullToRefresh onRefresh={() => {}}>
         <p>Refreshable content.</p>
       </PullToRefresh>
+    ),
+  ],
+  [
+    "BottomSheet",
+    () => (
+      <BottomSheet
+        open
+        onOpenChange={() => {}}
+        title="Quick actions"
+        description="Drag the handle to dismiss."
+      >
+        <p>Sheet body</p>
+      </BottomSheet>
     ),
   ],
   [

--- a/tests/bottom-sheet.test.tsx
+++ b/tests/bottom-sheet.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { useState } from "react";
 import { BottomSheet } from "@/components/motion/bottom-sheet";
@@ -33,10 +33,20 @@ describe("BottomSheet", () => {
   });
 
   test("closes on Escape", () => {
-    const { getByRole, queryByRole } = render(<TestSheet />);
+    const onOpenChange = mock((_: boolean) => {});
+    const { getByRole } = render(
+      <BottomSheet
+        open
+        onOpenChange={onOpenChange}
+        title="Quick actions"
+        description="Drag the handle to dismiss."
+      >
+        <p>Sheet body</p>
+      </BottomSheet>,
+    );
     expect(getByRole("dialog", { name: "Quick actions" })).toBeTruthy();
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(queryByRole("dialog")).toBeNull();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   test("keeps the title outside the drag handle", () => {

--- a/tests/bottom-sheet.test.tsx
+++ b/tests/bottom-sheet.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { useState } from "react";
+import { BottomSheet } from "@/components/motion/bottom-sheet";
+
+afterEach(cleanup);
+
+function TestSheet() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open sheet
+      </button>
+      <BottomSheet
+        open={open}
+        onOpenChange={setOpen}
+        title="Quick actions"
+        description="Drag the handle to dismiss."
+      >
+        <p>Sheet body</p>
+      </BottomSheet>
+    </>
+  );
+}
+
+describe("BottomSheet", () => {
+  test("names the dialog from the visible title", () => {
+    const { getByRole } = render(<TestSheet />);
+    const dialog = getByRole("dialog", { name: "Quick actions" });
+    expect(dialog.getAttribute("aria-labelledby")).toBeTruthy();
+    expect(dialog.getAttribute("aria-label")).toBeNull();
+  });
+
+  test("closes on Escape", () => {
+    const { getByRole, queryByRole } = render(<TestSheet />);
+    expect(getByRole("dialog", { name: "Quick actions" })).toBeTruthy();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(queryByRole("dialog")).toBeNull();
+  });
+
+  test("keeps the title outside the drag handle", () => {
+    const { getByRole } = render(<TestSheet />);
+    const title = getByRole("heading", { name: "Quick actions" });
+    expect(title.closest(".touch-none")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Close the Bottom Sheet on Escape, matching Drawer and Center Morph Modal.
- Limit drag to the handle pill so the title and description stay selectable.
- Name the dialog from the visible heading (`aria-labelledby`) instead of duplicating the title as `aria-label`.

## Test plan
- [ ] Open `/components/motion/bottom-sheet`, press Escape, and confirm the sheet closes.
- [ ] Click-drag on **Quick actions** / the description and confirm the sheet does not start a swipe; drag the gray pill to dismiss.
- [ ] Select the title text with the mouse.
- [ ] `bun test tests/bottom-sheet.test.tsx tests/a11y.test.tsx`


https://github.com/user-attachments/assets/ea8170cc-37c9-4d98-b79c-650af1b6c119


