### PR TITLE
fix(input): prevent validation layout shifts

### DIFF
--- a/components/motion/input.tsx
+++ b/components/motion/input.tsx
@@ -38,6 +38,8 @@ export interface InputProps extends Omit<
   onChange?: (value: string) => void;
   /** Truthy error triggers a shake, red border and (if a string) a message. */
   error?: string | boolean;
+  /** Reserve one message line so validation does not shift nearby content. */
+  reserveErrorLine?: boolean;
   success?: boolean;
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
@@ -54,6 +56,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     onFocus,
     onBlur,
     error,
+    reserveErrorLine = false,
     success,
     leftIcon,
     rightIcon,
@@ -206,32 +209,34 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         ) : null}
       </div>
 
-      <AnimatePresence initial={false}>
-        {errorMessage ? (
-          <motion.p
-            id={`${id}-error`}
-            role="alert"
-            initial={
-              reduce
-                ? { opacity: 0 }
-                : { opacity: 0, y: -4, filter: "blur(4px)" }
-            }
-            animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-            exit={
-              reduce
-                ? { opacity: 0 }
-                : { opacity: 0, y: -4, filter: "blur(4px)" }
-            }
-            transition={{ duration: 0.2 }}
-            className={cn(
-              "px-1 text-xs text-destructive",
-              classNames?.errorMessage,
-            )}
-          >
-            {errorMessage}
-          </motion.p>
-        ) : null}
-      </AnimatePresence>
+      <div className={reserveErrorLine ? "min-h-4" : "contents"}>
+        <AnimatePresence initial={false}>
+          {errorMessage ? (
+            <motion.p
+              id={`${id}-error`}
+              role="alert"
+              initial={
+                reduce
+                  ? { opacity: 0 }
+                  : { opacity: 0, y: -4, filter: "blur(4px)" }
+              }
+              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+              exit={
+                reduce
+                  ? { opacity: 0 }
+                  : { opacity: 0, y: -4, filter: "blur(4px)" }
+              }
+              transition={{ duration: 0.2 }}
+              className={cn(
+                "px-1 text-xs text-destructive",
+                classNames?.errorMessage,
+              )}
+            >
+              {errorMessage}
+            </motion.p>
+          ) : null}
+        </AnimatePresence>
+      </div>
     </div>
   );
 });

--- a/components/motion/signup-form.tsx
+++ b/components/motion/signup-form.tsx
@@ -278,7 +278,7 @@ export function SignUpForm({
         </div>
       ) : null}
 
-      <div className={cn("flex flex-col gap-4", classNames?.fields)}>
+      <div className={cn("flex flex-col gap-1", classNames?.fields)}>
         <Input
           label="Name"
           autoComplete="name"
