### PR TITLE
feat: add beui agent skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,5 @@ Internal imports are safe: the registry build follows `@/lib` and relative impor
 2. Create a fork or feature branch.
 3. Keep changes focused and include the component source, preview and registry entry together.
 4. Open a pull request against `main`.
+
+Agents working in this repository should follow [`skills/beui/SKILL.md`](./skills/beui/SKILL.md) and `AGENTS.md`.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ https://beui.dev/r/{slug}.json
 https://beui.dev/r/{slug}/raw
 ```
 
+Install the beUI skill so Cursor, Claude Code and Codex pick existing `@beui`
+components before inventing new motion UI:
+
+```bash
+npx skills add starc007/ui-components --skill beui
+```
+
 ## Run locally
 
 ```bash

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -123,6 +123,7 @@ export const registry: CategoryEntry[] = [
             name: "Expanding Arrow Button",
             description:
               "An accent tile that expands into a dotted-arrow trail on hover or focus.",
+            installSlug: "expanding-arrow-button",
             file: "components/motion/expanding-arrow-button.tsx",
             previewKey: "motion/expanding-arrow-button",
             previewFile:

--- a/skills/beui/SKILL.md
+++ b/skills/beui/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: beui
+description: Pick and install beUI (@beui) animated React components from the shadcn registry. Use when building motion UI, agent/chat interfaces, toasts, docks, bottom sheets, drawers, popovers, sliders, loaders, 404 pages, or any beui.dev component. Maps user intent to exact @beui install slugs instead of inventing custom widgets.
+---
+
+# beUI
+
+Use beUI as copy-paste source through the `@beui` shadcn registry.
+
+## Workflow
+
+1. Fetch the live registry before choosing a component:
+
+```bash
+curl -fsS https://beui.dev/r/registry.json
+```
+
+2. Pick the closest install slug from `items[].name`.
+3. Inspect before installing:
+
+```bash
+npx shadcn@latest view @beui/<slug>
+```
+
+4. Install with the user's package runner:
+
+```bash
+npx shadcn@latest add @beui/<slug>
+# or
+pnpm dlx shadcn@latest add @beui/<slug>
+# or
+bunx --bun shadcn@latest add @beui/<slug>
+```
+
+5. Read the files that were added, then compose with the named exports. There is no `beui` runtime package.
+
+The live registry is the source of truth. Use the table below only to resolve common lookalikes.
+
+## Picker
+
+| User asks for | Install `@beui/...` | Avoid |
+| --- | --- | --- |
+| Toast or snackbar | `animated-toast-stack` | `notification-stack` |
+| Expanding notification inbox | `notification-stack` | `animated-toast-stack` |
+| Mobile bottom sheet, Vaul-style panel | `bottom-sheet` | `drawer` |
+| Side panel or app drawer | `drawer` | `bottom-sheet` |
+| App chrome sidebar | `animated-sidebar` | `bounce-sidebar`, `ai-sidebar` |
+| AI files, folders, bookmarks | `ai-sidebar` | `animated-sidebar` |
+| Whole agent workspace | `chat-app` | hand-rolled chat shell |
+| Streaming thread that follows tokens | `message-scroller`, `message` | custom scroll math |
+| Just a chat bubble | `message-bubble` | custom bubble |
+| Prompt box or composer | `prompt-input` | textarea plus custom buttons |
+| Agent reasoning, search, tool trace | `agent-activity` | plain log list |
+| Task plan | `todo-list` | custom checklist |
+| Code surface | `code-block` | pre/code from scratch |
+| File diff | `file-diff` | custom diff renderer |
+| Tool output | `tool-result` | raw terminal block |
+| Tool permission card | `tool-approval` | alert dialog |
+| Approval or HITL question | `approval-card` | custom form |
+| Inline citations | `citations` | plain numbered links |
+| Generated image canvas | `image-generation` | image card from scratch |
+| Liquid popover | `popover` | `popover-morph` |
+| Corner morph popover | `popover-morph` | `popover` |
+| Dropdown select | `select` | `select-morph`, `combobox` |
+| Select that grows into panel | `select-morph` | `select` |
+| Searchable select | `combobox` | `select` |
+| Cmd+K palette | `command-palette` | `combobox` |
+| Right-click or long-press menu | `context-menu` | `bloom-menu` |
+| Button that blooms into a menu | `bloom-menu` | `context-menu` |
+| Press button | `button-base` | custom `motion.button` |
+| Loading/success/error button | `button-stateful` | spinner button |
+| Magnetic button | `button-magnetic` | custom pointer tracking |
+| Hold to confirm | `hold-action-button` | `button-base` |
+| Slide to confirm | `slide-action-button` | `swipeable-list` |
+| Hover CTA with expanding arrow | `expanding-arrow-button` | `button-base` |
+| Spinner, dots, bars loader | `loader` | `thinking-shimmer` |
+| Agent thinking status | `thinking-shimmer` | `loader`, `text-shimmer` |
+| Cycling reasoning phrases | `reasoning-text` | `text-cascade` |
+| Timed agent progress glyph | `agent-progress` | `loader` |
+| Shimmer headline text | `text-shimmer` | `thinking-shimmer` |
+| Word or letter reveal | `text-reveal` | `text-cascade` |
+| Chromatic cycling word | `chromatic-text-reveal` | `text-shimmer` |
+| Slot-machine letters | `text-cascade` | `text-scramble` |
+| Scramble resolving text | `text-scramble` | `text-cascade` |
+| Rolling digits | `number-ticker` | `animated-number` |
+| Count-up on view | `animated-number` | `number-ticker` |
+| Tick-dot slider | `range-slider` | other `range-slider-*` |
+| Liquid fill slider | `range-slider-fluid` | `range-slider` |
+| Equalizer slider | `range-slider-wave` | `range-slider` |
+| Tilting value bubble slider | `range-slider-bubble` | `range-slider` |
+| Ruler slider | `range-slider-ruler` | `range-slider` |
+| iOS wheel picker | `wheel-picker` | `select` |
+| macOS dock | `dock` | `expandable-action-bar` |
+| Icon actions with labels | `expandable-action-bar` | `dock` |
+| Overflow action rail | `overflow-actions` | `expandable-action-bar` |
+| Icon tabs with active label | `expandable-tabs` | `tabs` |
+| Morphing tab content room | `morphing-tabs` | `tabs` |
+| Pill or underline tabs | `tabs` | `expandable-tabs` |
+| Hover gliding background | `shared-layout-bg` | `tabs` |
+| Preview ticks or rail | `preview-rail` | `bounce-sidebar` |
+| Dynamic Island | `dynamic-island` | `notification-stack` |
+| Swipe row actions | `swipeable-list` | `slide-action-button` |
+| Pull to refresh | `pull-to-refresh` | custom touch math |
+| Basic upload queue | `file-upload` | `attachment-upload` |
+| Mixed file, audio, image attachments | `attachment-upload` | `file-upload` |
+| OTP or PIN boxes | `otp-input` | `input` |
+| Sign-up form | `signup-form` | manual form assembly |
+| Theme wipe | `theme-toggle` | class toggle only |
+| Shader background | `shader-background` | custom canvas |
+| Cylinder carousel | `cylinder-carousel` | `marquee` |
+| Logo or text marquee | `marquee` | `cylinder-carousel` |
+| Data table | `table` | HTML table from scratch |
+| Editable table | `table-editable` | `table` |
+| Async table | `table-async` | `table` |
+| Tournament bracket | `knockout-bracket` | `knockout-wheel` |
+| Radial tournament wheel | `knockout-wheel` | `knockout-bracket` |
+| 404 page | `not-found-glitch` | custom 404 |
+| Project folder card | `project-folder` | folder card from scratch |
+| Token or chain swap | `swap` | custom swap form |
+| Weekly availability editor | `availability-scheduler` | custom calendar grid |
+| Wallet overview card | `wallet-card` | custom wallet card |
+| Prediction market ticket | `prediction-market` | custom trade ticket |
+| Feedback popup | `feedback-widget` | `animated-toast-stack` |
+| Infinite masonry grid | `infinite-masonry` | CSS columns |
+| Accordion | `bouncy-accordion` | custom accordion |
+| 3D tilt card | `tilt-card` | custom glare math |
+| Tooltip | `tooltip` | `popover` |
+| Switch, checkbox, radio, input | `switch`, `checkbox`, `radio`, `input` | restyled native controls |
+
+## Composition rules
+
+- Prefer installed beUI source over custom one-off motion widgets.
+- Import named exports from the files shadcn adds.
+- Use `className` for layout and small styling changes. Do not fork internals unless the user asks.
+- Keep helpers installed by the registry, such as `@/lib/ease`, `@/lib/utils`, and hooks.
+- If adding new motion around beUI components, use `useReducedMotion()` from `motion/react`.
+- Gate decorative hover effects like magnetic pull and tilt behind `useHoverCapable()`.
+- Animate `transform` and `opacity`; avoid layout-property animation.
+
+## In this repo
+
+When contributing to beUI itself, follow `AGENTS.md`. A new public component needs source, preview, registry entry, and a passing `bun run check:registry`. Never rename existing `/r/{name}.json` slugs.

--- a/skills/beui/evals.json
+++ b/skills/beui/evals.json
@@ -1,0 +1,59 @@
+{
+  "skill_name": "beui",
+  "evals": [
+    {
+      "id": "toast",
+      "prompt": "Show a toast when the form saves.",
+      "expected_slugs": ["animated-toast-stack"],
+      "not_slugs": ["notification-stack"]
+    },
+    {
+      "id": "bottom-sheet",
+      "prompt": "Add a mobile bottom sheet like Vaul.",
+      "expected_slugs": ["bottom-sheet"],
+      "not_slugs": ["drawer", "center-morph-modal"]
+    },
+    {
+      "id": "thinking",
+      "prompt": "Add a thinking indicator while the agent works.",
+      "expected_slugs": ["thinking-shimmer"],
+      "not_slugs": ["loader", "text-shimmer"]
+    },
+    {
+      "id": "gooey-popover",
+      "prompt": "I want a liquid gooey popover that oozes out of the button.",
+      "expected_slugs": ["popover"],
+      "not_slugs": ["popover-morph"]
+    },
+    {
+      "id": "wave-slider",
+      "prompt": "Build an equalizer-style wave slider.",
+      "expected_slugs": ["range-slider-wave"],
+      "not_slugs": ["range-slider"]
+    },
+    {
+      "id": "chat",
+      "prompt": "Build a streaming AI chat with a prompt box and a thread that follows new tokens.",
+      "expected_slugs": ["message-scroller", "message", "prompt-input"],
+      "not_slugs": ["loader"]
+    },
+    {
+      "id": "attachments",
+      "prompt": "Chat composer attachments for images, audio, and files.",
+      "expected_slugs": ["attachment-upload"],
+      "not_slugs": ["file-upload"]
+    },
+    {
+      "id": "project-folder",
+      "prompt": "Add an animated project folder card that opens into details.",
+      "expected_slugs": ["project-folder"],
+      "not_slugs": ["file-upload"]
+    },
+    {
+      "id": "command-palette",
+      "prompt": "Add a Cmd+K command palette.",
+      "expected_slugs": ["command-palette"],
+      "not_slugs": ["combobox"]
+    }
+  ]
+}

--- a/tests/beui-skill.test.ts
+++ b/tests/beui-skill.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { allShadcnTargets, buildShadcnRegistry } from "@/lib/registry-server";
+
+const ROOT = path.join(import.meta.dir, "..");
+const SKILL_PATH = path.join(ROOT, "skills/beui/SKILL.md");
+const EVALS_PATH = path.join(ROOT, "skills/beui/evals.json");
+const CATALOG_PATH = path.join(ROOT, "skills/beui/catalog.md");
+const LIVE_REGISTRY = "https://beui.dev/r/registry.json";
+
+type SkillEvals = {
+  skill_name: string;
+  evals: Array<{
+    id: string;
+    prompt: string;
+    expected_slugs: string[];
+    not_slugs: string[];
+  }>;
+};
+
+function installSlugs() {
+  return new Set(allShadcnTargets().map((target) => target.slug));
+}
+
+function slugsFromSkill(markdown: string) {
+  const found = new Set<string>();
+
+  for (const match of markdown.matchAll(/@beui\/([a-z][a-z0-9-]*)/g)) {
+    found.add(match[1]);
+  }
+
+  for (const match of markdown.matchAll(
+    /https:\/\/beui\.dev\/r\/([a-z][a-z0-9-]*)(?:\.json)?/g,
+  )) {
+    if (match[1] === "registry") continue;
+    found.add(match[1]);
+  }
+
+  for (const line of markdown.split("\n")) {
+    if (!line.includes("|")) continue;
+    for (const match of line.matchAll(/`([a-z][a-z0-9-]*)`/g)) {
+      found.add(match[1]);
+    }
+  }
+
+  return [...found];
+}
+
+describe("beUI skill", () => {
+  test("README documents a non-interactive skill install", async () => {
+    const readme = await readFile(path.join(ROOT, "README.md"), "utf8");
+    expect(readme).toContain("npx skills add starc007/ui-components --skill beui");
+    expect(readme).not.toContain("npx skills add https://beui.dev");
+  });
+
+  test("keeps the live registry as the source of truth", async () => {
+    const skill = await readFile(SKILL_PATH, "utf8");
+
+    expect(existsSync(CATALOG_PATH)).toBe(false);
+    expect(skill).toContain("curl -fsS https://beui.dev/r/registry.json");
+    expect(skill).toContain("items[].name");
+    expect(skill).toContain("The live registry is the source of truth");
+    expect(skill).not.toContain("!`curl");
+    expect(skill).not.toContain("when this skill loads");
+    expect(skill).not.toContain("catalog.md");
+  });
+
+  test("every picker slug is a real @beui install name", async () => {
+    const skill = await readFile(SKILL_PATH, "utf8");
+    const known = installSlugs();
+    const missing = slugsFromSkill(skill).filter((slug) => !known.has(slug));
+
+    expect(missing).toEqual([]);
+  });
+
+  test("local registry.json is a scrapeable catalog of install slugs", async () => {
+    const registry = await buildShadcnRegistry();
+    const names = registry.items.map((item) => item.name);
+
+    expect(registry.name).toBe("beui");
+    expect(names.length).toBeGreaterThan(40);
+    expect(new Set(names).size).toBe(names.length);
+
+    for (const item of registry.items) {
+      expect(item.name).toMatch(/^[a-z][a-z0-9-]*$/);
+      expect(item.title.length).toBeGreaterThan(0);
+      expect(item.description.length).toBeGreaterThan(0);
+      expect(item.files.length).toBeGreaterThan(0);
+    }
+
+    const skill = await readFile(SKILL_PATH, "utf8");
+    const missing = slugsFromSkill(skill).filter((slug) => !names.includes(slug));
+    expect(missing).toEqual([]);
+  });
+
+  test("picker evals point at real slugs", async () => {
+    const known = installSlugs();
+    const evals = JSON.parse(await readFile(EVALS_PATH, "utf8")) as SkillEvals;
+
+    expect(evals.skill_name).toBe("beui");
+    expect(evals.evals.length).toBeGreaterThan(5);
+
+    for (const item of evals.evals) {
+      expect(item.prompt.length).toBeGreaterThan(0);
+      expect(item.expected_slugs.length).toBeGreaterThan(0);
+
+      for (const slug of [...item.expected_slugs, ...item.not_slugs]) {
+        expect(known.has(slug)).toBe(true);
+      }
+
+      const overlap = item.expected_slugs.filter((slug) =>
+        item.not_slugs.includes(slug),
+      );
+      expect(overlap).toEqual([]);
+    }
+  });
+
+  test("production registry.json can be fetched with the skill command", async () => {
+    const proc = Bun.spawn(["curl", "-fsS", LIVE_REGISTRY], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const code = await proc.exited;
+
+    expect(code, stderr || `curl exited ${code}`).toBe(0);
+
+    const catalog = JSON.parse(stdout) as {
+      name?: string;
+      items?: Array<{ name?: string; title?: string; description?: string }>;
+    };
+
+    expect(catalog.name).toBe("beui");
+    expect(Array.isArray(catalog.items)).toBe(true);
+    expect(catalog.items?.length).toBeGreaterThan(40);
+
+    for (const item of catalog.items ?? []) {
+      expect(item.name).toMatch(/^[a-z][a-z0-9-]*$/);
+      expect(item.title).toBeTruthy();
+      expect(item.description).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a focused beUI agent skill that fetches the live registry before choosing install slugs
- document the non-interactive skills CLI install path
- add tests covering skill guidance, slug validity, evals, and live registry fetchability
- add the missing explicit install slug for the expanding arrow CTA variant

## Validation

- bun test ./tests/beui-skill.test.ts
- bun run typecheck
- bun run lint
- bun run check:registry
- npx skills add . -l