### PR TITLE
fix: keep availability ranges on the same calendar day

### DIFF
--- a/components/motion/availability-scheduler/day-row.tsx
+++ b/components/motion/availability-scheduler/day-row.tsx
@@ -80,12 +80,13 @@ export function DayRow({
   };
 
   const updateRange = (id: string, patch: Partial<TimeRange>) => {
+    const changed: "start" | "end" = patch.start !== undefined ? "start" : "end";
     onChange({
       ...state,
       ranges: state.ranges.map((r) => {
         if (r.id !== id) return r;
         const next = { ...r, ...patch };
-        return { ...next, ...clampRange(next.start, next.end, options) };
+        return { ...next, ...clampRange(next.start, next.end, options, changed) };
       }),
     });
   };

--- a/components/motion/availability-scheduler/day-row.tsx
+++ b/components/motion/availability-scheduler/day-row.tsx
@@ -10,9 +10,12 @@ import { CopyMenu } from "./copy-menu";
 import { IconButton } from "./icon-button";
 import { TimeSelect } from "./time-select";
 import {
+  clampRange,
   type DayAvailability,
   type DayKey,
+  endOptions,
   panelKey,
+  startOptions,
   type TimeOption,
   type TimeRange,
   toMinutes,
@@ -76,10 +79,19 @@ export function DayRow({
     }
   };
 
+  const step =
+    options.length > 1
+      ? toMinutes(options[1].value) - toMinutes(options[0].value)
+      : 30;
+
   const updateRange = (id: string, patch: Partial<TimeRange>) => {
     onChange({
       ...state,
-      ranges: state.ranges.map((r) => (r.id === id ? { ...r, ...patch } : r)),
+      ranges: state.ranges.map((r) => {
+        if (r.id !== id) return r;
+        const next = { ...r, ...patch };
+        return { ...next, ...clampRange(next.start, next.end, step) };
+      }),
     });
   };
 
@@ -167,7 +179,7 @@ export function DayRow({
                 <div className="min-w-0 flex-1 sm:max-w-[132px]">
                   <TimeSelect
                     value={r.start}
-                    options={options}
+                    options={startOptions(options, r.end)}
                     onChange={(v) => updateRange(r.id, { start: v })}
                     open={openPanel === panelId(r.id, "start")}
                     onOpenChange={(open) =>
@@ -179,7 +191,7 @@ export function DayRow({
                 <div className="min-w-0 flex-1 sm:max-w-[132px]">
                   <TimeSelect
                     value={r.end}
-                    options={options}
+                    options={endOptions(options, r.start)}
                     onChange={(v) => updateRange(r.id, { end: v })}
                     open={openPanel === panelId(r.id, "end")}
                     onOpenChange={(open) =>

--- a/components/motion/availability-scheduler/day-row.tsx
+++ b/components/motion/availability-scheduler/day-row.tsx
@@ -79,18 +79,13 @@ export function DayRow({
     }
   };
 
-  const step =
-    options.length > 1
-      ? toMinutes(options[1].value) - toMinutes(options[0].value)
-      : 30;
-
   const updateRange = (id: string, patch: Partial<TimeRange>) => {
     onChange({
       ...state,
       ranges: state.ranges.map((r) => {
         if (r.id !== id) return r;
         const next = { ...r, ...patch };
-        return { ...next, ...clampRange(next.start, next.end, step) };
+        return { ...next, ...clampRange(next.start, next.end, options) };
       }),
     });
   };
@@ -179,7 +174,7 @@ export function DayRow({
                 <div className="min-w-0 flex-1 sm:max-w-[132px]">
                   <TimeSelect
                     value={r.start}
-                    options={startOptions(options, r.end)}
+                    options={startOptions(options, r.end, r.start)}
                     onChange={(v) => updateRange(r.id, { start: v })}
                     open={openPanel === panelId(r.id, "start")}
                     onOpenChange={(open) =>
@@ -191,7 +186,7 @@ export function DayRow({
                 <div className="min-w-0 flex-1 sm:max-w-[132px]">
                   <TimeSelect
                     value={r.end}
-                    options={endOptions(options, r.start)}
+                    options={endOptions(options, r.start, r.end)}
                     onChange={(v) => updateRange(r.id, { end: v })}
                     open={openPanel === panelId(r.id, "end")}
                     onOpenChange={(open) =>

--- a/components/motion/availability-scheduler/types.ts
+++ b/components/motion/availability-scheduler/types.ts
@@ -56,6 +56,32 @@ export function buildOptions(step: number): TimeOption[] {
   return out;
 }
 
+/** Same-day ranges only: end must be after start. 7:00 PM → 1:00 AM is rejected. */
+export function clampRange(
+  start: string,
+  end: string,
+  step: number,
+): { start: string; end: string } {
+  const last = 24 * 60 - step;
+  let s = toMinutes(start);
+  let e = toMinutes(end);
+  s = Math.max(0, Math.min(s, last - step));
+  if (e <= s) e = s + step;
+  e = Math.min(Math.max(e, s + step), last);
+  if (e <= s) s = Math.max(0, e - step);
+  return { start: toValue(s), end: toValue(e) };
+}
+
+export function startOptions(options: TimeOption[], end: string) {
+  const endM = toMinutes(end);
+  return options.filter((o) => toMinutes(o.value) < endM);
+}
+
+export function endOptions(options: TimeOption[], start: string) {
+  const startM = toMinutes(start);
+  return options.filter((o) => toMinutes(o.value) > startM);
+}
+
 // Default: Mon–Fri 9–5, weekend off. Fixed ids so SSR and first client render
 // agree (new ranges get counter ids afterwards).
 export function defaultWeek(): WeekAvailability {

--- a/components/motion/availability-scheduler/types.ts
+++ b/components/motion/availability-scheduler/types.ts
@@ -105,6 +105,10 @@ export function clampRange(
   if (changed === "end") {
     const e = keepOrSnap(end);
     const earlier = [...slots].reverse().find((slot) => slot < e);
+    if (earlier === undefined && slots.length > 1) {
+      // Midnight cannot end a positive same-day range, so use the first pair.
+      return { start: toValue(slots[0]), end: toValue(slots[1]) };
+    }
     return {
       start: toValue(earlier ?? keepOrSnap(start)),
       end: toValue(e),
@@ -113,6 +117,13 @@ export function clampRange(
 
   const s = keepOrSnap(start);
   const later = slots.find((slot) => slot > s);
+  if (later === undefined && slots.length > 1) {
+    // The last slot cannot start a positive range, so use the final pair.
+    return {
+      start: toValue(slots[slots.length - 2]),
+      end: toValue(slots[slots.length - 1]),
+    };
+  }
   return {
     start: toValue(s),
     end: toValue(later ?? keepOrSnap(end)),
@@ -124,8 +135,14 @@ export function startOptions(
   end: string,
   current?: string,
 ) {
+  const filtered = options.filter(
+    (o) => toMinutes(o.value) < toMinutes(end),
+  );
+  // An invalid midnight end has no earlier option; expose midnight so choosing
+  // it can move the end forward through clampRange instead of trapping the row.
+  const recovery = filtered.length === 0 ? options.slice(0, 1) : filtered;
   return withCurrentOption(
-    options.filter((o) => toMinutes(o.value) < toMinutes(end)),
+    recovery,
     options,
     current,
   );
@@ -136,8 +153,14 @@ export function endOptions(
   start: string,
   current?: string,
 ) {
+  const filtered = options.filter(
+    (o) => toMinutes(o.value) > toMinutes(start),
+  );
+  // An invalid last-slot start has no later option; expose the last slot so
+  // choosing it can move the start backward through clampRange.
+  const recovery = filtered.length === 0 ? options.slice(-1) : filtered;
   return withCurrentOption(
-    options.filter((o) => toMinutes(o.value) > toMinutes(start)),
+    recovery,
     options,
     current,
   );

--- a/components/motion/availability-scheduler/types.ts
+++ b/components/motion/availability-scheduler/types.ts
@@ -79,33 +79,44 @@ function withCurrentOption(
 }
 
 /**
- * Same-day ranges only, snapped onto the generated option grid so `step`
- * values that do not divide 1440 still produce picker-legal times.
+ * Same-day ranges only. A valid pair is left alone so an off-grid persisted
+ * end (17:00 with `step={720}`) is not rewritten. When the invariant fails,
+ * the just-selected endpoint stays and only the opposite side moves onto a
+ * neighboring generated option.
  */
 export function clampRange(
   start: string,
   end: string,
   options: TimeOption[],
+  changed: "start" | "end" = "start",
 ): { start: string; end: string } {
   const slots = options.map((o) => toMinutes(o.value));
   if (slots.length === 0) return { start, end };
-  if (slots.length === 1) {
-    return { start: options[0].value, end: options[0].value };
+
+  const startM = toMinutes(start);
+  const endM = toMinutes(end);
+  if (endM > startM) return { start, end };
+
+  const keepOrSnap = (value: string) => {
+    const mins = toMinutes(value);
+    return slots.includes(mins) ? mins : snapToOption(mins, slots);
+  };
+
+  if (changed === "end") {
+    const e = keepOrSnap(end);
+    const earlier = [...slots].reverse().find((slot) => slot < e);
+    return {
+      start: toValue(earlier ?? keepOrSnap(start)),
+      end: toValue(e),
+    };
   }
 
-  let s = snapToOption(toMinutes(start), slots);
-  let e = snapToOption(toMinutes(end), slots);
-
-  if (e <= s) {
-    const later = slots.find((slot) => slot > s);
-    if (later !== undefined) e = later;
-    else {
-      const earlier = [...slots].reverse().find((slot) => slot < s);
-      if (earlier !== undefined) s = earlier;
-    }
-  }
-
-  return { start: toValue(s), end: toValue(e) };
+  const s = keepOrSnap(start);
+  const later = slots.find((slot) => slot > s);
+  return {
+    start: toValue(s),
+    end: toValue(later ?? keepOrSnap(end)),
+  };
 }
 
 export function startOptions(

--- a/components/motion/availability-scheduler/types.ts
+++ b/components/motion/availability-scheduler/types.ts
@@ -56,30 +56,80 @@ export function buildOptions(step: number): TimeOption[] {
   return out;
 }
 
-/** Same-day ranges only: end must be after start. 7:00 PM → 1:00 AM is rejected. */
+function snapToOption(mins: number, slots: number[]) {
+  let best = slots[0];
+  for (const slot of slots) {
+    if (Math.abs(slot - mins) < Math.abs(best - mins)) best = slot;
+  }
+  return best;
+}
+
+function withCurrentOption(
+  filtered: TimeOption[],
+  all: TimeOption[],
+  current?: string,
+) {
+  if (!current || filtered.some((o) => o.value === current)) return filtered;
+  const extra =
+    all.find((o) => o.value === current) ??
+    ({ value: current, label: label12(current) } satisfies TimeOption);
+  return [...filtered, extra].sort(
+    (a, b) => toMinutes(a.value) - toMinutes(b.value),
+  );
+}
+
+/**
+ * Same-day ranges only, snapped onto the generated option grid so `step`
+ * values that do not divide 1440 still produce picker-legal times.
+ */
 export function clampRange(
   start: string,
   end: string,
-  step: number,
+  options: TimeOption[],
 ): { start: string; end: string } {
-  const last = 24 * 60 - step;
-  let s = toMinutes(start);
-  let e = toMinutes(end);
-  s = Math.max(0, Math.min(s, last - step));
-  if (e <= s) e = s + step;
-  e = Math.min(Math.max(e, s + step), last);
-  if (e <= s) s = Math.max(0, e - step);
+  const slots = options.map((o) => toMinutes(o.value));
+  if (slots.length === 0) return { start, end };
+  if (slots.length === 1) {
+    return { start: options[0].value, end: options[0].value };
+  }
+
+  let s = snapToOption(toMinutes(start), slots);
+  let e = snapToOption(toMinutes(end), slots);
+
+  if (e <= s) {
+    const later = slots.find((slot) => slot > s);
+    if (later !== undefined) e = later;
+    else {
+      const earlier = [...slots].reverse().find((slot) => slot < s);
+      if (earlier !== undefined) s = earlier;
+    }
+  }
+
   return { start: toValue(s), end: toValue(e) };
 }
 
-export function startOptions(options: TimeOption[], end: string) {
-  const endM = toMinutes(end);
-  return options.filter((o) => toMinutes(o.value) < endM);
+export function startOptions(
+  options: TimeOption[],
+  end: string,
+  current?: string,
+) {
+  return withCurrentOption(
+    options.filter((o) => toMinutes(o.value) < toMinutes(end)),
+    options,
+    current,
+  );
 }
 
-export function endOptions(options: TimeOption[], start: string) {
-  const startM = toMinutes(start);
-  return options.filter((o) => toMinutes(o.value) > startM);
+export function endOptions(
+  options: TimeOption[],
+  start: string,
+  current?: string,
+) {
+  return withCurrentOption(
+    options.filter((o) => toMinutes(o.value) > toMinutes(start)),
+    options,
+    current,
+  );
 }
 
 // Default: Mon–Fri 9–5, weekend off. Fixed ids so SSR and first client render

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -124,7 +124,7 @@ const COMPONENT_DATES = {
   "blocks/notification-stack": { publishedAt: "2026-07-14", updatedAt: "2026-07-14" },
   "blocks/project-folder": { publishedAt: "2026-08-15", updatedAt: "2026-08-20" },
   "blocks/knockout-bracket": { publishedAt: "2026-07-12", updatedAt: "2026-07-27" },
-  "blocks/availability-scheduler": { publishedAt: "2026-07-10", updatedAt: "2026-07-10" },
+  "blocks/availability-scheduler": { publishedAt: "2026-07-10", updatedAt: "2026-08-23" },
   "blocks/swap": { publishedAt: "2026-05-19", updatedAt: "2026-06-13" },
   "blocks/dynamic-island": { publishedAt: "2026-06-10", updatedAt: "2026-07-13" },
   "blocks/command-palette": { publishedAt: "2026-05-17", updatedAt: "2026-08-20" },

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -124,7 +124,7 @@ const COMPONENT_DATES = {
   "blocks/notification-stack": { publishedAt: "2026-07-14", updatedAt: "2026-07-14" },
   "blocks/project-folder": { publishedAt: "2026-08-15", updatedAt: "2026-08-20" },
   "blocks/knockout-bracket": { publishedAt: "2026-07-12", updatedAt: "2026-07-27" },
-  "blocks/availability-scheduler": { publishedAt: "2026-07-10", updatedAt: "2026-08-23" },
+  "blocks/availability-scheduler": { publishedAt: "2026-07-10", updatedAt: "2026-08-24" },
   "blocks/swap": { publishedAt: "2026-05-19", updatedAt: "2026-06-13" },
   "blocks/dynamic-island": { publishedAt: "2026-06-10", updatedAt: "2026-07-13" },
   "blocks/command-palette": { publishedAt: "2026-05-17", updatedAt: "2026-08-20" },

--- a/tests/availability-scheduler.test.tsx
+++ b/tests/availability-scheduler.test.tsx
@@ -6,6 +6,12 @@ import {
   defaultWeek,
   type WeekAvailability,
 } from "@/components/motion/availability-scheduler";
+import {
+  buildOptions,
+  clampRange,
+  endOptions,
+  startOptions,
+} from "@/components/motion/availability-scheduler/types";
 
 function Scheduler({ initial }: { initial: WeekAvailability }) {
   const [value, setValue] = useState(initial);
@@ -72,5 +78,35 @@ describe("AvailabilityScheduler open panel", () => {
     fireEvent.click(monSwitch);
 
     expect(openFields(container)).toHaveLength(0);
+  });
+});
+
+const options = buildOptions(30);
+
+describe("availability scheduler ranges", () => {
+  test("rejects an overnight window like 7:00 PM to 1:00 AM", () => {
+    expect(clampRange("19:00", "01:00", 30)).toEqual({
+      start: "19:00",
+      end: "19:30",
+    });
+  });
+
+  test("keeps a same-day window", () => {
+    expect(clampRange("09:00", "17:00", 30)).toEqual({
+      start: "09:00",
+      end: "17:00",
+    });
+  });
+
+  test("end picker only lists times after start", () => {
+    const ends = endOptions(options, "19:00").map((o) => o.value);
+    expect(ends).not.toContain("01:00");
+    expect(ends[0]).toBe("19:30");
+  });
+
+  test("start picker only lists times before end", () => {
+    const starts = startOptions(options, "17:00").map((o) => o.value);
+    expect(starts).not.toContain("17:00");
+    expect(starts.at(-1)).toBe("16:30");
   });
 });

--- a/tests/availability-scheduler.test.tsx
+++ b/tests/availability-scheduler.test.tsx
@@ -79,22 +79,46 @@ describe("AvailabilityScheduler open panel", () => {
 
     expect(openFields(container)).toHaveLength(0);
   });
+
+  test("shows a persisted overnight range instead of a blank Select", () => {
+    const overnight: WeekAvailability = {
+      ...defaultWeek(),
+      mon: {
+        enabled: true,
+        ranges: [{ id: "mon-0", start: "19:00", end: "01:00" }],
+      },
+    };
+    const { container } = render(
+      <AvailabilityScheduler value={overnight} onChange={() => {}} />,
+    );
+    const [monStart, monEnd] = fields(container);
+    expect(monStart.textContent).toContain("7:00 PM");
+    expect(monEnd.textContent).toContain("1:00 AM");
+  });
 });
 
 const options = buildOptions(30);
+const options50 = buildOptions(50);
 
 describe("availability scheduler ranges", () => {
   test("rejects an overnight window like 7:00 PM to 1:00 AM", () => {
-    expect(clampRange("19:00", "01:00", 30)).toEqual({
+    expect(clampRange("19:00", "01:00", options)).toEqual({
       start: "19:00",
       end: "19:30",
     });
   });
 
   test("keeps a same-day window", () => {
-    expect(clampRange("09:00", "17:00", 30)).toEqual({
+    expect(clampRange("09:00", "17:00", options)).toEqual({
       start: "09:00",
       end: "17:00",
+    });
+  });
+
+  test("snaps onto generated options when step does not divide the day", () => {
+    expect(clampRange("22:30", "23:20", options50)).toEqual({
+      start: "22:30",
+      end: "23:20",
     });
   });
 
@@ -108,5 +132,14 @@ describe("availability scheduler ranges", () => {
     const starts = startOptions(options, "17:00").map((o) => o.value);
     expect(starts).not.toContain("17:00");
     expect(starts.at(-1)).toBe("16:30");
+  });
+
+  test("keeps a persisted overnight range visible in both pickers", () => {
+    expect(
+      startOptions(options, "01:00", "19:00").map((o) => o.value),
+    ).toContain("19:00");
+    expect(
+      endOptions(options, "19:00", "01:00").map((o) => o.value),
+    ).toContain("01:00");
   });
 });

--- a/tests/availability-scheduler.test.tsx
+++ b/tests/availability-scheduler.test.tsx
@@ -80,6 +80,19 @@ describe("AvailabilityScheduler open panel", () => {
     expect(openFields(container)).toHaveLength(0);
   });
 
+  test("keeps a 12:00 PM start against a 5:00 PM end on a 12h step", () => {
+    const { container, getByRole } = render(
+      <Scheduler initial={defaultWeek()} />,
+    );
+    const [monStart, monEnd] = fields(container);
+
+    fireEvent.click(monStart);
+    fireEvent.click(getByRole("option", { name: "12:00 PM" }));
+
+    expect(monStart.textContent).toContain("12:00 PM");
+    expect(monEnd.textContent).toContain("5:00 PM");
+  });
+
   test("shows a persisted overnight range instead of a blank Select", () => {
     const overnight: WeekAvailability = {
       ...defaultWeek(),
@@ -119,6 +132,20 @@ describe("availability scheduler ranges", () => {
     expect(clampRange("22:30", "23:20", options50)).toEqual({
       start: "22:30",
       end: "23:20",
+    });
+  });
+
+  test("preserves a 12:00 start when the 17:00 end is off the 12h grid", () => {
+    expect(clampRange("12:00", "17:00", buildOptions(720), "start")).toEqual({
+      start: "12:00",
+      end: "17:00",
+    });
+  });
+
+  test("moves only the opposite end when the user picks an overnight end", () => {
+    expect(clampRange("19:00", "01:00", options, "end")).toEqual({
+      start: "00:30",
+      end: "01:00",
     });
   });
 

--- a/tests/availability-scheduler.test.tsx
+++ b/tests/availability-scheduler.test.tsx
@@ -13,11 +13,16 @@ import {
   startOptions,
 } from "@/components/motion/availability-scheduler/types";
 
-function Scheduler({ initial }: { initial: WeekAvailability }) {
+function Scheduler({
+  initial,
+  step = 720,
+}: {
+  initial: WeekAvailability;
+  step?: number;
+}) {
   const [value, setValue] = useState(initial);
-  // A 12h step keeps every panel to two options — these tests only care which
-  // panel is open, not what is in it.
-  return <AvailabilityScheduler value={value} onChange={setValue} step={720} />;
+  // A 12h step keeps panel-focused tests small; value tests can override it.
+  return <AvailabilityScheduler value={value} onChange={setValue} step={step} />;
 }
 
 /** Every time field, in row order: mon start, mon end, tue start, … */
@@ -108,6 +113,26 @@ describe("AvailabilityScheduler open panel", () => {
     expect(monStart.textContent).toContain("7:00 PM");
     expect(monEnd.textContent).toContain("1:00 AM");
   });
+
+  test("offers a valid recovery from a boundary overnight range", () => {
+    const boundary: WeekAvailability = {
+      ...defaultWeek(),
+      mon: {
+        enabled: true,
+        ranges: [{ id: "mon-0", start: "23:30", end: "00:00" }],
+      },
+    };
+    const { container, getByRole } = render(
+      <Scheduler initial={boundary} step={30} />,
+    );
+    const [monStart, monEnd] = fields(container);
+
+    fireEvent.click(monStart);
+    fireEvent.click(getByRole("option", { name: "12:00 AM" }));
+
+    expect(monStart.textContent).toContain("12:00 AM");
+    expect(monEnd.textContent).toContain("12:30 AM");
+  });
 });
 
 const options = buildOptions(30);
@@ -142,7 +167,7 @@ describe("availability scheduler ranges", () => {
     });
   });
 
-  test("moves only the opposite end when the user picks an overnight end", () => {
+  test("moves only the opposite start when the user picks an overnight end", () => {
     expect(clampRange("19:00", "01:00", options, "end")).toEqual({
       start: "00:30",
       end: "01:00",
@@ -168,5 +193,24 @@ describe("availability scheduler ranges", () => {
     expect(
       endOptions(options, "19:00", "01:00").map((o) => o.value),
     ).toContain("01:00");
+  });
+
+  test("offers boundary choices that recover a 23:30 to 00:00 range", () => {
+    expect(startOptions(options, "00:00", "23:30").map((o) => o.value)).toEqual([
+      "00:00",
+      "23:30",
+    ]);
+    expect(endOptions(options, "23:30", "00:00").map((o) => o.value)).toEqual([
+      "00:00",
+      "23:30",
+    ]);
+    expect(clampRange("00:00", "00:00", options, "start")).toEqual({
+      start: "00:00",
+      end: "00:30",
+    });
+    expect(clampRange("23:30", "23:30", options, "end")).toEqual({
+      start: "23:00",
+      end: "23:30",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #159: the scheduler accepted ranges whose end is earlier than the start (e.g. 7:00 PM → 1:00 AM).
- Start/end pickers only list times that keep end after start; invalid pairs are clamped to the next valid slot.

## Test plan
- [ ] Open `/components/blocks/availability-scheduler`
- [ ] Set a day's start to 7:00 PM — 1:00 AM should not be selectable as the end
- [ ] Change end first to 1:00 AM, then start to 7:00 PM — range should clamp so end stays after start
- [ ] 9:00 AM – 5:00 PM still works
- [ ] `bun test tests/availability-scheduler.test.tsx`