@@ -289,6 +289,7 @@ export function SignUpForm({
           onChange={(next) => setValue("name", next)}
           onBlur={() => touch("name")}
           error={shownError("name")}
+          reserveErrorLine
           success={isValid("name")}
         />
 
@@ -304,6 +305,7 @@ export function SignUpForm({
           onChange={(next) => setValue("email", next)}
           onBlur={() => touch("email")}
           error={shownError("email")}
+          reserveErrorLine
           success={isValid("email")}
         />
 
@@ -330,6 +332,7 @@ export function SignUpForm({
             onChange={(next) => setValue("password", next)}
             onBlur={() => touch("password")}
             error={shownError("password")}
+            reserveErrorLine
           />
 
           <AnimatePresence initial={false}>
@@ -383,6 +386,7 @@ export function SignUpForm({
           onChange={(next) => setValue("confirmPassword", next)}
           onBlur={() => touch("confirmPassword")}
           error={shownError("confirmPassword")}
+          reserveErrorLine
           success={isValid("confirmPassword")}
         />
       </div>

--- a/components/previews/motion/input.preview.tsx
+++ b/components/previews/motion/input.preview.tsx
@@ -14,7 +14,7 @@ export function InputPreview() {
     email.length > 0 && !email.includes("@") ? "Enter a valid email address." : undefined;
 
   return (
-    <div className="flex w-full max-w-xs flex-col gap-5">
+    <div className="flex w-full max-w-xs flex-col gap-1">
       <Input
         label="Email"
         type="email"
@@ -23,6 +23,7 @@ export function InputPreview() {
         value={email}
         onChange={setEmail}
         error={emailError}
+        reserveErrorLine
       />
       <Input
         label="Password"
@@ -39,6 +40,7 @@ export function InputPreview() {
             {show ? <EyeOff /> : <Eye />}
           </button>
         }
+        reserveErrorLine
       />
       <Input
         label="Search"
@@ -46,6 +48,7 @@ export function InputPreview() {
         value={query}
         onChange={setQuery}
         success={query.length > 1}
+        reserveErrorLine
       />
     </div>
   );

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -18,7 +18,7 @@ const COMPONENT_DATES = {
   "motion/marquee": { publishedAt: "2026-05-17", updatedAt: "2026-07-04" },
   "motion/tabs": { publishedAt: "2026-05-17", updatedAt: "2026-07-13" },
   "motion/switch": { publishedAt: "2026-05-17", updatedAt: "2026-06-10" },
-  "motion/input": { publishedAt: "2026-06-29", updatedAt: "2026-07-05" },
+  "motion/input": { publishedAt: "2026-06-29", updatedAt: "2026-08-28" },
   "motion/select": { publishedAt: "2026-06-28", updatedAt: "2026-07-13" },
   "motion/combobox": { publishedAt: "2026-08-11", updatedAt: "2026-08-22" },
   "motion/checkbox": { publishedAt: "2026-06-23", updatedAt: "2026-07-01" },
@@ -63,7 +63,7 @@ const COMPONENT_DATES = {
   },
   "agents/chat-app": {
     publishedAt: "2026-08-02",
-    updatedAt: "2026-08-22",
+    updatedAt: "2026-08-28",
   },
   "agents/message-bubble": {
     publishedAt: "2026-08-02",
@@ -83,7 +83,7 @@ const COMPONENT_DATES = {
   },
   "agents/approval-card": {
     publishedAt: "2026-08-01",
-    updatedAt: "2026-08-02",
+    updatedAt: "2026-08-28",
   },
   "agents/code-block": {
     publishedAt: "2026-08-02",
@@ -143,7 +143,7 @@ const COMPONENT_DATES = {
   "blocks/prediction-market": { publishedAt: "2026-06-18", updatedAt: "2026-06-21" },
   "blocks/wallet-card": { publishedAt: "2026-07-03", updatedAt: "2026-07-03" },
   "blocks/otp-input": { publishedAt: "2026-06-13", updatedAt: "2026-07-13" },
-  "blocks/signup-form": { publishedAt: "2026-08-08", updatedAt: "2026-08-08" },
+  "blocks/signup-form": { publishedAt: "2026-08-08", updatedAt: "2026-08-28" },
   "blocks/bloom-menu": { publishedAt: "2026-06-26", updatedAt: "2026-06-26" },
   "blocks/feedback-widget": { publishedAt: "2026-06-29", updatedAt: "2026-07-13" },
   "blocks/not-found": { publishedAt: "2026-06-21", updatedAt: "2026-06-21" },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -206,7 +206,8 @@ export const registry: CategoryEntry[] = [
       {
         slug: "input",
         name: "Input",
-        description: "Text input with label, left/right icons, error shake and success check draw.",
+        description:
+          "Text input with label, left/right icons, optional stable error row, error shake and success check draw.",
         file: "components/motion/input.tsx",
         keywords: [
           "react animated input",

--- a/tests/input.test.tsx
+++ b/tests/input.test.tsx
@@ -62,4 +62,21 @@ describe("Input", () => {
 
     expect(onChange).toHaveBeenCalledWith("beUI");
   });
+
+  test("can reserve a stable validation message row", () => {
+    const { container, getByRole, rerender } = render(
+      <Input label="Email" reserveErrorLine />,
+    );
+    const root = container.firstElementChild;
+    const messageRow = root?.lastElementChild;
+
+    expect(messageRow?.classList).toContain("min-h-4");
+
+    rerender(
+      <Input label="Email" error="Enter a valid email address." reserveErrorLine />,
+    );
+
+    expect(root?.lastElementChild).toBe(messageRow);
+    expect(getByRole("alert").textContent).toBe("Enter a valid email address.");
+  });
 });


### PR DESCRIPTION
## Summary

- Add an opt-in reserveErrorLine prop so Input can keep one validation-message row without changing the default layout.
- Use the stable row in SignUpForm and the Input preview, with compact field spacing.
- Document the public behavior, refresh affected registry dates, and cover the stable message row with a focused test.

## Verification

- bun test tests/input.test.tsx: 4 passed
- bun run check: typecheck and lint passed; 79 registry components validated
- Cypress against the real local Sign Up Form page: four field errors appeared without moving any input relative to the form; input-to-next-label gap was 27px and field-container gap was 4px.