### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a PR.
 
 ## Star history
 
-<a href="https://www.star-history.com/#starc007/ui-components&Date">
+<a href="https://star-history.dera.page/#starc007/ui-components&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=starc007/ui-components&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=starc007/ui-components&type=Date" />
-    <img alt="Star history chart for starc007/ui-components" src="https://api.star-history.com/svg?repos=starc007/ui-components&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=starc007/ui-components&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=starc007/ui-components&type=Date" />
+    <img alt="Star history chart for starc007/ui-components" src="https://star-history.dera.page/svg?repos=starc007/ui-components&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken and needs a fix. This change repoints it to a working endpoint so the chart renders correctly again, including the dark and light variants.