### PR TITLE
fix: stop the text shimmer under reduced motion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ Before building a new component, check this list. If it exists, import it. If it
 - Biome a11y rules are strict: no redundant ARIA roles on divs/spans; use real elements (`<button>`) for interactive things. `DockItem` renders a `<button>` when given `onClick` and a plain div wrapper when children carry their own link/button — never nest interactive elements.
 - New component = source file + preview + `lib/registry.ts` entry in the same change. `bun run check:registry` must pass.
 - A `new` component's registry entry must set `launchedAt` to the ship date (`YYYY-MM-DD`). The landing "Recently launched" section sorts by it newest-first, so the just-added component leads.
+- A change to a component's public behavior or docs must bump `updatedAt` in `lib/component-dates.ts` to the ship date (`YYYY-MM-DD`) for every registry item that bundles a changed file, not just the one you were editing. A shared file usually ships in several entries, and the category slug is not the directory, so resolve the set from the entries' file lists rather than by path. Site-wide maintenance must not refresh every component's date.
 
 ## Commits
 

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -37,7 +37,7 @@ const COMPONENT_DATES = {
     publishedAt: "2026-07-21",
     updatedAt: "2026-07-21",
   },
-  "motion/text-animation": { publishedAt: "2026-05-17", updatedAt: "2026-08-14" },
+  "motion/text-animation": { publishedAt: "2026-05-17", updatedAt: "2026-08-19" },
   "motion/number": { publishedAt: "2026-05-17", updatedAt: "2026-06-28" },
   "motion/animated-badge": { publishedAt: "2026-06-05", updatedAt: "2026-06-10" },
   "motion/action-swap": { publishedAt: "2026-06-10", updatedAt: "2026-06-28" },
