### PR TITLE
feat: add metallic button variant

### DIFF
--- a/components/motion/button/index.tsx
+++ b/components/motion/button/index.tsx
@@ -7,5 +7,7 @@ export type {
 export { Button, ButtonLink } from "./base";
 export type { MagneticButtonProps } from "./magnetic";
 export { MagneticButton } from "./magnetic";
+export type { MetallicButtonProps } from "./metallic";
+export { MetallicButton } from "./metallic";
 export type { ButtonState, StatefulButtonProps } from "./stateful";
 export { StatefulButton } from "./stateful";

--- a/components/motion/button/metallic.tsx
+++ b/components/motion/button/metallic.tsx
@@ -16,8 +16,9 @@ export interface MetallicButtonProps extends Omit<
 
 // The rim and highlight drift separately so the material stays quiet and reflective.
 const SILVER_DRIFT = {
-  duration: 2.8,
+  duration: 8,
   ease: EASE_IN_OUT,
+  repeat: Infinity,
 };
 
 const CHROME_SHIMMER = {
@@ -70,7 +71,7 @@ export const MetallicButton = forwardRef<
       <motion.span
         aria-hidden="true"
         className="pointer-events-none absolute inset-y-0 left-[-18%] z-0 w-[136%] rounded-[inherit] bg-[linear-gradient(105deg,#111_0%,#737373_14%,#fafafa_26%,#525252_38%,#0a0a0a_50%,#a3a3a3_64%,#fff_75%,#404040_87%,#111_100%)]"
-        animate={still ? undefined : { x: hovered ? "13%" : "0%" }}
+        animate={still ? undefined : { x: ["0%", "13%", "0%"] }}
         transition={still ? undefined : SILVER_DRIFT}
       />
 

--- a/components/motion/button/metallic.tsx
+++ b/components/motion/button/metallic.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { motion, useReducedMotion } from "motion/react";
-import { forwardRef } from "react";
+import { forwardRef, useState } from "react";
+import { EASE_IN_OUT } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 import { Button, type ButtonProps } from "./base";
 
@@ -13,29 +14,49 @@ export interface MetallicButtonProps extends Omit<
   paused?: boolean;
 }
 
-// A straight pass reads as a changing reflection without turning into a spinner.
-const CHROME_SWEEP = {
-  duration: 3.2,
-  ease: "easeInOut" as const,
-  repeat: Infinity,
-  repeatDelay: 0.7,
+// The rim and highlight drift separately so the material stays quiet and reflective.
+const SILVER_DRIFT = {
+  duration: 2.8,
+  ease: EASE_IN_OUT,
+};
+
+const CHROME_SHIMMER = {
+  duration: 2.4,
+  ease: EASE_IN_OUT,
 };
 
 export const MetallicButton = forwardRef<
   HTMLButtonElement,
   MetallicButtonProps
 >(function MetallicButton(
-  { size = "md", paused = false, className, children, ...rest },
+  {
+    size = "md",
+    paused = false,
+    className,
+    children,
+    onHoverStart,
+    onHoverEnd,
+    ...rest
+  },
   ref,
 ) {
   const reduce = useReducedMotion();
   const still = paused || Boolean(reduce);
+  const [hovered, setHovered] = useState(false);
 
   return (
     <Button
       ref={ref}
       variant="ghost"
       size={size}
+      onHoverStart={(event, info) => {
+        setHovered(true);
+        onHoverStart?.(event, info);
+      }}
+      onHoverEnd={(event, info) => {
+        setHovered(false);
+        onHoverEnd?.(event, info);
+      }}
       className={cn(
         "group relative isolate overflow-hidden border border-transparent bg-transparent text-foreground",
         "hover:bg-transparent hover:text-foreground",
@@ -46,16 +67,18 @@ export const MetallicButton = forwardRef<
       )}
       {...rest}
     >
-      <span
+      <motion.span
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 z-0 rounded-[inherit] bg-[linear-gradient(105deg,#111_0%,#737373_14%,#fafafa_26%,#525252_38%,#0a0a0a_50%,#a3a3a3_64%,#fff_75%,#404040_87%,#111_100%)]"
+        className="pointer-events-none absolute inset-y-0 left-[-18%] z-0 w-[136%] rounded-[inherit] bg-[linear-gradient(105deg,#111_0%,#737373_14%,#fafafa_26%,#525252_38%,#0a0a0a_50%,#a3a3a3_64%,#fff_75%,#404040_87%,#111_100%)]"
+        animate={still ? undefined : { x: hovered ? "13%" : "0%" }}
+        transition={still ? undefined : SILVER_DRIFT}
       />
 
       <motion.span
         aria-hidden="true"
-        className="pointer-events-none absolute inset-y-0 left-[-58%] z-[1] w-[58%] -skew-x-12 bg-[linear-gradient(90deg,transparent,rgba(255,255,255,0.95)_48%,transparent)] blur-[2px] mix-blend-screen"
-        animate={still ? undefined : { x: ["0%", "310%"] }}
-        transition={still ? undefined : CHROME_SWEEP}
+        className="pointer-events-none absolute inset-y-0 left-[-58%] z-[1] w-[52%] -skew-x-12 bg-[linear-gradient(90deg,transparent,rgba(255,255,255,0.5)_48%,transparent)] opacity-50 blur-[3px] mix-blend-screen"
+        animate={still ? undefined : { x: hovered ? "310%" : "0%" }}
+        transition={still ? undefined : CHROME_SHIMMER}
       />
 
       <span

--- a/components/motion/button/metallic.tsx
+++ b/components/motion/button/metallic.tsx
@@ -58,7 +58,7 @@ export const MetallicButton = forwardRef<
         onHoverEnd?.(event, info);
       }}
       className={cn(
-        "group relative isolate overflow-hidden border border-transparent bg-transparent text-foreground",
+        "group relative isolate overflow-hidden border-0 bg-transparent text-foreground",
         "hover:bg-transparent hover:text-foreground",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         "shadow-[0_8px_22px_rgba(0,0,0,0.16)]",

--- a/components/motion/button/metallic.tsx
+++ b/components/motion/button/metallic.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+import { Button, type ButtonProps } from "./base";
+
+export interface MetallicButtonProps extends Omit<
+  ButtonProps,
+  "ripple" | "variant"
+> {
+  /** Stops the traveling reflection while preserving the chrome rim. */
+  paused?: boolean;
+}
+
+// A straight pass reads as a changing reflection without turning into a spinner.
+const CHROME_SWEEP = {
+  duration: 3.2,
+  ease: "easeInOut" as const,
+  repeat: Infinity,
+  repeatDelay: 0.7,
+};
+
+export const MetallicButton = forwardRef<
+  HTMLButtonElement,
+  MetallicButtonProps
+>(function MetallicButton(
+  { size = "md", paused = false, className, children, ...rest },
+  ref,
+) {
+  const reduce = useReducedMotion();
+  const still = paused || Boolean(reduce);
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size={size}
+      className={cn(
+        "group relative isolate overflow-hidden border border-transparent bg-transparent text-foreground",
+        "hover:bg-transparent hover:text-foreground",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "shadow-[0_8px_22px_rgba(0,0,0,0.16)]",
+        size === "icon" && "rounded-full",
+        className,
+      )}
+      {...rest}
+    >
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-0 rounded-[inherit] bg-[linear-gradient(105deg,#111_0%,#737373_14%,#fafafa_26%,#525252_38%,#0a0a0a_50%,#a3a3a3_64%,#fff_75%,#404040_87%,#111_100%)]"
+      />
+
+      <motion.span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-y-0 left-[-58%] z-[1] w-[58%] -skew-x-12 bg-[linear-gradient(90deg,transparent,rgba(255,255,255,0.95)_48%,transparent)] blur-[2px] mix-blend-screen"
+        animate={still ? undefined : { x: ["0%", "310%"] }}
+        transition={still ? undefined : CHROME_SWEEP}
+      />
+
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-[2px] z-[2] rounded-[inherit] bg-background transition-colors group-hover:bg-muted/40"
+      />
+
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-[2px] z-[3] rounded-[inherit] shadow-[inset_0_1px_0_rgba(255,255,255,0.28),inset_0_-1px_0_rgba(0,0,0,0.16)]"
+      />
+
+      <span className="relative z-10 inline-flex items-center justify-center gap-2">
+        {children}
+      </span>
+    </Button>
+  );
+});

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -387,6 +387,11 @@ export const previews: Record<string, ComponentType> = {
   "motion/button-magnetic": dynamic(() =>
     import("./motion/button-magnetic.preview").then((m) => m.ButtonMagneticPreview),
   ),
+  "motion/button-metallic": dynamic(() =>
+    import("./motion/button-metallic.preview").then(
+      (m) => m.ButtonMetallicPreview,
+    ),
+  ),
   "motion/expandable-control": dynamic(() =>
     import("./motion/expandable-control.preview").then(
       (m) => m.ExpandableControlPreview,

--- a/components/previews/motion/button-metallic.preview.tsx
+++ b/components/previews/motion/button-metallic.preview.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { ArrowUpRight, Sparkles } from "lucide-react";
+import { MetallicButton } from "@/components/motion/button";
+
+export function ButtonMetallicPreview() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-3 px-6 py-10">
+      <MetallicButton>
+        Continue
+        <ArrowUpRight className="size-4" />
+      </MetallicButton>
+      <MetallicButton size="sm">
+        <Sparkles className="size-3.5" />
+        Generate
+      </MetallicButton>
+      <MetallicButton size="icon" aria-label="Magic tools">
+        <Sparkles className="size-4" />
+      </MetallicButton>
+    </div>
+  );
+}

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -6,7 +6,7 @@
  */
 const COMPONENT_DATES = {
   "motion/tilt-card": { publishedAt: "2026-05-17", updatedAt: "2026-06-22" },
-  "motion/button": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
+  "motion/button": { publishedAt: "2026-05-17", updatedAt: "2026-08-25" },
   "motion/expandable-control": {
     publishedAt: "2026-08-22",
     updatedAt: "2026-08-22",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -68,8 +68,11 @@ export const registry: CategoryEntry[] = [
       {
         slug: "button",
         name: "Button",
-        description: "Spring-pressed Button plus StatefulButton (idle → loading → success / error) and MagneticButton.",
+        description:
+          "Spring-pressed Button plus StatefulButton, MagneticButton, and MetallicButton variants.",
         file: "components/motion/button/index.tsx",
+        badge: "new",
+        launchedAt: "2026-08-25",
         extraFiles: [
           "components/motion/button/base.tsx",
           "components/motion/button/stateful.tsx",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -74,6 +74,7 @@ export const registry: CategoryEntry[] = [
           "components/motion/button/base.tsx",
           "components/motion/button/stateful.tsx",
           "components/motion/button/magnetic.tsx",
+          "components/motion/button/metallic.tsx",
         ],
         examples: [
           {
@@ -102,6 +103,16 @@ export const registry: CategoryEntry[] = [
             file: "components/motion/button/magnetic.tsx",
             previewKey: "motion/button-magnetic",
             previewFile: "components/previews/motion/button-magnetic.preview.tsx",
+          },
+          {
+            slug: "metallic",
+            name: "Metallic Button",
+            description:
+              "A neutral button surface framed by a pronounced chrome rim with a straight traveling reflection.",
+            installSlug: "button-metallic",
+            file: "components/motion/button/metallic.tsx",
+            previewKey: "motion/button-metallic",
+            previewFile: "components/previews/motion/button-metallic.preview.tsx",
           },
         ],
       },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -81,6 +81,18 @@ export const registry: CategoryEntry[] = [
         ],
         examples: [
           {
+            slug: "metallic",
+            name: "Metallic Button",
+            description:
+              "A neutral button surface framed by a pronounced chrome rim with a straight traveling reflection.",
+            badge: "new",
+            launchedAt: "2026-08-25",
+            installSlug: "button-metallic",
+            file: "components/motion/button/metallic.tsx",
+            previewKey: "motion/button-metallic",
+            previewFile: "components/previews/motion/button-metallic.preview.tsx",
+          },
+          {
             slug: "base",
             name: "Button",
             description: "Press scale, hover lift, variants and sizes.",
@@ -106,16 +118,6 @@ export const registry: CategoryEntry[] = [
             file: "components/motion/button/magnetic.tsx",
             previewKey: "motion/button-magnetic",
             previewFile: "components/previews/motion/button-magnetic.preview.tsx",
-          },
-          {
-            slug: "metallic",
-            name: "Metallic Button",
-            description:
-              "A neutral button surface framed by a pronounced chrome rim with a straight traveling reflection.",
-            installSlug: "button-metallic",
-            file: "components/motion/button/metallic.tsx",
-            previewKey: "motion/button-metallic",
-            previewFile: "components/previews/motion/button-metallic.preview.tsx",
           },
         ],
       },


### PR DESCRIPTION
## Summary
- add a metallic button with a continuously moving silver rim
- add a low-intensity hover shimmer with reduced-motion support
- publish the variant through the preview and shadcn registry
- mark the Button entry and Metallic variant as newly launched

## Validation
- bun run check
- bun test (386 passing)