### PR TITLE
feat: add authenticated beui pro mcp

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # beUI MCP server
 
-Remote [MCP](https://modelcontextprotocol.io) server for the beUI component registry, running on a Cloudflare Worker. Lets AI agents discover and install beUI components.
+Remote [MCP](https://modelcontextprotocol.io) server for the beUI component registries, running on a Cloudflare Worker. It lets AI agents discover, inspect, and install both free beUI components and licensed beUI Pro blocks.
 
 It owns no data — it reads the live `beui.dev/r/*` registry endpoints at runtime (edge-cached), so new components appear without redeploying the worker.
 
@@ -14,6 +14,28 @@ https://mcp.beui.dev/mcp
 
 Streamable HTTP is recommended. An SSE endpoint (`/sse`) exists for legacy clients.
 
+## Connect to beUI Pro
+
+Paid users can connect to the authenticated Pro endpoint with the same license
+key they use as `BEUI_PRO_TOKEN`:
+
+```json
+{
+  "mcpServers": {
+    "beui-pro": {
+      "url": "https://mcp.beui.dev/pro/mcp",
+      "headers": {
+        "Authorization": "Bearer ${BEUI_PRO_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+The Pro endpoint forwards the bearer header to the private registry for each
+tool call. It does not accept tokens as tool arguments, include them in tool
+results, or cache authenticated source responses.
+
 ## Tools
 
 | tool | input | returns |
@@ -22,6 +44,12 @@ Streamable HTTP is recommended. An SSE endpoint (`/sse`) exists for legacy clien
 | `search_components` | `query` | best-matching components |
 | `get_component` | `slug` | description, dependencies, all source files, install command |
 | `get_install_command` | `slug`, `packageManager?` | shadcn CLI command per package manager |
+
+The Pro endpoint exposes the same four tool names against the installable
+`@beui-pro` catalog. `get_component` returns the licensed source files, while
+`get_install_command` also returns the registry configuration required by the
+shadcn CLI. Standalone templates that are not in the private shadcn index are
+not exposed as installable components.
 
 ## Develop
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { McpAgent } from "agents/mcp";
+import { createMcpHandler, McpAgent } from "agents/mcp";
 import { z } from "zod";
 import {
   getEntry,
@@ -9,10 +9,12 @@ import {
   type IndexComponent,
   type PackageManager,
 } from "./registry.js";
+import { createProServer } from "./pro-server.js";
 
 interface Env {
   BeUiMcp: DurableObjectNamespace;
   REGISTRY_URL?: string;
+  PRO_REGISTRY_URL?: string;
 }
 
 const json = (value: unknown) => ({
@@ -166,19 +168,56 @@ export class BeUiMcp extends McpAgent<Env, Record<string, never>, Record<string,
 
 const LANDING = `beUI MCP server
 
-Animated components for React and Next.js, available through a remote MCP server.
+Animated components and premium blocks for React and Next.js.
 
 Connect your MCP client to:
   https://mcp.beui.dev/mcp   (Streamable HTTP, recommended)
   https://mcp.beui.dev/sse   (SSE, legacy)
+  https://mcp.beui.dev/pro/mcp   (beUI Pro, bearer token required)
 
 Tools: list_components, search_components, get_component, get_install_command
 Docs:  https://beui.dev
 `;
 
+function getBearerAuthorization(request: Request) {
+  const authorization = request.headers.get("authorization")?.trim();
+  if (!authorization || !/^Bearer\s+\S+$/i.test(authorization)) return null;
+  return authorization;
+}
+
+function unauthorized() {
+  return new Response(
+    JSON.stringify({
+      error: "A beUI Pro bearer token is required.",
+    }),
+    {
+      status: 401,
+      headers: {
+        "cache-control": "private, no-store",
+        "content-type": "application/json; charset=utf-8",
+        "www-authenticate": 'Bearer realm="beUI Pro MCP"',
+      },
+    },
+  );
+}
+
 export default {
-  fetch(request: Request, env: Env, ctx: ExecutionContext) {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
     const url = new URL(request.url);
+
+    if (url.pathname === "/pro/mcp") {
+      const authorization = getBearerAuthorization(request);
+      if (!authorization) return unauthorized();
+
+      const server = createProServer(env, authorization);
+      const response = await createMcpHandler(server, { route: "/pro/mcp" })(
+        request,
+        env,
+        ctx,
+      );
+      response.headers.set("cache-control", "private, no-store");
+      return response;
+    }
 
     if (url.pathname.startsWith("/mcp")) {
       return BeUiMcp.serve("/mcp", { binding: "BeUiMcp" }).fetch(request, env, ctx);

--- a/mcp/src/pro-registry.ts
+++ b/mcp/src/pro-registry.ts
@@ -1,0 +1,107 @@
+export type ProRegistryFile = {
+  path: string;
+  type: string;
+  target: string;
+  content?: string;
+};
+
+export type ProRegistryItem = {
+  name: string;
+  type: "registry:block";
+  title: string;
+  description: string;
+  author: string;
+  dependencies: string[];
+  registryDependencies: string[];
+  files: ProRegistryFile[];
+};
+
+export type ProRegistryIndex = {
+  name: string;
+  homepage: string;
+  items: Array<Omit<ProRegistryItem, "$schema">>;
+};
+
+export class ProRegistryError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "ProRegistryError";
+  }
+}
+
+function base(env: { PRO_REGISTRY_URL?: string }) {
+  return (env.PRO_REGISTRY_URL ?? "https://pro.beui.dev").replace(/\/$/, "");
+}
+
+async function fetchJson<T>(url: string, authorization: string): Promise<T> {
+  // Private source must never enter caches.default or a shared Worker cache.
+  const response = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      authorization,
+    },
+    cf: { cacheTtl: 0 },
+  });
+
+  if (!response.ok) {
+    const message =
+      response.status === 401
+        ? "The beUI Pro token is invalid or expired."
+        : response.status === 404
+          ? "The requested beUI Pro component was not found."
+          : `The beUI Pro registry responded with status ${response.status}.`;
+    throw new ProRegistryError(message, response.status);
+  }
+
+  return (await response.json()) as T;
+}
+
+export function getProIndex(
+  env: { PRO_REGISTRY_URL?: string },
+  authorization: string,
+) {
+  return fetchJson<ProRegistryIndex>(
+    `${base(env)}/r/registry.json`,
+    authorization,
+  );
+}
+
+export function getProEntry(
+  env: { PRO_REGISTRY_URL?: string },
+  authorization: string,
+  slug: string,
+) {
+  return fetchJson<ProRegistryItem>(
+    `${base(env)}/r/${encodeURIComponent(slug)}.json`,
+    authorization,
+  );
+}
+
+const PM_PREFIX = {
+  bun: "bunx --bun",
+  npm: "npx",
+  pnpm: "pnpm dlx",
+  yarn: "yarn dlx",
+} as const;
+
+export type ProPackageManager = keyof typeof PM_PREFIX;
+export const PRO_PACKAGE_MANAGERS = Object.keys(
+  PM_PREFIX,
+) as ProPackageManager[];
+
+export function proInstallCommand(slug: string, pm: ProPackageManager) {
+  return `${PM_PREFIX[pm]} shadcn@latest add @beui-pro/${slug}`;
+}
+
+export const PRO_REGISTRY_SETUP = {
+  "@beui": "https://beui.dev/r/{name}.json",
+  "@beui-pro": {
+    url: "https://pro.beui.dev/r/{name}.json",
+    headers: {
+      Authorization: "Bearer ${BEUI_PRO_TOKEN}",
+    },
+  },
+} as const;

--- a/mcp/src/pro-server.ts
+++ b/mcp/src/pro-server.ts
@@ -1,0 +1,177 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  getProEntry,
+  getProIndex,
+  PRO_PACKAGE_MANAGERS,
+  PRO_REGISTRY_SETUP,
+  proInstallCommand,
+  type ProPackageManager,
+  type ProRegistryItem,
+} from "./pro-registry.js";
+
+type ProEnv = {
+  PRO_REGISTRY_URL?: string;
+};
+
+const json = (value: unknown) => ({
+  content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+});
+
+const error = (message: string) => ({
+  isError: true,
+  content: [{ type: "text" as const, text: message }],
+});
+
+function score(item: Omit<ProRegistryItem, "$schema">, query: string) {
+  const normalized = query.toLowerCase();
+  const name = item.name.toLowerCase();
+  const title = item.title.toLowerCase();
+  if (name === normalized || title === normalized) return 100;
+  if (name.includes(normalized) || title.includes(normalized)) return 60;
+  if (item.description.toLowerCase().includes(normalized)) return 30;
+  return 0;
+}
+
+function summary(item: Omit<ProRegistryItem, "$schema">) {
+  return {
+    slug: item.name,
+    name: item.title,
+    description: item.description,
+  };
+}
+
+export function createProServer(env: ProEnv, authorization: string) {
+  const server = new McpServer({
+    name: "beUI Pro",
+    version: "0.1.0",
+  });
+
+  server.registerTool(
+    "list_components",
+    {
+      description:
+        "List every installable beUI Pro premium animated block and component available to this license.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const index = await getProIndex(env, authorization);
+        return json(index.items.map(summary));
+      } catch (cause) {
+        return error(
+          `Failed to list beUI Pro components: ${(cause as Error).message}`,
+        );
+      }
+    },
+  );
+
+  server.registerTool(
+    "search_components",
+    {
+      description:
+        "Search installable beUI Pro blocks and components by name, slug, or description. Returns the closest matches first.",
+      inputSchema: {
+        query: z
+          .string()
+          .min(1)
+          .describe("Search term, such as 'hero', 'social proof', or 'pricing'."),
+      },
+    },
+    async ({ query }) => {
+      try {
+        const index = await getProIndex(env, authorization);
+        const matches = index.items
+          .map((item) => ({ item, relevance: score(item, query) }))
+          .filter(({ relevance }) => relevance > 0)
+          .sort((a, b) => b.relevance - a.relevance)
+          .map(({ item }) => summary(item));
+        return json(matches);
+      } catch (cause) {
+        return error(
+          `Failed to search beUI Pro components: ${(cause as Error).message}`,
+        );
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_component",
+    {
+      description:
+        "Get a licensed beUI Pro item with its dependencies and complete source files. Use the returned source to install or adapt the block in the current project.",
+      inputSchema: {
+        slug: z
+          .string()
+          .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+          .describe("An exact slug returned by list_components or search_components."),
+      },
+    },
+    async ({ slug }) => {
+      try {
+        const item = await getProEntry(env, authorization, slug);
+        return json({
+          slug: item.name,
+          name: item.title,
+          description: item.description,
+          dependencies: item.dependencies,
+          registryDependencies: item.registryDependencies,
+          install: proInstallCommand(item.name, "bun"),
+          requiredRegistries: PRO_REGISTRY_SETUP,
+          files: item.files.map((file) => ({
+            path: file.path,
+            target: file.target,
+            type: file.type,
+            content: file.content,
+          })),
+        });
+      } catch (cause) {
+        return error(
+          `Could not load beUI Pro component "${slug}": ${(cause as Error).message}`,
+        );
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_install_command",
+    {
+      description:
+        "Get the authenticated shadcn CLI install command and required components.json registry configuration for an installable beUI Pro item.",
+      inputSchema: {
+        slug: z
+          .string()
+          .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+          .describe("An exact slug returned by list_components or search_components."),
+        packageManager: z
+          .enum(["bun", "npm", "pnpm", "yarn"])
+          .default("bun")
+          .describe("Package manager. Defaults to bun."),
+      },
+    },
+    async ({ slug, packageManager }) => {
+      try {
+        // Verify the slug and entitlement before returning an install command.
+        const item = await getProEntry(env, authorization, slug);
+        const pm = packageManager as ProPackageManager;
+        return json({
+          slug: item.name,
+          packageManager: pm,
+          command: proInstallCommand(item.name, pm),
+          all: PRO_PACKAGE_MANAGERS.map((manager) => ({
+            packageManager: manager,
+            command: proInstallCommand(item.name, manager),
+          })),
+          requiredEnvironmentVariable: "BEUI_PRO_TOKEN",
+          requiredRegistries: PRO_REGISTRY_SETUP,
+        });
+      } catch (cause) {
+        return error(
+          `Could not create an install command for "${slug}": ${(cause as Error).message}`,
+        );
+      }
+    },
+  );
+
+  return server;
+}

--- a/mcp/wrangler.jsonc
+++ b/mcp/wrangler.jsonc
@@ -6,7 +6,8 @@
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": false },
   "vars": {
-    "REGISTRY_URL": "https://beui.dev"
+    "REGISTRY_URL": "https://beui.dev",
+    "PRO_REGISTRY_URL": "https://pro.beui.dev"
   },
   "durable_objects": {
     "bindings": [{ "name": "BeUiMcp", "class_name": "BeUiMcp" }]


### PR DESCRIPTION
## What changed

- added an authenticated beUI Pro MCP endpoint at `/pro/mcp`
- exposed discovery, search, source retrieval, and install-command tools for the private `@beui-pro` registry
- forwarded each request's bearer token directly to the private registry without accepting it as a tool argument
- disabled caching for authenticated registry requests and MCP responses
- documented the Pro MCP connection and kept the existing free `/mcp` and `/sse` routes unchanged

## Why

Paid users should be able to give coding agents licensed access to beUI Pro blocks without manually downloading and passing component source around.

## Validation

- `bun run check`
- `bun --cwd mcp run typecheck`
- Wrangler deployment dry run
- mocked private-registry authorization forwarding and install-command check

The live entitlement flow was not exercised because no customer `BEUI_PRO_TOKEN` was available in the local shell.
