### PR TITLE
feat: add morphing search block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `swap` | `components/motion/swap.tsx` + `swap/` | Cross-chain swap widget with chain/token selectors and morphing views |
 | `dynamic-island` | `components/motion/dynamic-island.tsx` | iOS-style island pill that morphs between live activity views |
 | `command-palette` | `components/motion/command-palette.tsx` | ⌘K palette with fuzzy filter and spring-animated active row |
+| `morphing-search` | `components/motion/morphing-search.tsx` | Search field that morphs into a focus-managed results surface on click or plain-key shortcut, then returns to the same shell on close |
 | `expandable-action-bar` | `components/motion/expandable-action-bar.tsx` | Icon actions that expand into labeled controls on hover/focus |
 | `overflow-actions` | `components/motion/overflow-actions.tsx` | Connected pill rail that springs open to reveal extra controls |
 | `expandable-tabs` | `components/motion/expandable-tabs.tsx` | Icon tab bar where active tab expands to labeled pill with height-morphing panel |

--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -347,9 +347,8 @@ export default async function ComponentPage({
               .
             </p>
           </section>
-        ) : cat.slug !== "agents" ? (
-          <KeepInMind />
         ) : null}
+        {cat.slug === "blocks" ? <KeepInMind /> : null}
         <p className="mt-6 text-xs text-muted-foreground">
           Updated{" "}
           <time dateTime={dates.updatedAt}>

--- a/components/motion/loader.tsx
+++ b/components/motion/loader.tsx
@@ -235,25 +235,34 @@ const MORPH_SCALE = [1, 1, 0.88, 0.88, 1, 1, 0.88, 0.88, 1, 1, 1];
 
 function Morph({ size, speed, reduce }: PartProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 100 100" role="img">
+    <motion.svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      role="img"
+      animate={
+        reduce
+          ? { opacity: [1, 0.4, 1] }
+          : { rotate: MORPH_ROT, scale: MORPH_SCALE }
+      }
+      transition={
+        reduce
+          ? { duration: 1.4, ease: EASE_IN_OUT, repeat: Infinity }
+          : { duration: speed * 5, ease: EASE_IN_OUT, repeat: Infinity }
+      }
+    >
       <title>Loading</title>
       <motion.path
         fill="currentColor"
         d={MORPH_PATHS[0]}
-        initial={false}
-        style={{ transformBox: "fill-box", transformOrigin: "center" }}
-        animate={
-          reduce
-            ? { opacity: [1, 0.4, 1] }
-            : { d: MORPH_SEQ, rotate: MORPH_ROT, scale: MORPH_SCALE }
-        }
+        animate={reduce ? undefined : { d: MORPH_SEQ }}
         transition={
           reduce
-            ? { duration: 1.4, ease: EASE_IN_OUT, repeat: Infinity }
+            ? undefined
             : { duration: speed * 5, ease: EASE_IN_OUT, repeat: Infinity }
         }
       />
-    </svg>
+    </motion.svg>
   );
 }
 
