### PR TITLE
feat: add animated multi select

### DIFF
--- a/components/motion/multi-select/content.tsx
+++ b/components/motion/multi-select/content.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { motion, type Transition } from "motion/react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { usePopoverPortalPosition } from "@/components/motion/popover-position";
+import { cn } from "@/lib/utils";
+import { useMultiSelectContext } from "./context";
+
+type Side = "top" | "bottom";
+type Align = "start" | "center" | "end";
+
+// Matches the Combobox surface: the field grows into a panel and then
+// separates, preserving a continuous spatial relationship with its trigger.
+const MULTI_SELECT_MORPH: Transition = {
+  type: "spring",
+  duration: 0.5,
+  bounce: 0.22,
+};
+const VIEWPORT_PADDING = 8;
+
+export interface MultiSelectContentProps {
+  children: ReactNode;
+  side?: Side;
+  align?: Align;
+  sideOffset?: number;
+  avoidCollisions?: boolean;
+  className?: string;
+}
+
+export function MultiSelectContent({
+  children,
+  side = "bottom",
+  align = "start",
+  sideOffset = 6,
+  avoidCollisions = true,
+  className,
+}: MultiSelectContentProps) {
+  const context = useMultiSelectContext("MultiSelectContent");
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [portalReady, setPortalReady] = useState(false);
+  const [actualSide, setActualSide] = useState<Side>(side);
+  const [morphReady, setMorphReady] = useState(false);
+  const layout = usePopoverPortalPosition(
+    context.triggerRef,
+    measureRef,
+    portalReady,
+  );
+
+  useEffect(() => setPortalReady(true), []);
+  useLayoutEffect(() => {
+    if (!portalReady) return;
+    const readyFrame = requestAnimationFrame(() => setMorphReady(true));
+    return () => cancelAnimationFrame(readyFrame);
+  }, [portalReady]);
+
+  useLayoutEffect(() => {
+    if (!context.open || !layout) return;
+    if (!avoidCollisions) {
+      setActualSide(side);
+      return;
+    }
+    const below =
+      window.innerHeight - (layout.trigger.top + layout.trigger.height);
+    const above = layout.trigger.top;
+    if (
+      side === "bottom" &&
+      below < layout.content.height + sideOffset &&
+      above > below
+    ) {
+      setActualSide("top");
+    } else if (
+      side === "top" &&
+      above < layout.content.height + sideOffset &&
+      below > above
+    ) {
+      setActualSide("bottom");
+    } else {
+      setActualSide(side);
+    }
+  }, [avoidCollisions, context.open, layout, side, sideOffset]);
+
+  if (!portalReady) return null;
+
+  const triggerLeft = layout?.trigger.left ?? 0;
+  const triggerWidth = layout?.trigger.width ?? 0;
+  const contentWidth = layout?.content.width ?? triggerWidth;
+  const desiredLeft =
+    align === "end"
+      ? triggerLeft + triggerWidth - contentWidth
+      : align === "center"
+        ? triggerLeft + (triggerWidth - contentWidth) / 2
+        : triggerLeft;
+  const maxLeft = Math.max(
+    VIEWPORT_PADDING,
+    window.innerWidth - contentWidth - VIEWPORT_PADDING,
+  );
+  const left = Math.min(Math.max(desiredLeft, VIEWPORT_PADDING), maxLeft);
+  const surfaceHeight = layout?.content.height ?? 0;
+
+  return createPortal(
+    <motion.div
+      ref={context.contentRef}
+      data-multi-select-content=""
+      data-side={actualSide}
+      aria-hidden={!context.open}
+      inert={!context.open}
+      initial={false}
+      animate={{
+        height: context.open ? surfaceHeight : 0,
+        opacity: context.open ? 1 : 0,
+        y: context.open
+          ? actualSide === "bottom"
+            ? sideOffset
+            : -sideOffset
+          : 0,
+      }}
+      transition={
+        context.reduce || !morphReady ? { duration: 0 } : MULTI_SELECT_MORPH
+      }
+      style={
+        {
+          left,
+          top:
+            actualSide === "bottom" && layout
+              ? layout.trigger.top + layout.trigger.height
+              : undefined,
+          bottom:
+            actualSide === "top" && layout
+              ? window.innerHeight - layout.trigger.top
+              : undefined,
+          minWidth: triggerWidth,
+          pointerEvents: context.open ? "auto" : "none",
+          transformOrigin: actualSide === "bottom" ? "top" : "bottom",
+          visibility: layout ? "visible" : "hidden",
+          "--multi-select-trigger-width": `${triggerWidth}px`,
+        } as CSSProperties
+      }
+      className={cn(
+        "fixed z-[9999] w-(--multi-select-trigger-width) overflow-hidden rounded-xl border border-border bg-background text-popover-foreground outline-none will-change-[height,transform]",
+        className,
+      )}
+    >
+      <motion.div
+        ref={measureRef}
+        initial={false}
+        animate={{ opacity: context.open ? 1 : 0 }}
+        transition={
+          context.reduce || !morphReady ? { duration: 0 } : MULTI_SELECT_MORPH
+        }
+      >
+        {children}
+      </motion.div>
+    </motion.div>,
+    document.body,
+  );
+}