@@ -54,11 +54,11 @@ const COMPONENT_DATES = {
   "motion/loader": { publishedAt: "2026-07-04", updatedAt: "2026-07-13" },
   "agents/loading-states": {
     publishedAt: "2026-07-30",
-    updatedAt: "2026-08-14",
+    updatedAt: "2026-08-19",
   },
   "agents/chat-app": {
     publishedAt: "2026-08-02",
-    updatedAt: "2026-08-02",
+    updatedAt: "2026-08-19",
   },
   "agents/message-bubble": {
     publishedAt: "2026-08-02",
@@ -118,7 +118,7 @@ const COMPONENT_DATES = {
   },
   "agents/agent-activity": {
     publishedAt: "2026-08-01",
-    updatedAt: "2026-08-14",
+    updatedAt: "2026-08-19",
   },
   "blocks/infinite-masonry": { publishedAt: "2026-07-15", updatedAt: "2026-07-15" },
   "blocks/notification-stack": { publishedAt: "2026-07-14", updatedAt: "2026-07-14" },

--- a/lib/text-shimmer.ts
+++ b/lib/text-shimmer.ts
@@ -1,10 +1,18 @@
 import type { CSSProperties } from "react";
 
+// The reduced-motion rule travels with the component. app/globals.css calms CSS
+// animation globally, but the registry bundles imports only, so an installed
+// copy never receives that reset.
+//
+// `!important` because the sweep is an inline style, which outranks a plain rule
+// in a media query. It selects a marker class carried by TEXT_SHIMMER_CLASS_NAME
+// so it also reaches consumers that build their own span out of these exports.
 export const TEXT_SHIMMER_KEYFRAMES =
-  "@keyframes beui-text-shimmer{from{background-position:200% 0}to{background-position:-200% 0}}";
+  "@keyframes beui-text-shimmer{from{background-position:200% 0}to{background-position:-200% 0}}" +
+  "@media (prefers-reduced-motion: reduce){.beui-text-shimmer{animation:none !important}}";
 
 export const TEXT_SHIMMER_CLASS_NAME =
-  "bg-[length:200%_100%] bg-clip-text text-transparent bg-[linear-gradient(110deg,var(--muted-foreground)_30%,var(--foreground)_50%,var(--muted-foreground)_70%)]";
+  "beui-text-shimmer bg-[length:200%_100%] bg-clip-text text-transparent bg-[linear-gradient(110deg,var(--muted-foreground)_30%,var(--foreground)_50%,var(--muted-foreground)_70%)]";
 
 export function textShimmerStyle(duration: number): CSSProperties {
   return {

--- a/tests/text-shimmer.test.tsx
+++ b/tests/text-shimmer.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { ReasoningText } from "@/components/agents/loading-states/reasoning-text";
+import { TextShimmer } from "@/components/motion/text-shimmer";
+import { TEXT_SHIMMER_CLASS_NAME } from "@/lib/text-shimmer";
+import { buildShadcnItem } from "@/lib/registry-server";
+
+afterEach(cleanup);
+
+const REDUCED_MOTION_RULE = /@media\s*\(prefers-reduced-motion:\s*reduce\)/;
+
+describe("TextShimmer", () => {
+  test("stops the sweep under reduced motion", () => {
+    const { container } = render(<TextShimmer>Loading projects…</TextShimmer>);
+    const style = container.querySelector("style");
+    const shimmer = container.querySelector(".beui-text-shimmer");
+
+    // The rule has to be `!important`: the animation is an inline style, and an
+    // inline declaration outranks a plain rule in a media query.
+    expect(style?.textContent).toMatch(REDUCED_MOTION_RULE);
+    expect(style?.textContent).toContain(".beui-text-shimmer");
+    expect(style?.textContent).toContain("!important");
+    expect(shimmer).not.toBeNull();
+  });
+
+  test("carries the marker class on every shimmering element", () => {
+    // ReasoningText builds its own spans out of the class and the style rather
+    // than using TextShimmer, so the rule only reaches it through the class.
+    const { container } = render(<ReasoningText />);
+    const shimmering = container.querySelectorAll('[style*="beui-text-shimmer"]');
+
+    expect(shimmering.length).toBeGreaterThan(0);
+    for (const element of shimmering) {
+      expect(element.className).toContain("beui-text-shimmer");
+    }
+  });
+
+  test("ships the reduced-motion rule to consumers", async () => {
+    // The docs site neutralises CSS animation globally in app/globals.css, which
+    // the registry does not bundle. Without this the rule reaches beui.dev only.
+    const item = await buildShadcnItem("motion", "text-shimmer");
+    const lib = item?.files.find((file) => file.path === "lib/text-shimmer.ts");
+
+    expect(lib?.content).toMatch(REDUCED_MOTION_RULE);
+  });
+});
+
+describe("TEXT_SHIMMER_CLASS_NAME", () => {
+  test("carries the marker the reduced-motion rule selects", () => {
+    expect(TEXT_SHIMMER_CLASS_NAME).toContain("beui-text-shimmer");
+  });
+});


### PR DESCRIPTION
## What is wrong

`text-shimmer` sets an infinite CSS animation and nothing switches it off when the reader asks for reduced motion.

This is invisible on beui.dev. `app/globals.css` calms every CSS animation globally:

```css
@media (prefers-reduced-motion: reduce) {
    *, *::before, *::after {
        animation-duration: 0.01ms !important;
        animation-iteration-count: 1 !important;
        ...
    }
}
```

The registry bundles a component's `@/` and relative imports, and `text-shimmer.tsx` imports no CSS. So that reset never travels with the component. The published item shows it:

```
$ curl -s https://beui.dev/r/text-shimmer.json | grep -c 'prefers-reduced-motion'
0
```

Anyone installing `@beui/text-shimmer` gets a sweep that runs forever, unless their own app happens to carry the same global reset.

`AGENTS.md` states the assumption directly: "The global CSS media query cannot stop JS springs, so the hook is required." That is right for springs. For a CSS animation the global query is the whole defence, and it is the one part that does not ship.

## Why this reads as an oversight

`ReasoningText` already calls `useReducedMotion()` and drops the letter cascade under reduced motion. Its reduced-motion branch still applies `textShimmerStyle(...)`, so the sweep keeps running in the code path written to stop movement:

https://github.com/starc007/ui-components/blob/main/components/agents/loading-states/reasoning-text.tsx#L50-L64

`rainbow-cta.tsx` animates the same way, a `bg-[length:200%_100%]` gradient, and does carry `motion-reduce:animate-none`.

## The fix

The rule ships in `TEXT_SHIMMER_KEYFRAMES`, which both consumers already inject through a `<style>` tag:

```css
@media (prefers-reduced-motion: reduce){.beui-text-shimmer{animation:none !important}}
```

Two details worth stating:

- **`!important` is required.** The animation is an inline style, and an inline declaration outranks a plain rule in a media query. A `motion-reduce:animate-none` utility would lose. Your global reset uses `!important` for the same reason.
- **It selects a marker class, not a component.** `ReasoningText` builds its own spans out of `TEXT_SHIMMER_CLASS_NAME` and `textShimmerStyle` rather than using `TextShimmer`. All five call sites apply the class and the style together, so a marker on the shared class reaches every one of them.

Under reduced motion the text keeps the gradient as a static fill and stays readable. Nothing changes for readers who have not asked for reduced motion.

## Alternative I did not take

Moving the animation out of the inline style and into the injected stylesheet would remove the need for `!important`. It also changes what `textShimmerStyle()` returns, which is an exported function consumers call directly. That felt too wide for a bug fix. Happy to switch if you prefer it.

## Test plan

`tests/text-shimmer.test.tsx` covers the rule, the marker on every shimmering element, and the packaged registry item. All four fail on `main` before the change.

```
bun test tests/text-shimmer.test.tsx     # 4 pass
bun run check                            # typecheck, lint, 77 registry components
bun test                                 # 296 pass
```

One unrelated test, `AttachmentUpload > shows pending feedback before removing an attachment`, fails intermittently on an 8s timeout with and without this change.