@@ -356,7 +365,6 @@ function Metaballs({ size, speed, reduce }: PartProps) {
         <motion.circle
           cy="50"
           r="15"
-          initial={false}
           animate={reduce ? { opacity: [0.4, 1, 0.4] } : { cx: [30, 70, 30] }}
           transition={{ duration: speed * 1.6, ease: EASE_IN_OUT, repeat: Infinity }}
           cx={reduce ? 40 : 30}
@@ -364,7 +372,6 @@ function Metaballs({ size, speed, reduce }: PartProps) {
         <motion.circle
           cy="50"
           r="15"
-          initial={false}
           animate={reduce ? { opacity: [0.4, 1, 0.4] } : { cx: [70, 30, 70] }}
           transition={{ duration: speed * 1.6, ease: EASE_IN_OUT, repeat: Infinity }}
           cx={reduce ? 60 : 70}

--- a/components/motion/morphing-search.tsx
+++ b/components/motion/morphing-search.tsx
@@ -2,6 +2,7 @@
 
 import { type LucideIcon, Search } from "lucide-react";
 import {
+	AnimatePresence,
 	LayoutGroup,
 	motion,
 	type Transition,
@@ -17,8 +18,22 @@ import {
 	useState,
 } from "react";
 import { createPortal } from "react-dom";
-import { EASE_OUT, SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
+import { EASE_OUT, SPRING_LAYOUT } from "@/lib/ease";
 import { cn } from "@/lib/utils";
+
+// Keeps the Wallet Card feel with a little more time to read the morph.
+const SEARCH_MORPH: Transition = {
+	type: "spring",
+	duration: 0.58,
+	bounce: 0.22,
+};
+
+// Keep the spring on the shell, but unfold complex clip-path values with the
+// same progressive tween as Morph Popover so the content never snaps ahead.
+const SEARCH_CLIP_TRANSITION: Transition = {
+	duration: 0.32,
+	ease: EASE_OUT,
+};
 
 export type MorphingSearchItem = {
 	id: string;
@@ -33,6 +48,8 @@ export interface MorphingSearchProps {
 	items: MorphingSearchItem[];
 	placeholder?: string;
 	shortcut?: string;
+	/** Render the closed trigger as a compact search icon. */
+	iconOnly?: boolean;
 	emptyMessage?: string;
 	open?: boolean;
 	defaultOpen?: boolean;
@@ -48,10 +65,6 @@ type AnchorRect = {
 	width: number;
 };
 
-// Conceal only the unstable first frames of the shared-layout projection.
-const CARET_REVEAL_DELAY_MS = 100;
-const INPUT_TEXT_REVEAL_DELAY_MS = 250;
-
 function isEditableTarget(target: EventTarget | null) {
 	if (!(target instanceof HTMLElement)) return false;
 	return (
@@ -66,6 +79,7 @@ export function MorphingSearch({
 	items,
 	placeholder = "Search",
 	shortcut = "f",
+	iconOnly = false,
 	emptyMessage = "No results found.",
 	open: controlledOpen,
 	defaultOpen = false,
@@ -77,9 +91,9 @@ export function MorphingSearch({
 	const [internalOpen, setInternalOpen] = useState(defaultOpen);
 	const [query, setQuery] = useState("");
 	const [activeIndex, setActiveIndex] = useState(0);
-	const [caretVisible, setCaretVisible] = useState(true);
-	const [inputTextVisible, setInputTextVisible] = useState(true);
 	const [mounted, setMounted] = useState(false);
+	const [backgroundScrollLocked, setBackgroundScrollLocked] =
+		useState(defaultOpen);
 	const [anchorRect, setAnchorRect] = useState<AnchorRect>({
 		top: 16,
 		left: 16,
@@ -97,6 +111,7 @@ export function MorphingSearch({
 	const previousFocusRef = useRef<HTMLElement | null>(null);
 	const wasOpenRef = useRef(open);
 	const transition: Transition = reduce ? { duration: 0 } : SPRING_LAYOUT;
+	const morphTransition: Transition = reduce ? { duration: 0 } : SEARCH_MORPH;
 
 	const setOpen = useCallback(
 		(next: boolean) => {
@@ -114,14 +129,13 @@ export function MorphingSearch({
 
 	const openSearch = useCallback(() => {
 		measureAnchor();
-		setCaretVisible(Boolean(reduce));
-		setInputTextVisible(Boolean(reduce));
+		setBackgroundScrollLocked(true);
 		previousFocusRef.current =
 			document.activeElement instanceof HTMLElement
 				? document.activeElement
 				: null;
 		setOpen(true);
-	}, [measureAnchor, reduce, setOpen]);
+	}, [measureAnchor, setOpen]);
 
 	const updateQuery = useCallback(
 		(next: string) => {
@@ -132,7 +146,16 @@ export function MorphingSearch({
 		[onQueryChange],
 	);
 
+	const closeSearch = useCallback(() => {
+		updateQuery("");
+		setOpen(false);
+	}, [setOpen, updateQuery]);
+
 	useEffect(() => setMounted(true), []);
+
+	useEffect(() => {
+		if (open) setBackgroundScrollLocked(true);
+	}, [open]);
 
 	useEffect(() => {
 		measureAnchor();
@@ -143,19 +166,49 @@ export function MorphingSearch({
 				: null;
 		if (anchor) observer?.observe(anchor);
 		window.addEventListener("resize", measureAnchor);
-		window.addEventListener("scroll", measureAnchor, { passive: true });
+		document.addEventListener("scroll", measureAnchor, true);
+		window.visualViewport?.addEventListener("resize", measureAnchor);
+		window.visualViewport?.addEventListener("scroll", measureAnchor);
 		return () => {
 			observer?.disconnect();
 			window.removeEventListener("resize", measureAnchor);
-			window.removeEventListener("scroll", measureAnchor);
+			document.removeEventListener("scroll", measureAnchor, true);
+			window.visualViewport?.removeEventListener("resize", measureAnchor);
+			window.visualViewport?.removeEventListener("scroll", measureAnchor);
 		};
 	}, [measureAnchor]);
+
+	useEffect(() => {
+		if (!backgroundScrollLocked) return;
+
+		const preventBackgroundWheel = (event: WheelEvent) => {
+			const target = event.target;
+			if (target instanceof Node && listRef.current?.contains(target)) return;
+			event.preventDefault();
+		};
+		const preventBackgroundTouch = (event: TouchEvent) => {
+			const target = event.target;
+			if (target instanceof Node && listRef.current?.contains(target)) return;
+			event.preventDefault();
+		};
+
+		document.addEventListener("wheel", preventBackgroundWheel, {
+			passive: false,
+		});
+		document.addEventListener("touchmove", preventBackgroundTouch, {
+			passive: false,
+		});
+		return () => {
+			document.removeEventListener("wheel", preventBackgroundWheel);
+			document.removeEventListener("touchmove", preventBackgroundTouch);
+		};
+	}, [backgroundScrollLocked]);
 
 	useEffect(() => {
 		const handleShortcut = (event: KeyboardEvent) => {
 			if (event.key === "Escape" && open) {
 				event.preventDefault();
-				setOpen(false);
+				closeSearch();
 				return;
 			}
 
@@ -177,36 +230,13 @@ export function MorphingSearch({
 
 		window.addEventListener("keydown", handleShortcut);
 		return () => window.removeEventListener("keydown", handleShortcut);
-	}, [open, openSearch, setOpen, shortcut]);
+	}, [closeSearch, open, openSearch, shortcut]);
 
 	useEffect(() => {
 		if (open) {
-			const opening = !wasOpenRef.current;
-			if (opening) {
-				setCaretVisible(Boolean(reduce));
-				setInputTextVisible(Boolean(reduce));
-			}
 			updateQuery("");
 			const frame = requestAnimationFrame(() => inputRef.current?.focus());
-			const caretTimer =
-				opening && !reduce
-					? window.setTimeout(
-							() => setCaretVisible(true),
-							CARET_REVEAL_DELAY_MS,
-						)
-					: undefined;
-			const inputTextTimer =
-				opening && !reduce
-					? window.setTimeout(
-							() => setInputTextVisible(true),
-							INPUT_TEXT_REVEAL_DELAY_MS,
-						)
-					: undefined;
-			return () => {
-				cancelAnimationFrame(frame);
-				if (caretTimer !== undefined) window.clearTimeout(caretTimer);
-				if (inputTextTimer !== undefined) window.clearTimeout(inputTextTimer);
-			};
+			return () => cancelAnimationFrame(frame);
 		}
 
 		if (wasOpenRef.current) {
@@ -219,24 +249,10 @@ export function MorphingSearch({
 			});
 			return () => cancelAnimationFrame(frame);
 		}
-	}, [open, reduce, updateQuery]);
+	}, [open, updateQuery]);
 
 	useEffect(() => {
 		wasOpenRef.current = open;
-	}, [open]);
-
-	useEffect(() => {
-		if (!open) return;
-		const root = document.documentElement;
-		const body = document.body;
-		const rootOverflow = root.style.overflow;
-		const bodyOverflow = body.style.overflow;
-		root.style.overflow = "hidden";
-		body.style.overflow = "hidden";
-		return () => {
-			root.style.overflow = rootOverflow;
-			body.style.overflow = bodyOverflow;
-		};
 	}, [open]);
 
 	const filteredItems = useMemo(() => {
@@ -267,9 +283,9 @@ export function MorphingSearch({
 		(item: MorphingSearchItem) => {
 			item.onSelect?.();
 			onSelect?.(item);
-			setOpen(false);
+			closeSearch();
 		},
-		[onSelect, setOpen],
+		[closeSearch, onSelect],
 	);
 
 	const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -315,9 +331,6 @@ export function MorphingSearch({
 	};
 
 	const shellLayoutId = `${uid}-shell`;
-	const iconLayoutId = `${uid}-icon`;
-	const labelLayoutId = `${uid}-label`;
-	const shortcutLayoutId = `${uid}-shortcut`;
 	const listboxId = `${uid}-results`;
 	const panelWidth = mounted
 		? Math.max(
@@ -328,176 +341,210 @@ export function MorphingSearch({
 	const resultsHeight = mounted
 		? Math.max(96, Math.min(288, window.innerHeight - anchorRect.top - 80))
 		: 288;
+	const collapsedContentClip = `inset(0px ${Math.max(
+		0,
+		panelWidth - anchorRect.width,
+	)}px ${resultsHeight}px 0px round 12px)`;
+	const expandedContentClip = "inset(0px 0px 0px 0px round 12px)";
 
 	const overlay = mounted
 		? createPortal(
 				<div
 					aria-hidden={!open}
 					inert={!open}
-					className={cn(
-						"fixed inset-0 z-50",
-						open ? "pointer-events-auto" : "pointer-events-none",
-					)}
+					className="pointer-events-none fixed inset-0 z-50"
 				>
-					{open ? (
-						<motion.div key="morphing-search-overlay" className="fixed inset-0">
-							<button
-								type="button"
-								aria-label="Close search"
-								className="absolute inset-0 cursor-default bg-transparent"
-								onClick={() => setOpen(false)}
-							/>
-
+					<AnimatePresence
+						initial={false}
+						mode="popLayout"
+						onExitComplete={() => setBackgroundScrollLocked(false)}
+					>
+						{open ? (
 							<motion.div
-								ref={dialogRef}
-								layoutId={shellLayoutId}
-								role="dialog"
-								aria-modal="true"
-								aria-label="Search"
-								onKeyDown={handleDialogKeyDown}
-								className="fixed z-10 overflow-hidden rounded-xl bg-background/90 backdrop-blur-xl"
-								style={{
-									top: anchorRect.top,
-									left: anchorRect.left,
-									width: panelWidth,
-									boxShadow: "inset 0 0 0 1px var(--color-border)",
-								}}
-								transition={{ layout: transition }}
+								key="morphing-search-overlay"
+								className="fixed inset-0"
 							>
-								<div className="flex h-12 items-center gap-2.5 border-b border-border px-3.5">
-									<motion.span layoutId={iconLayoutId} className="shrink-0">
-										<Search className="size-4 text-muted-foreground" />
-									</motion.span>
-									<div className="relative flex h-10 min-w-0 flex-1 items-center">
-										<input
-											ref={inputRef}
-											value={query}
-											onChange={(event) => updateQuery(event.target.value)}
-											role="combobox"
-											aria-label={placeholder}
-											aria-expanded="true"
-											aria-controls={listboxId}
-											aria-autocomplete="list"
-											aria-activedescendant={
-												filteredItems.length > 0
-													? `${uid}-option-${activeIndex}`
-													: undefined
-											}
-											style={{
-												color: inputTextVisible ? undefined : "transparent",
-												caretColor: caretVisible
-													? "var(--color-foreground)"
-													: "transparent",
-											}}
-											className="size-full bg-transparent text-sm text-foreground outline-none"
-										/>
-										<motion.span
-											layoutId={labelLayoutId}
-											aria-hidden="true"
-											className="pointer-events-none absolute inset-y-0 left-0 flex max-w-full items-center truncate text-sm text-muted-foreground"
-										>
-											<span
-												style={{ visibility: query ? "hidden" : "visible" }}
-											>
-												{placeholder}
-											</span>
-										</motion.span>
-									</div>
-									<motion.kbd
-										layoutId={shortcutLayoutId}
-										className="flex h-7 shrink-0 items-center rounded-md border border-border px-2 text-xs text-muted-foreground"
-									>
-										Esc
-									</motion.kbd>
-								</div>
+								<button
+									type="button"
+									aria-label="Close search"
+									className="pointer-events-auto absolute inset-0 cursor-default bg-transparent"
+									onClick={closeSearch}
+								/>
 
 								<motion.div
-									ref={listRef}
-									id={listboxId}
-									role="listbox"
-									aria-label="Search results"
-									transition={reduce ? { duration: 0 } : undefined}
-									variants={
-										reduce
-											? undefined
-											: {
-													initial: {
-														opacity: 0,
-														transform: "translateY(6px)",
-													},
-													open: {
-														opacity: 1,
-														transform: "translateY(0px)",
-														transition: {
-															duration: 0.16,
-															delay: 0.06,
-															ease: EASE_OUT,
-														},
-													},
-												}
-									}
+									layoutId={shellLayoutId}
+									aria-hidden="true"
+									className="fixed z-10 rounded-xl bg-background/90 backdrop-blur-xl"
+									style={{
+										top: anchorRect.top,
+										left: anchorRect.left,
+										width: panelWidth,
+										height: 48 + resultsHeight,
+										boxShadow: "inset 0 0 0 1px var(--color-border)",
+									}}
+									transition={morphTransition}
+								/>
+
+								<motion.div
+									ref={dialogRef}
+									role="dialog"
+									aria-modal="true"
+									aria-label="Search"
+									onKeyDown={handleDialogKeyDown}
 									initial={
 										reduce
-											? { opacity: 1, transform: "translateY(0px)" }
-											: "initial"
+											? false
+											: { opacity: 0, clipPath: collapsedContentClip }
 									}
-									animate={
+									animate={{ opacity: 1, clipPath: expandedContentClip }}
+									exit={{
+										opacity: 0,
+										clipPath: collapsedContentClip,
+										transition: reduce
+											? { duration: 0 }
+											: {
+													clipPath: SEARCH_CLIP_TRANSITION,
+													opacity: SEARCH_MORPH,
+												},
+									}}
+									transition={
 										reduce
-											? { opacity: 1, transform: "translateY(0px)" }
-											: "open"
+											? { duration: 0 }
+											: {
+													clipPath: SEARCH_CLIP_TRANSITION,
+													opacity: SEARCH_MORPH,
+												}
 									}
-									className="overflow-y-auto p-2"
-									style={{ maxHeight: resultsHeight }}
+									className="pointer-events-auto fixed z-20 overflow-hidden rounded-xl"
+									style={{
+										top: anchorRect.top,
+										left: anchorRect.left,
+										width: panelWidth,
+									}}
 								>
-									{filteredItems.length > 0 ? (
-										filteredItems.map((item, index) => {
-											const Icon = item.icon;
-											const active = index === activeIndex;
-											return (
-												<button
-													key={item.id}
-													id={`${uid}-option-${index}`}
-													type="button"
-													role="option"
-													aria-selected={active}
-													data-index={index}
-													onMouseMove={() => setActiveIndex(index)}
-													onFocus={() => setActiveIndex(index)}
-													onClick={() => selectItem(item)}
-													className="relative flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-												>
-													{active ? (
-														<motion.span
-															layoutId={`${uid}-active-result`}
-															className="absolute inset-0 rounded-lg bg-foreground/5"
-															transition={transition}
-														/>
-													) : null}
-													{Icon ? (
-														<Icon className="relative size-4 shrink-0 text-muted-foreground" />
-													) : null}
-													<span className="relative min-w-0">
-														<span className="block truncate text-sm font-medium text-foreground">
-															{item.title}
-														</span>
-														{item.description ? (
-															<span className="block truncate text-xs text-muted-foreground">
-																{item.description}
-															</span>
+									<div className="flex h-12 items-center gap-2.5 border-b border-border px-3.5">
+										<span className="shrink-0">
+											<Search className="size-4 text-muted-foreground" />
+										</span>
+										<div className="flex h-10 min-w-0 flex-1 items-center">
+											<input
+												ref={inputRef}
+												value={query}
+												onChange={(event) => updateQuery(event.target.value)}
+												role="combobox"
+												aria-label={placeholder}
+												aria-expanded="true"
+												aria-controls={listboxId}
+												aria-autocomplete="list"
+												aria-activedescendant={
+													filteredItems.length > 0
+														? `${uid}-option-${activeIndex}`
+														: undefined
+												}
+												placeholder={placeholder}
+												className="size-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+											/>
+										</div>
+										<kbd className="flex h-7 shrink-0 items-center rounded-md border border-border px-2 text-xs text-muted-foreground">
+											Esc
+										</kbd>
+									</div>
+
+									<motion.div
+										ref={listRef}
+										id={listboxId}
+										role="listbox"
+										aria-label="Search results"
+										transition={reduce ? { duration: 0 } : undefined}
+										variants={
+											reduce
+												? undefined
+												: {
+														closed: {
+															opacity: 0,
+															transform: "translateY(6px)",
+															transition: {
+																duration: 0.16,
+																delay: 0.18,
+																ease: EASE_OUT,
+															},
+														},
+														open: {
+															opacity: 1,
+															transform: "translateY(0px)",
+															transition: {
+																duration: 0.16,
+																ease: EASE_OUT,
+															},
+														},
+													}
+										}
+										initial={
+											reduce
+												? { opacity: 1, transform: "translateY(0px)" }
+												: "closed"
+										}
+										animate={
+											reduce
+												? { opacity: 1, transform: "translateY(0px)" }
+												: "open"
+										}
+										exit={reduce ? undefined : "closed"}
+										className="overscroll-contain overflow-y-auto p-2"
+										style={{
+											maxHeight: resultsHeight,
+										}}
+									>
+										{filteredItems.length > 0 ? (
+											filteredItems.map((item, index) => {
+												const Icon = item.icon;
+												const active = index === activeIndex;
+												return (
+													<button
+														key={item.id}
+														id={`${uid}-option-${index}`}
+														type="button"
+														role="option"
+														aria-selected={active}
+														data-index={index}
+														onMouseMove={() => setActiveIndex(index)}
+														onFocus={() => setActiveIndex(index)}
+														onClick={() => selectItem(item)}
+														className="relative flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+													>
+														{active ? (
+															<motion.span
+																layoutId={`${uid}-active-result`}
+																className="absolute inset-0 rounded-lg bg-foreground/5"
+																transition={transition}
+															/>
 														) : null}
-													</span>
-												</button>
-											);
-										})
-									) : (
-										<p className="px-3 py-8 text-center text-sm text-muted-foreground">
-											{emptyMessage}
-										</p>
-									)}
+														{Icon ? (
+															<Icon className="relative size-4 shrink-0 text-muted-foreground" />
+														) : null}
+														<span className="relative min-w-0">
+															<span className="block truncate text-sm font-medium text-foreground">
+																{item.title}
+															</span>
+															{item.description ? (
+																<span className="block truncate text-xs text-muted-foreground">
+																	{item.description}
+																</span>
+															) : null}
+														</span>
+													</button>
+												);
+											})
+										) : (
+											<p className="px-3 py-8 text-center text-sm text-muted-foreground">
+												{emptyMessage}
+											</p>
+										)}
+									</motion.div>
 								</motion.div>
 							</motion.div>
-						</motion.div>
-					) : null}
+						) : null}
+					</AnimatePresence>
 				</div>,
 				document.body,
 			)
@@ -505,7 +552,14 @@ export function MorphingSearch({
 
 	return (
 		<LayoutGroup id={uid}>
-			<div ref={anchorRef} className={cn("h-12 w-72 max-w-full", className)}>
+			<div
+				ref={anchorRef}
+				className={cn(
+					"relative",
+					iconOnly ? "size-12" : "h-12 w-72 max-w-full",
+					className,
+				)}
+			>
 				{!open ? (
 					<motion.button
 						ref={triggerRef}
@@ -514,35 +568,51 @@ export function MorphingSearch({
 						type="button"
 						aria-haspopup="dialog"
 						aria-expanded="false"
+						aria-label={placeholder}
 						onClick={openSearch}
-						whileTap={reduce ? undefined : { scale: 0.985 }}
-						transition={{ layout: transition, ...SPRING_PRESS }}
+						transition={morphTransition}
 						style={{
 							boxShadow: "inset 0 0 0 1px var(--search-trigger-stroke)",
 						}}
-						className="flex size-full cursor-text items-center gap-2.5 rounded-xl bg-background/60 px-3.5 text-left backdrop-blur-md outline-none [--search-trigger-stroke:var(--color-border)] hover:[--search-trigger-stroke:var(--color-border-strong)] focus-visible:ring-2 focus-visible:ring-ring"
-					>
-						<motion.span layoutId={iconLayoutId} className="shrink-0">
-							<Search className="size-4 text-muted-foreground" />
-						</motion.span>
-						<span className="flex h-10 min-w-0 flex-1 items-center truncate text-sm text-muted-foreground">
-							<motion.span
-								layoutId={labelLayoutId}
-								className="flex h-10 items-center truncate"
-							>
-								{placeholder}
-							</motion.span>
-						</span>
-						{shortcut ? (
-							<motion.kbd
-								layoutId={shortcutLayoutId}
-								className="flex h-7 min-w-7 shrink-0 items-center justify-center rounded-md border border-border px-2 text-xs text-muted-foreground"
-							>
-								{shortcut.toUpperCase()}
-							</motion.kbd>
-						) : null}
-					</motion.button>
+						className={cn(
+							"flex size-full items-center rounded-xl bg-background/60 text-left backdrop-blur-md outline-none [--search-trigger-stroke:var(--color-border)] hover:[--search-trigger-stroke:var(--color-border-strong)] focus-visible:ring-2 focus-visible:ring-ring",
+							iconOnly ? "cursor-pointer justify-center" : "cursor-text px-3.5",
+						)}
+					></motion.button>
 				) : null}
+				<motion.div
+					aria-hidden="true"
+					initial={false}
+					animate={{ opacity: open ? 0 : 1 }}
+					transition={
+						reduce
+							? { duration: 0 }
+							: {
+									duration: 0.1,
+									delay: open ? 0.1 : 0.12,
+									ease: EASE_OUT,
+								}
+					}
+					className={cn(
+						"pointer-events-none absolute inset-0 flex items-center",
+						backgroundScrollLocked && "z-[60]",
+						iconOnly ? "justify-center" : "gap-2.5 px-3.5",
+					)}
+				>
+					<Search className="size-4 shrink-0 text-muted-foreground" />
+					{iconOnly ? null : (
+						<>
+							<span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+								{placeholder}
+							</span>
+							{shortcut ? (
+								<kbd className="flex h-7 min-w-7 shrink-0 items-center justify-center rounded-md border border-border px-2 text-xs text-muted-foreground">
+									{shortcut.toUpperCase()}
+								</kbd>
+							) : null}
+						</>
+					)}
+				</motion.div>
 			</div>
 			{overlay}
 		</LayoutGroup>

--- a/components/motion/morphing-search.tsx
+++ b/components/motion/morphing-search.tsx
@@ -50,6 +50,7 @@ type AnchorRect = {
 
 // Conceal only the unstable first frames of the shared-layout projection.
 const CARET_REVEAL_DELAY_MS = 100;
+const INPUT_TEXT_REVEAL_DELAY_MS = 250;
 
 function isEditableTarget(target: EventTarget | null) {
 	if (!(target instanceof HTMLElement)) return false;
@@ -77,6 +78,7 @@ export function MorphingSearch({
 	const [query, setQuery] = useState("");
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [caretVisible, setCaretVisible] = useState(true);
+	const [inputTextVisible, setInputTextVisible] = useState(true);
 	const [mounted, setMounted] = useState(false);
 	const [anchorRect, setAnchorRect] = useState<AnchorRect>({
 		top: 16,
@@ -113,6 +115,7 @@ export function MorphingSearch({
 	const openSearch = useCallback(() => {
 		measureAnchor();
 		setCaretVisible(Boolean(reduce));
+		setInputTextVisible(Boolean(reduce));
 		previousFocusRef.current =
 			document.activeElement instanceof HTMLElement
 				? document.activeElement
@@ -179,7 +182,10 @@ export function MorphingSearch({
 	useEffect(() => {
 		if (open) {
 			const opening = !wasOpenRef.current;
-			if (opening) setCaretVisible(Boolean(reduce));
+			if (opening) {
+				setCaretVisible(Boolean(reduce));
+				setInputTextVisible(Boolean(reduce));
+			}
 			updateQuery("");
 			const frame = requestAnimationFrame(() => inputRef.current?.focus());
 			const caretTimer =
@@ -189,9 +195,17 @@ export function MorphingSearch({
 							CARET_REVEAL_DELAY_MS,
 						)
 					: undefined;
+			const inputTextTimer =
+				opening && !reduce
+					? window.setTimeout(
+							() => setInputTextVisible(true),
+							INPUT_TEXT_REVEAL_DELAY_MS,
+						)
+					: undefined;
 			return () => {
 				cancelAnimationFrame(frame);
 				if (caretTimer !== undefined) window.clearTimeout(caretTimer);
+				if (inputTextTimer !== undefined) window.clearTimeout(inputTextTimer);
 			};
 		}
 
@@ -369,20 +383,24 @@ export function MorphingSearch({
 													? `${uid}-option-${activeIndex}`
 													: undefined
 											}
-											className={cn(
-												"h-10 w-full bg-transparent text-sm text-foreground outline-none",
-												!caretVisible && "caret-transparent",
-											)}
+											style={{
+												color: inputTextVisible ? undefined : "transparent",
+												caretColor: caretVisible
+													? "var(--color-foreground)"
+													: "transparent",
+											}}
+											className="size-full bg-transparent text-sm text-foreground outline-none"
 										/>
 										<motion.span
 											layoutId={labelLayoutId}
 											aria-hidden="true"
-											className={cn(
-												"pointer-events-none absolute inset-y-0 left-0 flex max-w-full items-center truncate text-sm text-muted-foreground",
-												query && "opacity-0",
-											)}
+											className="pointer-events-none absolute inset-y-0 left-0 flex max-w-full items-center truncate text-sm text-muted-foreground"
 										>
-											{placeholder}
+											<span
+												style={{ visibility: query ? "hidden" : "visible" }}
+											>
+												{placeholder}
+											</span>
 										</motion.span>
 									</div>
 									<motion.kbd

--- a/components/motion/morphing-search.tsx
+++ b/components/motion/morphing-search.tsx
@@ -48,6 +48,9 @@ type AnchorRect = {
 	width: number;
 };
 
+// Conceal only the unstable first frames of the shared-layout projection.
+const CARET_REVEAL_DELAY_MS = 100;
+
 function isEditableTarget(target: EventTarget | null) {
 	if (!(target instanceof HTMLElement)) return false;
 	return (
@@ -73,6 +76,7 @@ export function MorphingSearch({
 	const [internalOpen, setInternalOpen] = useState(defaultOpen);
 	const [query, setQuery] = useState("");
 	const [activeIndex, setActiveIndex] = useState(0);
+	const [caretVisible, setCaretVisible] = useState(true);
 	const [mounted, setMounted] = useState(false);
 	const [anchorRect, setAnchorRect] = useState<AnchorRect>({
 		top: 16,
@@ -108,12 +112,13 @@ export function MorphingSearch({
 
 	const openSearch = useCallback(() => {
 		measureAnchor();
+		setCaretVisible(Boolean(reduce));
 		previousFocusRef.current =
 			document.activeElement instanceof HTMLElement
 				? document.activeElement
 				: null;
 		setOpen(true);
-	}, [measureAnchor, setOpen]);
+	}, [measureAnchor, reduce, setOpen]);
 
 	const updateQuery = useCallback(
 		(next: string) => {
@@ -173,9 +178,21 @@ export function MorphingSearch({
 
 	useEffect(() => {
 		if (open) {
+			const opening = !wasOpenRef.current;
+			if (opening) setCaretVisible(Boolean(reduce));
 			updateQuery("");
 			const frame = requestAnimationFrame(() => inputRef.current?.focus());
-			return () => cancelAnimationFrame(frame);
+			const caretTimer =
+				opening && !reduce
+					? window.setTimeout(
+							() => setCaretVisible(true),
+							CARET_REVEAL_DELAY_MS,
+						)
+					: undefined;
+			return () => {
+				cancelAnimationFrame(frame);
+				if (caretTimer !== undefined) window.clearTimeout(caretTimer);
+			};
 		}
 
 		if (wasOpenRef.current) {
@@ -188,7 +205,7 @@ export function MorphingSearch({
 			});
 			return () => cancelAnimationFrame(frame);
 		}
-	}, [open, updateQuery]);
+	}, [open, reduce, updateQuery]);
 
 	useEffect(() => {
 		wasOpenRef.current = open;
@@ -337,10 +354,7 @@ export function MorphingSearch({
 									<motion.span layoutId={iconLayoutId} className="shrink-0">
 										<Search className="size-4 text-muted-foreground" />
 									</motion.span>
-									<motion.div
-										layoutId={labelLayoutId}
-										className="min-w-0 flex-1"
-									>
+									<div className="relative flex h-10 min-w-0 flex-1 items-center">
 										<input
 											ref={inputRef}
 											value={query}
@@ -355,10 +369,22 @@ export function MorphingSearch({
 													? `${uid}-option-${activeIndex}`
 													: undefined
 											}
-											placeholder={placeholder}
-											className="h-10 w-full bg-transparent text-base text-foreground outline-none placeholder:text-muted-foreground"
+											className={cn(
+												"h-10 w-full bg-transparent text-sm text-foreground outline-none",
+												!caretVisible && "caret-transparent",
+											)}
 										/>
-									</motion.div>
+										<motion.span
+											layoutId={labelLayoutId}
+											aria-hidden="true"
+											className={cn(
+												"pointer-events-none absolute inset-y-0 left-0 flex max-w-full items-center truncate text-sm text-muted-foreground",
+												query && "opacity-0",
+											)}
+										>
+											{placeholder}
+										</motion.span>
+									</div>
 									<motion.kbd
 										layoutId={shortcutLayoutId}
 										className="flex h-7 shrink-0 items-center rounded-md border border-border px-2 text-xs text-muted-foreground"
@@ -476,17 +502,19 @@ export function MorphingSearch({
 						style={{
 							boxShadow: "inset 0 0 0 1px var(--search-trigger-stroke)",
 						}}
-						className="flex size-full items-center gap-2.5 rounded-xl bg-background/60 px-3.5 text-left backdrop-blur-md outline-none [--search-trigger-stroke:var(--color-border)] hover:[--search-trigger-stroke:var(--color-border-strong)] focus-visible:ring-2 focus-visible:ring-ring"
+						className="flex size-full cursor-text items-center gap-2.5 rounded-xl bg-background/60 px-3.5 text-left backdrop-blur-md outline-none [--search-trigger-stroke:var(--color-border)] hover:[--search-trigger-stroke:var(--color-border-strong)] focus-visible:ring-2 focus-visible:ring-ring"
 					>
 						<motion.span layoutId={iconLayoutId} className="shrink-0">
 							<Search className="size-4 text-muted-foreground" />
 						</motion.span>
-						<motion.span
-							layoutId={labelLayoutId}
-							className="min-w-0 flex-1 truncate text-sm text-muted-foreground"
-						>
-							{placeholder}
-						</motion.span>
+						<span className="flex h-10 min-w-0 flex-1 items-center truncate text-sm text-muted-foreground">
+							<motion.span
+								layoutId={labelLayoutId}
+								className="flex h-10 items-center truncate"
+							>
+								{placeholder}
+							</motion.span>
+						</span>
 						{shortcut ? (
 							<motion.kbd
 								layoutId={shortcutLayoutId}

--- a/components/motion/morphing-search.tsx
+++ b/components/motion/morphing-search.tsx
@@ -1,0 +1,504 @@
+"use client";
+
+import { type LucideIcon, Search } from "lucide-react";
+import {
+	LayoutGroup,
+	motion,
+	type Transition,
+	useReducedMotion,
+} from "motion/react";
+import {
+	type KeyboardEvent as ReactKeyboardEvent,
+	useCallback,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { EASE_OUT, SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+export type MorphingSearchItem = {
+	id: string;
+	title: string;
+	description?: string;
+	keywords?: string[];
+	icon?: LucideIcon;
+	onSelect?: () => void;
+};
+
+export interface MorphingSearchProps {
+	items: MorphingSearchItem[];
+	placeholder?: string;
+	shortcut?: string;
+	emptyMessage?: string;
+	open?: boolean;
+	defaultOpen?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	onQueryChange?: (query: string) => void;
+	onSelect?: (item: MorphingSearchItem) => void;
+	className?: string;
+}
+
+type AnchorRect = {
+	top: number;
+	left: number;
+	width: number;
+};
+
+function isEditableTarget(target: EventTarget | null) {
+	if (!(target instanceof HTMLElement)) return false;
+	return (
+		target.isContentEditable ||
+		target instanceof HTMLInputElement ||
+		target instanceof HTMLTextAreaElement ||
+		target instanceof HTMLSelectElement
+	);
+}
+
+export function MorphingSearch({
+	items,
+	placeholder = "Search",
+	shortcut = "f",
+	emptyMessage = "No results found.",
+	open: controlledOpen,
+	defaultOpen = false,
+	onOpenChange,
+	onQueryChange,
+	onSelect,
+	className,
+}: MorphingSearchProps) {
+	const [internalOpen, setInternalOpen] = useState(defaultOpen);
+	const [query, setQuery] = useState("");
+	const [activeIndex, setActiveIndex] = useState(0);
+	const [mounted, setMounted] = useState(false);
+	const [anchorRect, setAnchorRect] = useState<AnchorRect>({
+		top: 16,
+		left: 16,
+		width: 288,
+	});
+	const open = controlledOpen ?? internalOpen;
+	const controlled = controlledOpen !== undefined;
+	const reduce = useReducedMotion();
+	const uid = useId();
+	const anchorRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const listRef = useRef<HTMLDivElement>(null);
+	const previousFocusRef = useRef<HTMLElement | null>(null);
+	const wasOpenRef = useRef(open);
+	const transition: Transition = reduce ? { duration: 0 } : SPRING_LAYOUT;
+
+	const setOpen = useCallback(
+		(next: boolean) => {
+			if (!controlled) setInternalOpen(next);
+			onOpenChange?.(next);
+		},
+		[controlled, onOpenChange],
+	);
+
+	const measureAnchor = useCallback(() => {
+		const rect = anchorRef.current?.getBoundingClientRect();
+		if (!rect || rect.width === 0) return;
+		setAnchorRect({ top: rect.top, left: rect.left, width: rect.width });
+	}, []);
+
+	const openSearch = useCallback(() => {
+		measureAnchor();
+		previousFocusRef.current =
+			document.activeElement instanceof HTMLElement
+				? document.activeElement
+				: null;
+		setOpen(true);
+	}, [measureAnchor, setOpen]);
+
+	const updateQuery = useCallback(
+		(next: string) => {
+			setQuery(next);
+			setActiveIndex(0);
+			onQueryChange?.(next);
+		},
+		[onQueryChange],
+	);
+
+	useEffect(() => setMounted(true), []);
+
+	useEffect(() => {
+		measureAnchor();
+		const anchor = anchorRef.current;
+		const observer =
+			anchor && typeof ResizeObserver !== "undefined"
+				? new ResizeObserver(measureAnchor)
+				: null;
+		if (anchor) observer?.observe(anchor);
+		window.addEventListener("resize", measureAnchor);
+		window.addEventListener("scroll", measureAnchor, { passive: true });
+		return () => {
+			observer?.disconnect();
+			window.removeEventListener("resize", measureAnchor);
+			window.removeEventListener("scroll", measureAnchor);
+		};
+	}, [measureAnchor]);
+
+	useEffect(() => {
+		const handleShortcut = (event: KeyboardEvent) => {
+			if (event.key === "Escape" && open) {
+				event.preventDefault();
+				setOpen(false);
+				return;
+			}
+
+			if (
+				!open &&
+				shortcut &&
+				event.key.toLowerCase() === shortcut.toLowerCase() &&
+				!event.repeat &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!event.altKey &&
+				!event.shiftKey &&
+				!isEditableTarget(event.target)
+			) {
+				event.preventDefault();
+				openSearch();
+			}
+		};
+
+		window.addEventListener("keydown", handleShortcut);
+		return () => window.removeEventListener("keydown", handleShortcut);
+	}, [open, openSearch, setOpen, shortcut]);
+
+	useEffect(() => {
+		if (open) {
+			updateQuery("");
+			const frame = requestAnimationFrame(() => inputRef.current?.focus());
+			return () => cancelAnimationFrame(frame);
+		}
+
+		if (wasOpenRef.current) {
+			const frame = requestAnimationFrame(() => {
+				const previousFocus = previousFocusRef.current;
+				const focusTarget = previousFocus?.isConnected
+					? previousFocus
+					: triggerRef.current;
+				focusTarget?.focus();
+			});
+			return () => cancelAnimationFrame(frame);
+		}
+	}, [open, updateQuery]);
+
+	useEffect(() => {
+		wasOpenRef.current = open;
+	}, [open]);
+
+	useEffect(() => {
+		if (!open) return;
+		const root = document.documentElement;
+		const body = document.body;
+		const rootOverflow = root.style.overflow;
+		const bodyOverflow = body.style.overflow;
+		root.style.overflow = "hidden";
+		body.style.overflow = "hidden";
+		return () => {
+			root.style.overflow = rootOverflow;
+			body.style.overflow = bodyOverflow;
+		};
+	}, [open]);
+
+	const filteredItems = useMemo(() => {
+		const needle = query.trim().toLowerCase();
+		if (!needle) return items;
+
+		return items.filter((item) =>
+			[item.title, item.description ?? "", ...(item.keywords ?? [])]
+				.join(" ")
+				.toLowerCase()
+				.includes(needle),
+		);
+	}, [items, query]);
+
+	useEffect(() => {
+		if (activeIndex < filteredItems.length) return;
+		setActiveIndex(Math.max(0, filteredItems.length - 1));
+	}, [activeIndex, filteredItems.length]);
+
+	useEffect(() => {
+		if (!open) return;
+		listRef.current
+			?.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`)
+			?.scrollIntoView({ block: "nearest" });
+	}, [activeIndex, open]);
+
+	const selectItem = useCallback(
+		(item: MorphingSearchItem) => {
+			item.onSelect?.();
+			onSelect?.(item);
+			setOpen(false);
+		},
+		[onSelect, setOpen],
+	);
+
+	const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+		if (event.key === "ArrowDown") {
+			event.preventDefault();
+			if (filteredItems.length === 0) return;
+			setActiveIndex((current) =>
+				Math.min(current + 1, filteredItems.length - 1),
+			);
+			return;
+		}
+
+		if (event.key === "ArrowUp") {
+			event.preventDefault();
+			setActiveIndex((current) => Math.max(current - 1, 0));
+			return;
+		}
+
+		if (event.key === "Enter") {
+			event.preventDefault();
+			const item = filteredItems[activeIndex];
+			if (item) selectItem(item);
+			return;
+		}
+
+		if (event.key !== "Tab" || !dialogRef.current) return;
+		const focusable = Array.from(
+			dialogRef.current.querySelectorAll<HTMLElement>(
+				'input, button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+			),
+		);
+		const first = focusable[0];
+		const last = focusable.at(-1);
+		if (!first || !last) return;
+
+		if (event.shiftKey && document.activeElement === first) {
+			event.preventDefault();
+			last.focus();
+		} else if (!event.shiftKey && document.activeElement === last) {
+			event.preventDefault();
+			first.focus();
+		}
+	};
+
+	const shellLayoutId = `${uid}-shell`;
+	const iconLayoutId = `${uid}-icon`;
+	const labelLayoutId = `${uid}-label`;
+	const shortcutLayoutId = `${uid}-shortcut`;
+	const listboxId = `${uid}-results`;
+	const panelWidth = mounted
+		? Math.max(
+				anchorRect.width,
+				Math.min(448, window.innerWidth - anchorRect.left - 16),
+			)
+		: anchorRect.width;
+	const resultsHeight = mounted
+		? Math.max(96, Math.min(288, window.innerHeight - anchorRect.top - 80))
+		: 288;
+
+	const overlay = mounted
+		? createPortal(
+				<div
+					aria-hidden={!open}
+					inert={!open}
+					className={cn(
+						"fixed inset-0 z-50",
+						open ? "pointer-events-auto" : "pointer-events-none",
+					)}
+				>
+					{open ? (
+						<motion.div key="morphing-search-overlay" className="fixed inset-0">
+							<button
+								type="button"
+								aria-label="Close search"
+								className="absolute inset-0 cursor-default bg-transparent"
+								onClick={() => setOpen(false)}
+							/>
+
+							<motion.div
+								ref={dialogRef}
+								layoutId={shellLayoutId}
+								role="dialog"
+								aria-modal="true"
+								aria-label="Search"
+								onKeyDown={handleDialogKeyDown}
+								className="fixed z-10 overflow-hidden rounded-xl bg-background/90 backdrop-blur-xl"
+								style={{
+									top: anchorRect.top,
+									left: anchorRect.left,
+									width: panelWidth,
+									boxShadow: "inset 0 0 0 1px var(--color-border)",
+								}}
+								transition={{ layout: transition }}
+							>
+								<div className="flex h-12 items-center gap-2.5 border-b border-border px-3.5">
+									<motion.span layoutId={iconLayoutId} className="shrink-0">
+										<Search className="size-4 text-muted-foreground" />
+									</motion.span>
+									<motion.div
+										layoutId={labelLayoutId}
+										className="min-w-0 flex-1"
+									>
+										<input
+											ref={inputRef}
+											value={query}
+											onChange={(event) => updateQuery(event.target.value)}
+											role="combobox"
+											aria-label={placeholder}
+											aria-expanded="true"
+											aria-controls={listboxId}
+											aria-autocomplete="list"
+											aria-activedescendant={
+												filteredItems.length > 0
+													? `${uid}-option-${activeIndex}`
+													: undefined
+											}
+											placeholder={placeholder}
+											className="h-10 w-full bg-transparent text-base text-foreground outline-none placeholder:text-muted-foreground"
+										/>
+									</motion.div>
+									<motion.kbd
+										layoutId={shortcutLayoutId}
+										className="flex h-7 shrink-0 items-center rounded-md border border-border px-2 text-xs text-muted-foreground"
+									>
+										Esc
+									</motion.kbd>
+								</div>
+
+								<motion.div
+									ref={listRef}
+									id={listboxId}
+									role="listbox"
+									aria-label="Search results"
+									transition={reduce ? { duration: 0 } : undefined}
+									variants={
+										reduce
+											? undefined
+											: {
+													initial: {
+														opacity: 0,
+														transform: "translateY(6px)",
+													},
+													open: {
+														opacity: 1,
+														transform: "translateY(0px)",
+														transition: {
+															duration: 0.16,
+															delay: 0.06,
+															ease: EASE_OUT,
+														},
+													},
+												}
+									}
+									initial={
+										reduce
+											? { opacity: 1, transform: "translateY(0px)" }
+											: "initial"
+									}
+									animate={
+										reduce
+											? { opacity: 1, transform: "translateY(0px)" }
+											: "open"
+									}
+									className="overflow-y-auto p-2"
+									style={{ maxHeight: resultsHeight }}
+								>
+									{filteredItems.length > 0 ? (
+										filteredItems.map((item, index) => {
+											const Icon = item.icon;
+											const active = index === activeIndex;
+											return (
+												<button
+													key={item.id}
+													id={`${uid}-option-${index}`}
+													type="button"
+													role="option"
+													aria-selected={active}
+													data-index={index}
+													onMouseMove={() => setActiveIndex(index)}
+													onFocus={() => setActiveIndex(index)}
+													onClick={() => selectItem(item)}
+													className="relative flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+												>
+													{active ? (
+														<motion.span
+															layoutId={`${uid}-active-result`}
+															className="absolute inset-0 rounded-lg bg-foreground/5"
+															transition={transition}
+														/>
+													) : null}
+													{Icon ? (
+														<Icon className="relative size-4 shrink-0 text-muted-foreground" />
+													) : null}
+													<span className="relative min-w-0">
+														<span className="block truncate text-sm font-medium text-foreground">
+															{item.title}
+														</span>
+														{item.description ? (
+															<span className="block truncate text-xs text-muted-foreground">
+																{item.description}
+															</span>
+														) : null}
+													</span>
+												</button>
+											);
+										})
+									) : (
+										<p className="px-3 py-8 text-center text-sm text-muted-foreground">
+											{emptyMessage}
+										</p>
+									)}
+								</motion.div>
+							</motion.div>
+						</motion.div>
+					) : null}
+				</div>,
+				document.body,
+			)
+		: null;
+
+	return (
+		<LayoutGroup id={uid}>
+			<div ref={anchorRef} className={cn("h-12 w-72 max-w-full", className)}>
+				{!open ? (
+					<motion.button
+						ref={triggerRef}
+						key="morphing-search-trigger"
+						layoutId={shellLayoutId}
+						type="button"
+						aria-haspopup="dialog"
+						aria-expanded="false"
+						onClick={openSearch}
+						whileTap={reduce ? undefined : { scale: 0.985 }}
+						transition={{ layout: transition, ...SPRING_PRESS }}
+						style={{
+							boxShadow: "inset 0 0 0 1px var(--search-trigger-stroke)",
+						}}
+						className="flex size-full items-center gap-2.5 rounded-xl bg-background/60 px-3.5 text-left backdrop-blur-md outline-none [--search-trigger-stroke:var(--color-border)] hover:[--search-trigger-stroke:var(--color-border-strong)] focus-visible:ring-2 focus-visible:ring-ring"
+					>
+						<motion.span layoutId={iconLayoutId} className="shrink-0">
+							<Search className="size-4 text-muted-foreground" />
+						</motion.span>
+						<motion.span
+							layoutId={labelLayoutId}
+							className="min-w-0 flex-1 truncate text-sm text-muted-foreground"
+						>
+							{placeholder}
+						</motion.span>
+						{shortcut ? (
+							<motion.kbd
+								layoutId={shortcutLayoutId}
+								className="flex h-7 min-w-7 shrink-0 items-center justify-center rounded-md border border-border px-2 text-xs text-muted-foreground"
+							>
+								{shortcut.toUpperCase()}
+							</motion.kbd>
+						) : null}
+					</motion.button>
+				) : null}
+			</div>
+			{overlay}
+		</LayoutGroup>
+	);
+}

--- a/components/previews/blocks/morphing-search.preview.tsx
+++ b/components/previews/blocks/morphing-search.preview.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Blocks, BookOpen, Bot, FolderOpen, Palette } from "lucide-react";
+import {
+  MorphingSearch,
+  type MorphingSearchItem,
+} from "@/components/motion/morphing-search";
+
+const ITEMS: MorphingSearchItem[] = [
+  {
+    id: "project-folder",
+    title: "Project Folder",
+    description: "Block · Files and previews",
+    keywords: ["files", "overlay"],
+    icon: FolderOpen,
+  },
+  {
+    id: "motion-components",
+    title: "Motion components",
+    description: "Collection · Interaction primitives",
+    keywords: ["animation", "components"],
+    icon: Blocks,
+  },
+  {
+    id: "agent-interfaces",
+    title: "Agent interfaces",
+    description: "Collection · AI building blocks",
+    keywords: ["ai", "chat"],
+    icon: Bot,
+  },
+  {
+    id: "installation",
+    title: "Installation guide",
+    description: "Documentation · Add your first component",
+    keywords: ["setup", "shadcn"],
+    icon: BookOpen,
+  },
+  {
+    id: "design-tokens",
+    title: "Design tokens",
+    description: "Documentation · Color, type, and motion",
+    keywords: ["theme", "styles"],
+    icon: Palette,
+  },
+];
+
+export function MorphingSearchPreview() {
+  return (
+    <div className="w-full max-w-xs">
+      <MorphingSearch items={ITEMS} placeholder="Find components" />
+    </div>
+  );
+}

--- a/components/previews/blocks/morphing-search.preview.tsx
+++ b/components/previews/blocks/morphing-search.preview.tsx
@@ -46,8 +46,14 @@ const ITEMS: MorphingSearchItem[] = [
 
 export function MorphingSearchPreview() {
   return (
-    <div className="w-full max-w-xs">
+    <div className="flex w-full max-w-[22rem] items-center gap-3">
       <MorphingSearch items={ITEMS} placeholder="Find components" />
+      <MorphingSearch
+        items={ITEMS}
+        placeholder="Find components"
+        shortcut=""
+        iconOnly
+      />
     </div>
   );
 }

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -160,6 +160,11 @@ export const previews: Record<string, ComponentType> = {
   "blocks/command-palette": dynamic(() =>
     import("./blocks/command-palette.preview").then((m) => m.CommandPalettePreview),
   ),
+  "blocks/morphing-search": dynamic(() =>
+    import("./blocks/morphing-search.preview").then(
+      (m) => m.MorphingSearchPreview,
+    ),
+  ),
   "blocks/feedback-widget": dynamic(() =>
     import("./blocks/feedback-widget.preview").then((m) => m.FeedbackWidgetPreview),
   ),

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -128,6 +128,7 @@ const COMPONENT_DATES = {
   "blocks/swap": { publishedAt: "2026-05-19", updatedAt: "2026-06-13" },
   "blocks/dynamic-island": { publishedAt: "2026-06-10", updatedAt: "2026-07-13" },
   "blocks/command-palette": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "blocks/morphing-search": { publishedAt: "2026-08-18", updatedAt: "2026-08-18" },
   "blocks/expandable-action-bar": { publishedAt: "2026-06-05", updatedAt: "2026-06-22" },
   "blocks/overflow-actions": { publishedAt: "2026-06-19", updatedAt: "2026-06-28" },
   "blocks/expandable-tabs": { publishedAt: "2026-06-14", updatedAt: "2026-06-28" },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1499,6 +1499,22 @@ export const registry: CategoryEntry[] = [
         file: "components/motion/command-palette.tsx",
       },
       {
+        slug: "morphing-search",
+        name: "Morphing Search",
+        description:
+          "Search field that expands into a glass results surface from the same shell, whether opened by click or keyboard shortcut.",
+        file: "components/motion/morphing-search.tsx",
+        badge: "new",
+        launchedAt: "2026-08-18",
+        keywords: [
+          "morphing search react",
+          "animated search component",
+          "search overlay react",
+          "keyboard search shortcut",
+          "command search ui",
+        ],
+      },
+      {
         slug: "expandable-action-bar",
         name: "Expandable Action Bar",
         description: "Compact icon actions that expand into labeled controls on hover or focus with shared layout motion.",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1502,7 +1502,7 @@ export const registry: CategoryEntry[] = [
         slug: "morphing-search",
         name: "Morphing Search",
         description:
-          "Search field that expands into a glass results surface from the same shell, whether opened by click or keyboard shortcut.",
+          "Search field or compact icon that morphs into a glass results surface, whether opened by click or keyboard shortcut.",
         file: "components/motion/morphing-search.tsx",
         badge: "new",
         launchedAt: "2026-08-18",

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -54,6 +54,7 @@ import {
 } from "@/components/motion/knockout-wheel";
 import { Marquee } from "@/components/motion/marquee";
 import { MorphingModal } from "@/components/motion/morphing-modal";
+import { MorphingSearch } from "@/components/motion/morphing-search";
 import { Parallax } from "@/components/motion/parallax";
 import {
   Popover,
@@ -696,6 +697,35 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
   ],
   ["TextReveal", () => <TextReveal text="Ship it" />],
   ["TextScramble", () => <TextScramble text="Running checks…" />],
+  [
+    "MorphingSearch closed",
+    () => (
+      <MorphingSearch
+        items={[
+          {
+            id: "docs",
+            title: "Documentation",
+            description: "Read the component guide",
+          },
+        ]}
+      />
+    ),
+  ],
+  [
+    "MorphingSearch open",
+    () => (
+      <MorphingSearch
+        defaultOpen
+        items={[
+          {
+            id: "docs",
+            title: "Documentation",
+            description: "Read the component guide",
+          },
+        ]}
+      />
+    ),
+  ],
   [
     "Tooltip",
     () => (

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -711,8 +711,8 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
       />
     ),
   ],
-  [
-    "MorphingSearch open",
+	[
+		"MorphingSearch open",
     () => (
       <MorphingSearch
         defaultOpen
@@ -724,10 +724,26 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
           },
         ]}
       />
-    ),
-  ],
-  [
-    "Tooltip",
+		),
+	],
+	[
+		"MorphingSearch icon only",
+		() => (
+			<MorphingSearch
+				iconOnly
+				shortcut=""
+				items={[
+					{
+						id: "docs",
+						title: "Documentation",
+						description: "Read the component guide",
+					},
+				]}
+			/>
+		),
+	],
+	[
+		"Tooltip",
     () => (
       <Tooltip content="More info">
         <button type="button">Hover me</button>


### PR DESCRIPTION
## Summary

- add a Morphing Search block with full-field and icon-only triggers
- open from click or plain-key shortcut with filtering, keyboard navigation, focus management, and selection callbacks
- unfold the content progressively while retaining the spring-driven shell motion in both directions
- keep the panel anchored, isolate background scrolling while open, and clean up interaction state after close
- register the block, preview both variants, and add accessibility coverage

## Why

The search needed to feel spatially connected to its trigger without scaling or stretching readable text. The final motion separates the spring-driven surface from the progressive content reveal, following the Morph Popover interaction model while preserving the current search spring.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun test tests/a11y.test.tsx` — 70 passed
- `bun run check:registry` — 77 components validated
- opening and closing verified frame-by-frame in the in-app browser