--- a/components/motion/multi-select/context.tsx
+++ b/components/motion/multi-select/context.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import {
+  createContext,
+  type MutableRefObject,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useActiveOption } from "@/components/motion/combobox/use-active-option";
+import { cn } from "@/lib/utils";
+
+export type RegisteredMultiSelectItem = {
+  value: string;
+  label: string;
+  keywords: string[];
+  disabled: boolean;
+  groupId: string | null;
+  id: string;
+  ref: MutableRefObject<HTMLButtonElement | null>;
+};
+
+export type MultiSelectFilter = (
+  value: string,
+  query: string,
+  keywords: string[],
+) => boolean;
+
+const defaultFilter: MultiSelectFilter = (value, query, keywords) => {
+  const needle = query.trim().toLocaleLowerCase();
+  if (!needle) return true;
+
+  const haystack = [value, ...keywords].join(" ").toLocaleLowerCase();
+  let queryIndex = 0;
+  for (const character of haystack) {
+    if (character === needle[queryIndex]) queryIndex += 1;
+    if (queryIndex === needle.length) return true;
+  }
+  return false;
+};
+
+export type MultiSelectContextValue = {
+  open: boolean;
+  setOpen: (open: boolean, restoreFocus?: boolean) => void;
+  values: string[];
+  toggle: (value: string) => void;
+  remove: (value: string) => void;
+  query: string;
+  setQuery: (query: string) => void;
+  activeValue: string | null;
+  setActiveValue: (value: string | null) => void;
+  moveActive: (direction: 1 | -1 | "first" | "last") => void;
+  toggleActive: () => void;
+  registerItem: (item: RegisteredMultiSelectItem) => void;
+  unregisterItem: (value: string) => void;
+  labelFor: (value: string) => string;
+  isVisible: (value: string) => boolean;
+  hasVisibleItems: (groupId: string) => boolean;
+  visibleCount: number;
+  activeItemId: string | undefined;
+  triggerId: string;
+  listId: string;
+  inputId: string;
+  disabled: boolean;
+  reduce: boolean;
+  triggerRef: MutableRefObject<HTMLDivElement | null>;
+  contentRef: MutableRefObject<HTMLDivElement | null>;
+  inputRef: MutableRefObject<HTMLInputElement | null>;
+  activeLayoutId: string;
+};
+
+export const MultiSelectContext =
+  createContext<MultiSelectContextValue | null>(null);
+export const MultiSelectGroupContext = createContext<string | null>(null);
+
+export function useMultiSelectContext(component: string) {
+  const context = useContext(MultiSelectContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <MultiSelect>`);
+  }
+  return context;
+}
+
+export function mergeRefs<T>(...refs: Array<Ref<T> | undefined>) {
+  return (node: T | null) => {
+    for (const ref of refs) {
+      if (typeof ref === "function") ref(node);
+      else if (ref && typeof ref === "object") {
+        (ref as MutableRefObject<T | null>).current = node;
+      }
+    }
+  };
+}
+
+export interface MultiSelectProps {
+  children: ReactNode;
+  value?: string[];
+  defaultValue?: string[];
+  onValueChange?: (value: string[]) => void;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  query?: string;
+  defaultQuery?: string;
+  onQueryChange?: (query: string) => void;
+  filter?: MultiSelectFilter;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function MultiSelect({
+  children,
+  value: controlledValue,
+  defaultValue = [],
+  onValueChange,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  query: controlledQuery,
+  defaultQuery = "",
+  onQueryChange,
+  filter = defaultFilter,
+  disabled = false,
+  className,
+}: MultiSelectProps) {
+  const reduce = useReducedMotion() ?? false;
+  const baseId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const [internalQuery, setInternalQuery] = useState(defaultQuery);
+  const [items, setItems] = useState<Map<string, RegisteredMultiSelectItem>>(
+    new Map(),
+  );
+
+  const valueControlled = controlledValue !== undefined;
+  const openControlled = controlledOpen !== undefined;
+  const queryControlled = controlledQuery !== undefined;
+  const values = controlledValue ?? internalValue;
+  const open = controlledOpen ?? internalOpen;
+  const query = controlledQuery ?? internalQuery;
+
+  const updateQuery = useCallback(
+    (next: string) => {
+      if (!queryControlled) setInternalQuery(next);
+      onQueryChange?.(next);
+    },
+    [onQueryChange, queryControlled],
+  );
+
+  const updateOpen = useCallback(
+    (next: boolean, restoreFocus = false) => {
+      if (disabled && next) return;
+      if (!openControlled) setInternalOpen(next);
+      onOpenChange?.(next);
+      if (!next) updateQuery("");
+      if (restoreFocus) {
+        requestAnimationFrame(() =>
+          inputRef.current?.focus({ preventScroll: true }),
+        );
+      }
+    },
+    [disabled, onOpenChange, openControlled, updateQuery],
+  );
+
+  const registerItem = useCallback((item: RegisteredMultiSelectItem) => {
+    setItems((current) => {
+      const existing = current.get(item.value);
+      if (
+        existing?.label === item.label &&
+        existing.disabled === item.disabled &&
+        existing.id === item.id &&
+        existing.ref === item.ref &&
+        existing.groupId === item.groupId &&
+        existing.keywords.join("\u0000") === item.keywords.join("\u0000")
+      ) {
+        return current;
+      }
+      const next = new Map(current);
+      next.set(item.value, item);
+      return next;
+    });
+  }, []);
+
+  const unregisterItem = useCallback((itemValue: string) => {
+    setItems((current) => {
+      if (!current.has(itemValue)) return current;
+      const next = new Map(current);
+      next.delete(itemValue);
+      return next;
+    });
+  }, []);
+
+  const [openQuery, setOpenQuery] = useState(query);
+  if (open && openQuery !== query) setOpenQuery(query);
+  const listQuery = open ? query : openQuery;
+
+  const visibleItems = useMemo(
+    () =>
+      Array.from(items.values()).filter((item) =>
+        filter(item.value, listQuery, [item.label, ...item.keywords]),
+      ),
+    [filter, items, listQuery],
+  );
+  const enabledVisibleItems = useMemo(
+    () => visibleItems.filter((item) => !item.disabled),
+    [visibleItems],
+  );
+  const visibleValues = useMemo(
+    () => new Set(visibleItems.map((item) => item.value)),
+    [visibleItems],
+  );
+  const visibleGroupIds = useMemo(
+    () => new Set(visibleItems.map((item) => item.groupId)),
+    [visibleItems],
+  );
+
+  const { activeValue, setActiveValue, moveActive } = useActiveOption({
+    open,
+    query: listQuery,
+    value: values[0],
+    enabledItems: enabledVisibleItems,
+  });
+
+  const commitValue = useCallback(
+    (next: string[]) => {
+      if (!valueControlled) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [onValueChange, valueControlled],
+  );
+
+  const toggle = useCallback(
+    (next: string) => {
+      if (items.get(next)?.disabled) return;
+      commitValue(
+        values.includes(next)
+          ? values.filter((value) => value !== next)
+          : [...values, next],
+      );
+      updateQuery("");
+      requestAnimationFrame(() =>
+        inputRef.current?.focus({ preventScroll: true }),
+      );
+    },
+    [commitValue, items, updateQuery, values],
+  );
+
+  const remove = useCallback(
+    (itemValue: string) => {
+      if (!values.includes(itemValue)) return;
+      commitValue(values.filter((value) => value !== itemValue));
+    },
+    [commitValue, values],
+  );
+
+  const toggleActive = useCallback(() => {
+    if (activeValue) toggle(activeValue);
+  }, [activeValue, toggle]);
+
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() =>
+      inputRef.current?.focus({ preventScroll: true }),
+    );
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
+
+  useEffect(() => {
+    if (!activeValue || !open) return;
+    const item = items.get(activeValue)?.ref.current;
+    const list = item?.closest<HTMLElement>("[role='listbox']");
+    if (!item || !list) return;
+    const itemRect = item.getBoundingClientRect();
+    const listRect = list.getBoundingClientRect();
+    if (itemRect.top < listRect.top) list.scrollTop -= listRect.top - itemRect.top;
+    else if (itemRect.bottom > listRect.bottom) {
+      list.scrollTop += itemRect.bottom - listRect.bottom;
+    }
+  }, [activeValue, items, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const isInside = (target: Node) =>
+      rootRef.current?.contains(target) || contentRef.current?.contains(target);
+    const onPointerDown = (event: PointerEvent) => {
+      if (!isInside(event.target as Node)) updateOpen(false);
+    };
+    const onFocusIn = (event: FocusEvent) => {
+      if (!isInside(event.target as Node)) updateOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      updateOpen(false, true);
+    };
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("focusin", onFocusIn);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("focusin", onFocusIn);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, updateOpen]);
+
+  const activeItem = activeValue ? items.get(activeValue) : undefined;
+  const context = useMemo<MultiSelectContextValue>(
+    () => ({
+      open,
+      setOpen: updateOpen,
+      values,
+      toggle,
+      remove,
+      query,
+      setQuery: updateQuery,
+      activeValue,
+      setActiveValue,
+      moveActive,
+      toggleActive,
+      registerItem,
+      unregisterItem,
+      labelFor: (itemValue) => items.get(itemValue)?.label ?? itemValue,
+      isVisible: (itemValue) => !listQuery.trim() || visibleValues.has(itemValue),
+      hasVisibleItems: (groupId) => visibleGroupIds.has(groupId),
+      visibleCount: visibleItems.length,
+      activeItemId: activeItem?.id,
+      triggerId: `${baseId}-trigger`,
+      listId: `${baseId}-list`,
+      inputId: `${baseId}-input`,
+      disabled,
+      reduce,
+      triggerRef,
+      contentRef,
+      inputRef,
+      activeLayoutId: `${baseId}-active`,
+    }),
+    [
+      activeItem?.id,
+      activeValue,
+      baseId,
+      disabled,
+      items,
+      listQuery,
+      moveActive,
+      open,
+      query,
+      reduce,
+      registerItem,
+      remove,
+      setActiveValue,
+      toggle,
+      toggleActive,
+      unregisterItem,
+      updateOpen,
+      updateQuery,
+      values,
+      visibleGroupIds,
+      visibleItems.length,
+      visibleValues,
+    ],
+  );
+
+  return (
+    <MultiSelectContext.Provider value={context}>
+      <div ref={rootRef} className={cn("relative w-full", className)}>
+        {children}
+      </div>
+    </MultiSelectContext.Provider>
+  );
+}

--- a/components/motion/multi-select/index.tsx
+++ b/components/motion/multi-select/index.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+export {
+  MultiSelect,
+  type MultiSelectFilter,
+  type MultiSelectProps,
+} from "./context";
+export {
+  MultiSelectInput,
+  type MultiSelectInputProps,
+  MultiSelectTrigger,
+  type MultiSelectTriggerProps,
+  MultiSelectValue,
+  type MultiSelectValueProps,
+} from "./trigger";
+export {
+  MultiSelectContent,
+  type MultiSelectContentProps,
+} from "./content";
+export {
+  MultiSelectEmpty,
+  type MultiSelectEmptyProps,
+  MultiSelectGroup,
+  type MultiSelectGroupProps,
+  MultiSelectItem,
+  type MultiSelectItemProps,
+  MultiSelectLabel,
+  type MultiSelectLabelProps,
+  MultiSelectList,
+  type MultiSelectListProps,
+  MultiSelectSeparator,
+  type MultiSelectSeparatorProps,
+} from "./list";

--- a/components/motion/multi-select/list.tsx
+++ b/components/motion/multi-select/list.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { Check } from "lucide-react";
+import { motion } from "motion/react";
+import {
+  type ReactNode,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
+import { EASE_OUT, SPRING_LAYOUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+import {
+  MultiSelectGroupContext,
+  useMultiSelectContext,
+} from "./context";
+
+export interface MultiSelectListProps {
+  children: ReactNode;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function MultiSelectList({
+  children,
+  ariaLabel = "Options",
+  className,
+}: MultiSelectListProps) {
+  const context = useMultiSelectContext("MultiSelectList");
+  return (
+    <div
+      id={context.listId}
+      role="listbox"
+      aria-label={ariaLabel}
+      aria-multiselectable="true"
+      className={cn(
+        "relative isolate max-h-64 overflow-y-auto overscroll-contain p-1.5 [-ms-overflow-style:none] scrollbar-none [&::-webkit-scrollbar]:hidden",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface MultiSelectGroupProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function MultiSelectGroup({
+  children,
+  className,
+}: MultiSelectGroupProps) {
+  const context = useMultiSelectContext("MultiSelectGroup");
+  const groupId = useId();
+  return (
+    <MultiSelectGroupContext.Provider value={groupId}>
+      <fieldset
+        hidden={!context.hasVisibleItems(groupId)}
+        className={cn("m-0 min-w-0 border-0 p-0 py-0.5", className)}
+      >
+        {children}
+      </fieldset>
+    </MultiSelectGroupContext.Provider>
+  );
+}
+
+export interface MultiSelectLabelProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function MultiSelectLabel({
+  children,
+  className,
+}: MultiSelectLabelProps) {
+  const groupId = useContext(MultiSelectGroupContext);
+  const labelClassName = cn(
+    "w-full px-2 py-1.5 text-[0.68rem] font-medium uppercase tracking-[0.12em] text-muted-foreground",
+    className,
+  );
+  return groupId ? (
+    <legend className={labelClassName}>{children}</legend>
+  ) : (
+    <div className={labelClassName}>{children}</div>
+  );
+}
+
+export interface MultiSelectItemProps {
+  value: string;
+  children: ReactNode;
+  textValue?: string;
+  keywords?: string[];
+  disabled?: boolean;
+  onSelect?: (value: string) => void;
+  className?: string;
+}
+
+export function MultiSelectItem({
+  value,
+  children,
+  textValue,
+  keywords = [],
+  disabled = false,
+  onSelect,
+  className,
+}: MultiSelectItemProps) {
+  const context = useMultiSelectContext("MultiSelectItem");
+  const groupId = useContext(MultiSelectGroupContext);
+  const id = useId();
+  const itemRef = useRef<HTMLButtonElement>(null);
+  const label = textValue ?? (typeof children === "string" ? children : value);
+  const visible = context.isVisible(value);
+  const active = context.activeValue === value;
+  const selected = context.values.includes(value);
+  const keywordKey = keywords.join("\u0000");
+  const normalizedKeywords = useMemo(
+    () => (keywordKey ? keywordKey.split("\u0000") : []),
+    [keywordKey],
+  );
+  const { registerItem, unregisterItem } = context;
+
+  useLayoutEffect(() => {
+    registerItem({
+      value,
+      label,
+      keywords: normalizedKeywords,
+      disabled,
+      groupId,
+      id,
+      ref: itemRef,
+    });
+    return () => unregisterItem(value);
+  }, [
+    disabled,
+    groupId,
+    id,
+    label,
+    normalizedKeywords,
+    registerItem,
+    unregisterItem,
+    value,
+  ]);
+
+  if (!visible) return null;
+
+  return (
+    <button
+      ref={itemRef}
+      id={id}
+      type="button"
+      role="option"
+      aria-selected={selected}
+      disabled={disabled}
+      tabIndex={-1}
+      data-multi-select-item=""
+      data-active={active || undefined}
+      data-selected={selected || undefined}
+      onPointerMove={() => {
+        if (!disabled) context.setActiveValue(value);
+      }}
+      onPointerDown={(event) => event.preventDefault()}
+      onClick={() => {
+        if (disabled) return;
+        onSelect?.(value);
+        context.toggle(value);
+      }}
+      className={cn(
+        "relative flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm outline-none transition-colors duration-150",
+        active || selected ? "text-foreground" : "text-muted-foreground",
+        "disabled:pointer-events-none disabled:opacity-45",
+        className,
+      )}
+    >
+      {active ? (
+        <motion.span
+          aria-hidden="true"
+          layoutId={context.activeLayoutId}
+          className="absolute inset-0 -z-10 rounded-lg bg-muted"
+          transition={context.reduce ? { duration: 0 } : SPRING_LAYOUT}
+        />
+      ) : null}
+      <span className="min-w-0 flex-1">{children}</span>
+      <motion.span
+        aria-hidden="true"
+        initial={false}
+        animate={{
+          opacity: selected ? 1 : 0,
+          transform: selected ? "scale(1)" : "scale(0.82)",
+        }}
+        transition={
+          context.reduce ? { duration: 0 } : { duration: 0.14, ease: EASE_OUT }
+        }
+        className="grid size-5 shrink-0 place-items-center text-foreground"
+      >
+        <Check className="size-4" />
+      </motion.span>
+    </button>
+  );
+}
+
+export interface MultiSelectEmptyProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+export function MultiSelectEmpty({
+  children = "No options found.",
+  className,
+}: MultiSelectEmptyProps) {
+  const context = useMultiSelectContext("MultiSelectEmpty");
+  if (context.visibleCount > 0) return null;
+  return (
+    <div
+      role="status"
+      className={cn(
+        "px-3 py-8 text-center text-sm text-muted-foreground",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface MultiSelectSeparatorProps {
+  className?: string;
+}
+
+export function MultiSelectSeparator({
+  className,
+}: MultiSelectSeparatorProps) {
+  return (
+    <div aria-hidden="true" className={cn("-mx-1 my-1 h-px bg-border", className)} />
+  );
+}

--- a/components/motion/multi-select/trigger.tsx
+++ b/components/motion/multi-select/trigger.tsx
@@ -73,45 +73,54 @@ export function MultiSelectValue({
   chipClassName,
 }: MultiSelectValueProps) {
   const context = useMultiSelectContext("MultiSelectValue");
-
-  if (context.values.length === 0 && !context.open) {
-    return (
-      <span className={cn("text-muted-foreground", className)}>
-        {placeholder}
-      </span>
-    );
-  }
+  const showPlaceholder = context.values.length === 0 && !context.open;
 
   return (
     <div className={cn("contents", className)}>
       <AnimatePresence initial={false} mode="popLayout">
+        {showPlaceholder ? (
+          <span key="multi-select-placeholder" className="text-muted-foreground">
+            {placeholder}
+          </span>
+        ) : null}
         {context.values.map((value) => {
           const label = context.labelFor(value);
           return (
             <motion.span
               layout={context.reduce ? false : "position"}
-              key={value}
-              initial={
-                context.reduce
-                  ? false
-                  : {
-                      opacity: 0,
-                      transform: "translateY(6px) scale(0.92)",
-                    }
-              }
+              key={`multi-select-value-${value}`}
+              initial={{
+                opacity: 0,
+                clipPath: "inset(0 0 0 0% round 0.5rem)",
+                transform: context.reduce
+                  ? "translateY(0px) scale(1)"
+                  : "translateY(6px) scale(0.92)",
+              }}
               animate={{
                 opacity: 1,
+                clipPath: "inset(0 0 0 0% round 0.5rem)",
                 transform: "translateY(0px) scale(1)",
               }}
               exit={{
-                opacity: 0,
-                transform: context.reduce
-                  ? "translateY(0px) scale(1)"
-                  : "translateY(-2px) scale(0.97)",
+                opacity: 1,
+                clipPath: context.reduce
+                  ? "inset(0 0 0 0% round 0.5rem)"
+                  : "inset(0 0 0 100% round 0.5rem)",
+                transform: "translateY(0px) scale(1)",
+                transition: {
+                  clipPath: context.reduce
+                    ? { duration: 0 }
+                    : { duration: 0.16, ease: EASE_OUT },
+                  transform: { duration: 0 },
+                },
               }}
               transition={
                 context.reduce
-                  ? { duration: 0 }
+                  ? {
+                      layout: { duration: 0 },
+                      opacity: { duration: 0.15, ease: EASE_OUT },
+                      transform: { duration: 0 },
+                    }
                   : {
                       layout: SPRING_LAYOUT,
                       opacity: { duration: 0.18, ease: EASE_OUT },

--- a/components/motion/multi-select/trigger.tsx
+++ b/components/motion/multi-select/trigger.tsx
@@ -8,7 +8,7 @@ import type {
   ReactNode,
   Ref,
 } from "react";
-import { EASE_OUT } from "@/lib/ease";
+import { EASE_OUT, SPRING_LAYOUT, SPRING_SWAP } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 import { mergeRefs, useMultiSelectContext } from "./context";
 
@@ -96,7 +96,7 @@ export function MultiSelectValue({
                   ? false
                   : {
                       opacity: 0,
-                      transform: "translateY(4px) scale(0.96)",
+                      transform: "translateY(6px) scale(0.92)",
                     }
               }
               animate={{
@@ -107,12 +107,16 @@ export function MultiSelectValue({
                 opacity: 0,
                 transform: context.reduce
                   ? "translateY(0px) scale(1)"
-                  : "translateY(-4px) scale(0.96)",
+                  : "translateY(-2px) scale(0.97)",
               }}
               transition={
                 context.reduce
                   ? { duration: 0 }
-                  : { duration: 0.16, ease: EASE_OUT }
+                  : {
+                      layout: SPRING_LAYOUT,
+                      opacity: { duration: 0.18, ease: EASE_OUT },
+                      transform: SPRING_SWAP,
+                    }
               }
               className={cn(
                 "inline-flex h-7 max-w-full items-center gap-1 rounded-lg bg-muted px-2 text-xs font-medium text-foreground",

--- a/components/motion/multi-select/trigger.tsx
+++ b/components/motion/multi-select/trigger.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { ChevronsUpDown, Search, X } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import type {
+  InputHTMLAttributes,
+  KeyboardEvent as ReactKeyboardEvent,
+  ReactNode,
+  Ref,
+} from "react";
+import { EASE_OUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+import { mergeRefs, useMultiSelectContext } from "./context";
+
+export interface MultiSelectTriggerProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function MultiSelectTrigger({
+  children,
+  className,
+}: MultiSelectTriggerProps) {
+  const context = useMultiSelectContext("MultiSelectTrigger");
+
+  return (
+    <div
+      ref={context.triggerRef}
+      id={context.triggerId}
+      data-state={context.open ? "open" : "closed"}
+      onPointerDown={(event) => {
+        const target = event.target as HTMLElement;
+        if (
+          context.disabled ||
+          target === context.inputRef.current ||
+          target.closest("[data-multi-select-remove]")
+        ) {
+          return;
+        }
+        event.preventDefault();
+        context.inputRef.current?.focus({ preventScroll: true });
+        context.setOpen(true);
+      }}
+      className={cn(
+        "relative z-20 flex min-h-11 w-full min-w-52 cursor-text items-center gap-2 rounded-xl border border-border bg-transparent px-2.5 py-1.5 text-sm text-foreground transition-[border-color] hover:border-(--color-border-strong)",
+        "focus-within:ring-2 focus-within:ring-foreground/20",
+        context.disabled && "pointer-events-none opacity-50",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+        {children}
+      </div>
+      <ChevronsUpDown
+        aria-hidden="true"
+        className="size-4 shrink-0 text-muted-foreground"
+      />
+    </div>
+  );
+}
+
+export interface MultiSelectValueProps {
+  placeholder?: ReactNode;
+  children?: (value: string, label: string) => ReactNode;
+  className?: string;
+  chipClassName?: string;
+}
+
+export function MultiSelectValue({
+  placeholder = "Select options",
+  children,
+  className,
+  chipClassName,
+}: MultiSelectValueProps) {
+  const context = useMultiSelectContext("MultiSelectValue");
+
+  if (context.values.length === 0 && !context.open) {
+    return (
+      <span className={cn("text-muted-foreground", className)}>
+        {placeholder}
+      </span>
+    );
+  }
+
+  return (
+    <div className={cn("contents", className)}>
+      <AnimatePresence initial={false} mode="popLayout">
+        {context.values.map((value) => {
+          const label = context.labelFor(value);
+          return (
+            <motion.span
+              layout={context.reduce ? false : "position"}
+              key={value}
+              initial={
+                context.reduce
+                  ? false
+                  : {
+                      opacity: 0,
+                      transform: "translateY(4px) scale(0.96)",
+                    }
+              }
+              animate={{
+                opacity: 1,
+                transform: "translateY(0px) scale(1)",
+              }}
+              exit={{
+                opacity: 0,
+                transform: context.reduce
+                  ? "translateY(0px) scale(1)"
+                  : "translateY(-4px) scale(0.96)",
+              }}
+              transition={
+                context.reduce
+                  ? { duration: 0 }
+                  : { duration: 0.16, ease: EASE_OUT }
+              }
+              className={cn(
+                "inline-flex h-7 max-w-full items-center gap-1 rounded-lg bg-muted px-2 text-xs font-medium text-foreground",
+                chipClassName,
+              )}
+            >
+              <span className="truncate">
+                {children ? children(value, label) : label}
+              </span>
+              <button
+                type="button"
+                data-multi-select-remove=""
+                aria-label={`Remove ${label}`}
+                disabled={context.disabled}
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  context.remove(value);
+                  context.inputRef.current?.focus({ preventScroll: true });
+                }}
+                className="-mr-1 grid size-5 shrink-0 place-items-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <X aria-hidden="true" className="size-3" />
+              </button>
+            </motion.span>
+          );
+        })}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export interface MultiSelectInputProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    "defaultValue" | "value"
+  > {
+  ref?: Ref<HTMLInputElement>;
+  showIcon?: boolean;
+}
+
+export function MultiSelectInput({
+  ref,
+  className,
+  "aria-label": ariaLabel = "Search options",
+  onChange,
+  onClick,
+  onFocus,
+  onKeyDown,
+  onPointerDown,
+  placeholder = "Search…",
+  showIcon = false,
+  ...props
+}: MultiSelectInputProps) {
+  const context = useMultiSelectContext("MultiSelectInput");
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+
+    if (event.key === "Backspace" && !context.query && context.values.length) {
+      event.preventDefault();
+      context.remove(context.values.at(-1) ?? "");
+    } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (!context.open) {
+        context.setOpen(true);
+        return;
+      }
+      context.moveActive(event.key === "ArrowDown" ? 1 : -1);
+    } else if (event.key === "Home" && context.open) {
+      event.preventDefault();
+      context.moveActive("first");
+    } else if (event.key === "End" && context.open) {
+      event.preventDefault();
+      context.moveActive("last");
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      if (context.open) context.toggleActive();
+      else context.setOpen(true);
+    } else if (event.key === "Escape" && context.open) {
+      event.preventDefault();
+      context.setOpen(false, true);
+    }
+  };
+
+  return (
+    <div className="flex min-w-20 flex-1 items-center gap-1.5">
+      {showIcon ? (
+        <Search aria-hidden="true" className="size-3.5 text-muted-foreground" />
+      ) : null}
+      <input
+        {...props}
+        ref={mergeRefs(ref, context.inputRef)}
+        id={context.inputId}
+        role="combobox"
+        aria-label={ariaLabel}
+        aria-autocomplete="list"
+        aria-expanded={context.open}
+        aria-controls={context.listId}
+        aria-activedescendant={
+          context.open ? context.activeItemId : undefined
+        }
+        autoComplete="off"
+        disabled={context.disabled}
+        value={context.query}
+        placeholder={context.values.length ? "" : placeholder}
+        onPointerDown={(event) => {
+          onPointerDown?.(event);
+          if (event.defaultPrevented || context.open) return;
+          context.setOpen(true);
+        }}
+        onFocus={(event) => {
+          context.setOpen(true);
+          onFocus?.(event);
+        }}
+        onClick={(event) => {
+          context.setOpen(true);
+          onClick?.(event);
+        }}
+        onChange={(event) => {
+          context.setOpen(true);
+          context.setQuery(event.target.value);
+          onChange?.(event);
+        }}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          "h-7 min-w-12 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed",
+          className,
+        )}
+      />
+    </div>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -298,6 +298,9 @@ export const previews: Record<string, ComponentType> = {
   "motion/combobox": dynamic(() =>
     import("./motion/combobox.preview").then((m) => m.ComboboxPreview),
   ),
+  "motion/multi-select": dynamic(() =>
+    import("./motion/multi-select.preview").then((m) => m.MultiSelectPreview),
+  ),
   "motion/checkbox": dynamic(() =>
     import("./motion/checkbox.preview").then((m) => m.CheckboxPreview),
   ),

--- a/components/previews/motion/multi-select.preview.tsx
+++ b/components/previews/motion/multi-select.preview.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Circle } from "lucide-react";
+import {
+  MultiSelect,
+  MultiSelectContent,
+  MultiSelectEmpty,
+  MultiSelectGroup,
+  MultiSelectInput,
+  MultiSelectItem,
+  MultiSelectLabel,
+  MultiSelectList,
+  MultiSelectTrigger,
+  MultiSelectValue,
+} from "@/components/motion/multi-select";
+
+const colors = {
+  design: "fill-rose-500 text-rose-500",
+  engineering: "fill-sky-500 text-sky-500",
+  product: "fill-amber-500 text-amber-500",
+  research: "fill-violet-500 text-violet-500",
+  marketing: "fill-emerald-500 text-emerald-500",
+  operations: "fill-slate-500 text-slate-500",
+};
+
+function Option({
+  value,
+  children,
+}: {
+  value: keyof typeof colors;
+  children: string;
+}) {
+  return (
+    <MultiSelectItem value={value} textValue={children}>
+      <span className="flex items-center gap-2.5">
+        <Circle aria-hidden="true" className={`size-2.5 ${colors[value]}`} />
+        {children}
+      </span>
+    </MultiSelectItem>
+  );
+}
+
+export function MultiSelectPreview() {
+  return (
+    <div className="flex min-h-[420px] w-full items-start justify-center px-4 pt-24">
+      <div className="w-full max-w-sm">
+        <MultiSelect defaultValue={["design", "engineering"]}>
+          <MultiSelectTrigger>
+            <MultiSelectValue placeholder="Choose teams" />
+            <MultiSelectInput aria-label="Search teams" />
+          </MultiSelectTrigger>
+          <MultiSelectContent>
+            <MultiSelectList ariaLabel="Teams">
+              <MultiSelectGroup>
+                <MultiSelectLabel>Product teams</MultiSelectLabel>
+                <Option value="design">Design</Option>
+                <Option value="engineering">Engineering</Option>
+                <Option value="product">Product</Option>
+                <Option value="research">Research</Option>
+              </MultiSelectGroup>
+              <MultiSelectGroup>
+                <MultiSelectLabel>Business teams</MultiSelectLabel>
+                <Option value="marketing">Marketing</Option>
+                <Option value="operations">Operations</Option>
+              </MultiSelectGroup>
+              <MultiSelectEmpty>No teams found.</MultiSelectEmpty>
+            </MultiSelectList>
+          </MultiSelectContent>
+        </MultiSelect>
+      </div>
+    </div>
+  );
+}

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -21,6 +21,7 @@ const COMPONENT_DATES = {
   "motion/input": { publishedAt: "2026-06-29", updatedAt: "2026-08-28" },
   "motion/select": { publishedAt: "2026-06-28", updatedAt: "2026-07-13" },
   "motion/combobox": { publishedAt: "2026-08-11", updatedAt: "2026-08-22" },
+  "motion/multi-select": { publishedAt: "2026-08-29", updatedAt: "2026-08-29" },
   "motion/checkbox": { publishedAt: "2026-06-23", updatedAt: "2026-07-01" },
   "motion/radio": { publishedAt: "2026-06-23", updatedAt: "2026-07-13" },
   "motion/bottom-sheet": { publishedAt: "2026-05-17", updatedAt: "2026-08-20" },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -264,6 +264,29 @@ export const registry: CategoryEntry[] = [
         ],
       },
       {
+        slug: "multi-select",
+        name: "Multi Select",
+        description:
+          "Composable multi-select primitives with searchable options, removable animated tokens, and a morphing collision-aware panel.",
+        file: "components/motion/multi-select/index.tsx",
+        badge: "new",
+        launchedAt: "2026-08-29",
+        extraFiles: [
+          "components/motion/multi-select/context.tsx",
+          "components/motion/multi-select/trigger.tsx",
+          "components/motion/multi-select/content.tsx",
+          "components/motion/multi-select/list.tsx",
+        ],
+        keywords: [
+          "react multi select",
+          "animated multi select",
+          "searchable multi select",
+          "tag picker react",
+          "multiple combobox",
+          "composable listbox",
+        ],
+      },
+      {
         slug: "checkbox",
         name: "Checkbox",
         description:

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -60,6 +60,15 @@ import {
 import { Marquee } from "@/components/motion/marquee";
 import { MorphingModal } from "@/components/motion/morphing-modal";
 import { MorphingSearch } from "@/components/motion/morphing-search";
+import {
+  MultiSelect,
+  MultiSelectContent,
+  MultiSelectInput,
+  MultiSelectItem,
+  MultiSelectList,
+  MultiSelectTrigger,
+  MultiSelectValue,
+} from "@/components/motion/multi-select";
 import { Parallax } from "@/components/motion/parallax";
 import {
   Popover,
@@ -99,6 +108,23 @@ afterEach(cleanup);
 // no violations. Add a row here when you ship a new interactive component.
 // Render thunks (not bare JSX) keep these out of an iterable literal.
 const cases: Array<[name: string, render: () => ReactElement]> = [
+  [
+    "MultiSelect",
+    () => (
+      <MultiSelect defaultValue={["design"]}>
+        <MultiSelectTrigger>
+          <MultiSelectValue placeholder="Choose teams" />
+          <MultiSelectInput />
+        </MultiSelectTrigger>
+        <MultiSelectContent>
+          <MultiSelectList>
+            <MultiSelectItem value="design">Design</MultiSelectItem>
+            <MultiSelectItem value="engineering">Engineering</MultiSelectItem>
+          </MultiSelectList>
+        </MultiSelectContent>
+      </MultiSelect>
+    ),
+  ],
   [
     "FileTree",
     () => (


### PR DESCRIPTION
## Summary

- add composable, searchable Multi Select primitives with controlled and uncontrolled state
- reuse the Combobox-style portalled, collision-aware morphing panel and keyboard navigation
- animate selected pill entry, removal, and shared layout movement with reduced-motion support
- add the component preview, registry metadata, launch date, and shared accessibility coverage

## Validation

- `bun run check`
- `bun test` (389 passed)
- `bun test tests/a11y.test.tsx` (72 passed)
- `git diff --check`