### PR TITLE
feat: add adaptive stepper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `tilt-card` | `components/motion/tilt-card.tsx` | 3D perspective tilt on hover with cursor-tracked glare |
 | `button` | `components/motion/button/` | Spring-pressed `Button` (optional `ripple` prop for a Material-style press ripple), `StatefulButton` (idle/loading/success/error), `MagneticButton` |
 | `expandable-control` | `components/motion/expandable-control.tsx` | Click-to-expand `ExpandableButton` and `ExpandableChip` controls that reveal a label or trailing action with layout continuity; controlled/uncontrolled, reduced-motion safe |
+| `adaptive-stepper` | `components/motion/adaptive-stepper.tsx` | Composable numeric stepper whose fixed footprint adapts at its bounds: the unavailable action exits while the value surface expands into its space; controlled/uncontrolled, keyboard focus handoff, reduced-motion safe |
 | `marquee` | `components/motion/marquee.tsx` | Infinite horizontal or vertical scroll, pause-on-hover |
 | `tabs` | `components/motion/tabs.tsx` | Pill, segment or underline tabs with spring layoutId indicator |
 | `switch` | `components/motion/switch.tsx` | Toggle with spring-driven thumb and press feedback |

--- a/components/app/docs/props-table.tsx
+++ b/components/app/docs/props-table.tsx
@@ -17,7 +17,7 @@ export function PropsTable({ docs }: { docs: ComponentPropsDoc[] }) {
             {doc.props.map((prop) => (
               <div
                 key={prop.name}
-                className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-[140px_minmax(0,1fr)_100px] sm:gap-4"
+                className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-[140px_minmax(160px,0.75fr)_minmax(240px,2fr)] sm:gap-4"
               >
                 <code className="h-fit w-fit rounded-md bg-foreground/5 px-2 py-0.5 font-mono text-[11px] text-foreground">
                   {prop.name}
@@ -33,9 +33,8 @@ export function PropsTable({ docs }: { docs: ComponentPropsDoc[] }) {
                     </p>
                   ) : null}
                 </div>
-                {/* Grid items size to their min-content by default, so a long
-                    default value would push its chip out of the last track and
-                    paint over the type column. Let it wrap inside the track. */}
+                {/* Give verbose defaults the widest track and let them wrap
+                    without pushing into the type column. */}
                 <code className="h-fit w-fit min-w-0 wrap-anywhere rounded-md bg-foreground/5 px-2 py-0.5 font-mono text-[11px] text-foreground sm:justify-self-end">
                   {prop.defaultValue ?? "—"}
                 </code>

--- a/components/motion/adaptive-stepper.tsx
+++ b/components/motion/adaptive-stepper.tsx
@@ -306,7 +306,7 @@ function StepperAction({
           }
           style={{ ...style, gridColumn: direction === -1 ? "1" : "3" }}
           className={cn(
-            "relative z-10 grid size-12 place-items-center rounded-2xl border border-border bg-background text-foreground shadow-sm outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+            "relative z-10 grid size-12 place-items-center rounded-full border border-border bg-background text-foreground outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
             className,
           )}
           onClick={(event) => {
@@ -366,7 +366,7 @@ export function AdaptiveStepperValue({
       transition={context.reduce ? { duration: 0 } : SPRING_LAYOUT}
       style={{ ...style, gridColumn }}
       className={cn(
-        "relative z-0 flex h-12 min-w-0 items-center justify-center overflow-hidden rounded-2xl border border-border bg-background px-4 text-lg font-semibold tabular-nums text-foreground shadow-sm",
+        "relative z-0 flex h-12 min-w-0 items-center justify-center overflow-hidden rounded-full border border-border bg-background px-4 text-lg font-semibold tabular-nums text-foreground",
         className,
       )}
     >

--- a/components/motion/adaptive-stepper.tsx
+++ b/components/motion/adaptive-stepper.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import { Minus, Plus } from "lucide-react";
+import {
+  AnimatePresence,
+  type HTMLMotionProps,
+  motion,
+  useReducedMotion,
+} from "motion/react";
+import {
+  createContext,
+  type MouseEvent,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { EASE_OUT, SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+type StepDirection = -1 | 0 | 1;
+
+type AdaptiveStepperContextValue = {
+  value: number;
+  valueText: string;
+  direction: StepDirection;
+  atMin: boolean;
+  atMax: boolean;
+  disabled: boolean;
+  reduce: boolean;
+  decrement: (restoreFocus: boolean) => void;
+  increment: (restoreFocus: boolean) => void;
+  decrementRef: React.MutableRefObject<HTMLButtonElement | null>;
+  incrementRef: React.MutableRefObject<HTMLButtonElement | null>;
+};
+
+const AdaptiveStepperContext = createContext<AdaptiveStepperContextValue | null>(
+  null,
+);
+
+function useAdaptiveStepperContext(component: string) {
+  const context = useContext(AdaptiveStepperContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <AdaptiveStepper>`);
+  }
+  return context;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function cleanNumber(value: number) {
+  return Number(value.toFixed(10));
+}
+
+function nextStep(
+  value: number,
+  direction: -1 | 1,
+  min: number,
+  max: number,
+  step: number,
+) {
+  if (direction === 1) {
+    const nextIndex = Math.floor((value - min) / step + 1e-10) + 1;
+    return cleanNumber(Math.min(max, min + nextIndex * step));
+  }
+
+  const previousIndex = Math.ceil((value - min) / step - 1e-10) - 1;
+  return cleanNumber(Math.max(min, min + previousIndex * step));
+}
+
+function mergeRefs<T>(...refs: Array<Ref<T> | undefined>) {
+  return (node: T | null) => {
+    for (const ref of refs) {
+      if (typeof ref === "function") ref(node);
+      else if (ref && typeof ref === "object") {
+        (ref as React.MutableRefObject<T | null>).current = node;
+      }
+    }
+  };
+}
+
+export interface AdaptiveStepperProps {
+  children: ReactNode;
+  value?: number;
+  defaultValue?: number;
+  onValueChange?: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  name?: string;
+  formatValueText?: (value: number) => string;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function AdaptiveStepper({
+  children,
+  value: controlledValue,
+  defaultValue = 0,
+  onValueChange,
+  min = 0,
+  max = 10,
+  step = 1,
+  disabled = false,
+  name,
+  formatValueText,
+  className,
+  "aria-label": ariaLabel = "Quantity",
+}: AdaptiveStepperProps) {
+  const reduce = useReducedMotion() ?? false;
+  const labelId = useId();
+  const decrementRef = useRef<HTMLButtonElement>(null);
+  const incrementRef = useRef<HTMLButtonElement>(null);
+  const lower = Number.isFinite(min) ? min : 0;
+  const suppliedMax = Number.isFinite(max) ? max : lower;
+  const upper = suppliedMax > lower ? suppliedMax : lower;
+  const stride = Number.isFinite(step) && step > 0 ? step : 1;
+  const [internalValue, setInternalValue] = useState(() =>
+    clamp(Number.isFinite(defaultValue) ? defaultValue : lower, lower, upper),
+  );
+  const controlled = controlledValue !== undefined;
+  const suppliedValue = controlled ? controlledValue : internalValue;
+  const currentValue = clamp(
+    Number.isFinite(suppliedValue) ? suppliedValue : lower,
+    lower,
+    upper,
+  );
+  const previousValueRef = useRef(currentValue);
+  const currentValueRef = useRef(currentValue);
+  const direction: StepDirection =
+    currentValue === previousValueRef.current
+      ? 0
+      : currentValue > previousValueRef.current
+        ? 1
+        : -1;
+
+  useLayoutEffect(() => {
+    previousValueRef.current = currentValue;
+    currentValueRef.current = currentValue;
+  }, [currentValue]);
+
+  const commit = useCallback(
+    (nextValue: number, restoreFocus: boolean) => {
+      const next = clamp(cleanNumber(nextValue), lower, upper);
+      if (next === currentValue) return;
+      if (!controlled) setInternalValue(next);
+      onValueChange?.(next);
+
+      if (!restoreFocus) return;
+      requestAnimationFrame(() => {
+        if (next === upper && currentValueRef.current === upper) {
+          decrementRef.current?.focus();
+        } else if (next === lower && currentValueRef.current === lower) {
+          incrementRef.current?.focus();
+        }
+      });
+    },
+    [controlled, currentValue, lower, onValueChange, upper],
+  );
+
+  const decrement = useCallback(
+    (restoreFocus: boolean) => {
+      if (disabled || currentValue <= lower) return;
+      commit(nextStep(currentValue, -1, lower, upper, stride), restoreFocus);
+    },
+    [commit, currentValue, disabled, lower, stride, upper],
+  );
+
+  const increment = useCallback(
+    (restoreFocus: boolean) => {
+      if (disabled || currentValue >= upper) return;
+      commit(nextStep(currentValue, 1, lower, upper, stride), restoreFocus);
+    },
+    [commit, currentValue, disabled, lower, stride, upper],
+  );
+
+  const valueText = formatValueText?.(currentValue) ?? String(currentValue);
+  const context = useMemo<AdaptiveStepperContextValue>(
+    () => ({
+      value: currentValue,
+      valueText,
+      direction,
+      atMin: currentValue <= lower,
+      atMax: currentValue >= upper,
+      disabled,
+      reduce,
+      decrement,
+      increment,
+      decrementRef,
+      incrementRef,
+    }),
+    [
+      currentValue,
+      decrement,
+      direction,
+      disabled,
+      increment,
+      lower,
+      reduce,
+      upper,
+      valueText,
+    ],
+  );
+
+  return (
+    <AdaptiveStepperContext.Provider value={context}>
+      <fieldset
+        disabled={disabled}
+        className={cn(
+          "relative m-0 inline-grid h-12 w-[12.5rem] grid-cols-[3rem_5.5rem_3rem] items-stretch gap-2 border-0 p-0",
+          className,
+        )}
+      >
+        <legend id={labelId} className="sr-only">
+          {ariaLabel}. Current value: {valueText}
+        </legend>
+        {children}
+        {name ? <input type="hidden" name={name} value={currentValue} /> : null}
+      </fieldset>
+    </AdaptiveStepperContext.Provider>
+  );
+}
+
+export interface AdaptiveStepperActionProps
+  extends Omit<HTMLMotionProps<"button">, "children" | "onClick"> {
+  children?: ReactNode;
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  ref?: Ref<HTMLButtonElement>;
+}
+
+function StepperAction({
+  direction,
+  children,
+  className,
+  onClick,
+  ref,
+  style,
+  "aria-label": ariaLabel,
+  ...props
+}: AdaptiveStepperActionProps & { direction: -1 | 1 }) {
+  const context = useAdaptiveStepperContext("AdaptiveStepper action");
+  const hidden = direction === -1 ? context.atMin : context.atMax;
+  const actionRef =
+    direction === -1 ? context.decrementRef : context.incrementRef;
+  const label =
+    ariaLabel ?? (direction === -1 ? "Decrease value" : "Increase value");
+  const action = direction === -1 ? context.decrement : context.increment;
+
+  return (
+    <AnimatePresence initial={false} mode="popLayout">
+      {!hidden ? (
+        <motion.button
+          {...props}
+          ref={mergeRefs(ref, actionRef)}
+          key={direction === -1 ? "decrement" : "increment"}
+          layout
+          type="button"
+          aria-label={label}
+          disabled={context.disabled}
+          initial={
+            context.reduce
+              ? { opacity: 0 }
+              : {
+                  opacity: 0,
+                  filter: "blur(6px)",
+                  transform: "scale(0.92)",
+                }
+          }
+          animate={{
+            opacity: 1,
+            filter: "blur(0px)",
+            transform: "scale(1)",
+          }}
+          exit={
+            context.reduce
+              ? { opacity: 0, transition: { duration: 0.12, ease: EASE_OUT } }
+              : {
+                  opacity: 0,
+                  filter: "blur(6px)",
+                  transform: "scale(0.92)",
+                  transition: { duration: 0.12, ease: EASE_OUT },
+                }
+          }
+          whileTap={
+            context.reduce || context.disabled
+              ? undefined
+              : { transform: "scale(0.94)" }
+          }
+          transition={
+            context.reduce
+              ? { duration: 0 }
+              : {
+                  layout: SPRING_LAYOUT,
+                  opacity: { duration: 0.16, ease: EASE_OUT },
+                  filter: { duration: 0.16, ease: EASE_OUT },
+                  transform: SPRING_PRESS,
+                }
+          }
+          style={{ ...style, gridColumn: direction === -1 ? "1" : "3" }}
+          className={cn(
+            "relative z-10 grid size-12 place-items-center rounded-2xl border border-border bg-background text-foreground shadow-sm outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+            className,
+          )}
+          onClick={(event) => {
+            onClick?.(event);
+            if (!event.defaultPrevented) action(event.detail === 0);
+          }}
+        >
+          <span aria-hidden="true">
+            {children ??
+              (direction === -1 ? (
+                <Minus className="size-5" strokeWidth={2.5} />
+              ) : (
+                <Plus className="size-5" strokeWidth={2.5} />
+              ))}
+          </span>
+        </motion.button>
+      ) : null}
+    </AnimatePresence>
+  );
+}
+
+export function AdaptiveStepperDecrement(props: AdaptiveStepperActionProps) {
+  return <StepperAction {...props} direction={-1} />;
+}
+
+export interface AdaptiveStepperValueProps
+  extends Omit<HTMLMotionProps<"output">, "children"> {
+  children?: ReactNode | ((value: number) => ReactNode);
+}
+
+export function AdaptiveStepperValue({
+  children,
+  className,
+  style,
+  ...props
+}: AdaptiveStepperValueProps) {
+  const context = useAdaptiveStepperContext("AdaptiveStepperValue");
+  const gridColumn =
+    context.atMin && context.atMax
+      ? "1 / 4"
+      : context.atMin
+        ? "1 / 3"
+        : context.atMax
+          ? "2 / 4"
+          : "2";
+  const displayValue =
+    typeof children === "function" ? children(context.value) : children;
+  const enterFrom = context.direction >= 0 ? "65%" : "-65%";
+  const exitTo = context.direction >= 0 ? "-65%" : "65%";
+
+  return (
+    <motion.output
+      {...props}
+      layout
+      aria-live="polite"
+      aria-atomic="true"
+      transition={context.reduce ? { duration: 0 } : SPRING_LAYOUT}
+      style={{ ...style, gridColumn }}
+      className={cn(
+        "relative z-0 flex h-12 min-w-0 items-center justify-center overflow-hidden rounded-2xl border border-border bg-background px-4 text-lg font-semibold tabular-nums text-foreground shadow-sm",
+        className,
+      )}
+    >
+      <span className="sr-only">{context.valueText}</span>
+      <span aria-hidden="true" className="relative grid place-items-center">
+        <AnimatePresence initial={false} mode="popLayout">
+          <motion.span
+            key={context.value}
+            initial={
+              context.reduce
+                ? { opacity: 0 }
+                : {
+                    opacity: 0,
+                    filter: "blur(4px)",
+                    transform: `translateY(${enterFrom})`,
+                  }
+            }
+            animate={{
+              opacity: 1,
+              filter: "blur(0px)",
+              transform: "translateY(0%)",
+            }}
+            exit={
+              context.reduce
+                ? { opacity: 0 }
+                : {
+                    opacity: 0,
+                    filter: "blur(4px)",
+                    transform: `translateY(${exitTo})`,
+                  }
+            }
+            transition={{ duration: 0.18, ease: EASE_OUT }}
+            className="col-start-1 row-start-1"
+          >
+            {displayValue ?? context.value}
+          </motion.span>
+        </AnimatePresence>
+      </span>
+    </motion.output>
+  );
+}
+
+export function AdaptiveStepperIncrement(props: AdaptiveStepperActionProps) {
+  return <StepperAction {...props} direction={1} />;
+}

--- a/components/motion/adaptive-stepper.tsx
+++ b/components/motion/adaptive-stepper.tsx
@@ -37,9 +37,12 @@ const STEPPER_LIQUID_TRANSITION = {
   ease: [0.22, 1.3, 0.71, 1],
 } as const satisfies LiquidTransition;
 
+type StepDirection = -1 | 0 | 1;
+
 type AdaptiveStepperContextValue = {
   value: number;
   valueText: string;
+  direction: StepDirection;
   atMin: boolean;
   atMax: boolean;
   disabled: boolean;
@@ -144,9 +147,17 @@ export function AdaptiveStepper({
     lower,
     upper,
   );
+  const previousValueRef = useRef(currentValue);
   const currentValueRef = useRef(currentValue);
+  const direction: StepDirection =
+    currentValue === previousValueRef.current
+      ? 0
+      : currentValue > previousValueRef.current
+        ? 1
+        : -1;
 
   useLayoutEffect(() => {
+    previousValueRef.current = currentValue;
     currentValueRef.current = currentValue;
   }, [currentValue]);
 
@@ -190,6 +201,7 @@ export function AdaptiveStepper({
     () => ({
       value: currentValue,
       valueText,
+      direction,
       atMin: currentValue <= lower,
       atMax: currentValue >= upper,
       disabled,
@@ -202,6 +214,7 @@ export function AdaptiveStepper({
     [
       currentValue,
       decrement,
+      direction,
       disabled,
       increment,
       lower,
@@ -357,6 +370,11 @@ export function AdaptiveStepperValue({
   const displayValue =
     typeof children === "function" ? children(context.value) : children;
   const renderedValue = displayValue ?? context.value;
+  const canRoll =
+    typeof renderedValue === "number" || typeof renderedValue === "string";
+  const distance = context.reduce || !canRoll ? 0 : context.direction * 32;
+  const enterFrom = `translateY(${distance}%)`;
+  const exitTo = `translateY(${-distance}%)`;
 
   return (
     <LiquidItem
@@ -378,18 +396,37 @@ export function AdaptiveStepperValue({
         )}
       >
         <span className="sr-only">{context.valueText}</span>
-        <span aria-hidden="true" className="relative grid place-items-center">
+        <span
+          aria-hidden="true"
+          className="relative grid min-h-[1.1em] min-w-[1ch] place-items-center overflow-hidden leading-none"
+        >
           <AnimatePresence initial={false} mode="popLayout">
             <motion.span
               key={context.value}
-              initial={{ opacity: 0, filter: "blur(2px)" }}
-              animate={{ opacity: 1, filter: "blur(0px)" }}
-              exit={{ opacity: 0, filter: "blur(2px)" }}
+              initial={{
+                opacity: context.reduce ? 1 : 0.35,
+                filter: context.reduce ? "blur(0px)" : "blur(2px)",
+                transform: enterFrom,
+              }}
+              animate={{
+                opacity: 1,
+                filter: "blur(0px)",
+                transform: "translateY(0%)",
+              }}
+              exit={{
+                opacity: context.reduce ? 1 : 0,
+                filter: context.reduce ? "blur(0px)" : "blur(2px)",
+                transform: exitTo,
+                transition: {
+                  duration: context.reduce ? 0 : 0.12,
+                  ease: EASE_OUT,
+                },
+              }}
               transition={{
-                duration: context.reduce ? 0 : 0.15,
+                duration: context.reduce ? 0 : 0.18,
                 ease: EASE_OUT,
               }}
-              className="col-start-1 row-start-1"
+              className="col-start-1 row-start-1 will-change-[transform,filter,opacity]"
             >
               {renderedValue}
             </motion.span>

--- a/components/motion/adaptive-stepper.tsx
+++ b/components/motion/adaptive-stepper.tsx
@@ -20,15 +20,26 @@ import {
   useRef,
   useState,
 } from "react";
-import { EASE_OUT, SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
+import {
+  EASE_OUT,
+  SPRING_PRESS,
+} from "@/lib/ease";
+import {
+  Liquid,
+  LiquidItem,
+  type LiquidTransition,
+} from "@/components/motion/liquid";
 import { cn } from "@/lib/utils";
 
-type StepDirection = -1 | 0 | 1;
+// The deliberately elastic separation curve from the liquid email reference.
+const STEPPER_LIQUID_TRANSITION = {
+  duration: 600,
+  ease: [0.22, 1.3, 0.71, 1],
+} as const satisfies LiquidTransition;
 
 type AdaptiveStepperContextValue = {
   value: number;
   valueText: string;
-  direction: StepDirection;
   atMin: boolean;
   atMax: boolean;
   disabled: boolean;
@@ -133,17 +144,9 @@ export function AdaptiveStepper({
     lower,
     upper,
   );
-  const previousValueRef = useRef(currentValue);
   const currentValueRef = useRef(currentValue);
-  const direction: StepDirection =
-    currentValue === previousValueRef.current
-      ? 0
-      : currentValue > previousValueRef.current
-        ? 1
-        : -1;
 
   useLayoutEffect(() => {
-    previousValueRef.current = currentValue;
     currentValueRef.current = currentValue;
   }, [currentValue]);
 
@@ -187,7 +190,6 @@ export function AdaptiveStepper({
     () => ({
       value: currentValue,
       valueText,
-      direction,
       atMin: currentValue <= lower,
       atMax: currentValue >= upper,
       disabled,
@@ -200,7 +202,6 @@ export function AdaptiveStepper({
     [
       currentValue,
       decrement,
-      direction,
       disabled,
       increment,
       lower,
@@ -215,14 +216,21 @@ export function AdaptiveStepper({
       <fieldset
         disabled={disabled}
         className={cn(
-          "relative m-0 inline-grid h-12 w-[12.5rem] grid-cols-[3rem_5.5rem_3rem] items-stretch gap-2 border-0 p-0",
+          "relative isolate m-0 inline-block h-12 w-[13.5rem] border-0 p-0",
           className,
         )}
       >
         <legend id={labelId} className="sr-only">
           {ariaLabel}. Current value: {valueText}
         </legend>
-        {children}
+        <Liquid
+          blur={8}
+          contrast={22}
+          fill="var(--background)"
+          className="size-full"
+        >
+          {children}
+        </Liquid>
         {name ? <input type="hidden" name={name} value={currentValue} /> : null}
       </fieldset>
     </AdaptiveStepperContext.Provider>
@@ -243,6 +251,7 @@ function StepperAction({
   onClick,
   ref,
   style,
+  tabIndex,
   "aria-label": ariaLabel,
   ...props
 }: AdaptiveStepperActionProps & { direction: -1 | 1 }) {
@@ -253,78 +262,71 @@ function StepperAction({
   const label =
     ariaLabel ?? (direction === -1 ? "Decrease value" : "Increase value");
   const action = direction === -1 ? context.decrement : context.increment;
+  const x =
+    direction === -1
+      ? hidden
+        ? 32
+        : 0
+      : hidden
+        ? 136
+        : 168;
 
   return (
-    <AnimatePresence initial={false} mode="popLayout">
-      {!hidden ? (
-        <motion.button
-          {...props}
-          ref={mergeRefs(ref, actionRef)}
-          key={direction === -1 ? "decrement" : "increment"}
-          layout
-          type="button"
-          aria-label={label}
-          disabled={context.disabled}
-          initial={
-            context.reduce
-              ? { opacity: 0 }
-              : {
-                  opacity: 0,
-                  filter: "blur(6px)",
-                  transform: "scale(0.92)",
-                }
-          }
+    <LiquidItem
+      x={x}
+      y={0}
+      width={48}
+      height={48}
+      radius={24}
+      transition={STEPPER_LIQUID_TRANSITION}
+    >
+      <motion.button
+        {...props}
+        ref={mergeRefs(ref, actionRef)}
+        type="button"
+        aria-label={label}
+        aria-hidden={hidden || undefined}
+        tabIndex={hidden ? -1 : tabIndex}
+        disabled={context.disabled || hidden}
+        whileTap={
+          context.reduce || context.disabled || hidden
+            ? undefined
+            : { scale: 0.94 }
+        }
+        transition={context.reduce ? { duration: 0 } : SPRING_PRESS}
+        style={style}
+        className={cn(
+          "grid size-full place-items-center rounded-full border border-transparent bg-transparent bg-clip-padding text-foreground outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none",
+          hidden && "hover:bg-transparent",
+          context.disabled && "opacity-50",
+          className,
+        )}
+        onClick={(event) => {
+          onClick?.(event);
+          if (!event.defaultPrevented) action(event.detail === 0);
+        }}
+      >
+        <motion.span
+          aria-hidden="true"
+          initial={{
+            opacity: hidden ? 0 : 1,
+            filter: hidden ? "blur(2px)" : "blur(0px)",
+          }}
           animate={{
-            opacity: 1,
-            filter: "blur(0px)",
-            transform: "scale(1)",
+            opacity: hidden ? 0 : 1,
+            filter: hidden ? "blur(2px)" : "blur(0px)",
           }}
-          exit={
-            context.reduce
-              ? { opacity: 0, transition: { duration: 0.12, ease: EASE_OUT } }
-              : {
-                  opacity: 0,
-                  filter: "blur(6px)",
-                  transform: "scale(0.92)",
-                  transition: { duration: 0.12, ease: EASE_OUT },
-                }
-          }
-          whileTap={
-            context.reduce || context.disabled
-              ? undefined
-              : { transform: "scale(0.94)" }
-          }
-          transition={
-            context.reduce
-              ? { duration: 0 }
-              : {
-                  layout: SPRING_LAYOUT,
-                  opacity: { duration: 0.16, ease: EASE_OUT },
-                  filter: { duration: 0.16, ease: EASE_OUT },
-                  transform: SPRING_PRESS,
-                }
-          }
-          style={{ ...style, gridColumn: direction === -1 ? "1" : "3" }}
-          className={cn(
-            "relative z-10 grid size-12 place-items-center rounded-full border border-border bg-background text-foreground outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
-            className,
-          )}
-          onClick={(event) => {
-            onClick?.(event);
-            if (!event.defaultPrevented) action(event.detail === 0);
-          }}
+          transition={{ duration: context.reduce ? 0 : 0.15, ease: EASE_OUT }}
         >
-          <span aria-hidden="true">
-            {children ??
-              (direction === -1 ? (
-                <Minus className="size-5" strokeWidth={2.5} />
-              ) : (
-                <Plus className="size-5" strokeWidth={2.5} />
-              ))}
-          </span>
-        </motion.button>
-      ) : null}
-    </AnimatePresence>
+          {children ??
+            (direction === -1 ? (
+              <Minus className="size-5" strokeWidth={2.5} />
+            ) : (
+              <Plus className="size-5" strokeWidth={2.5} />
+            ))}
+        </motion.span>
+      </motion.button>
+    </LiquidItem>
   );
 }
 
@@ -344,68 +346,57 @@ export function AdaptiveStepperValue({
   ...props
 }: AdaptiveStepperValueProps) {
   const context = useAdaptiveStepperContext("AdaptiveStepperValue");
-  const gridColumn =
+  const geometry =
     context.atMin && context.atMax
-      ? "1 / 4"
+      ? { x: 0, width: 216 }
       : context.atMin
-        ? "1 / 3"
+        ? { x: 0, width: 152 }
         : context.atMax
-          ? "2 / 4"
-          : "2";
+          ? { x: 64, width: 152 }
+          : { x: 64, width: 88 };
   const displayValue =
     typeof children === "function" ? children(context.value) : children;
-  const enterFrom = context.direction >= 0 ? "65%" : "-65%";
-  const exitTo = context.direction >= 0 ? "-65%" : "65%";
+  const renderedValue = displayValue ?? context.value;
 
   return (
-    <motion.output
-      {...props}
-      layout
-      aria-live="polite"
-      aria-atomic="true"
-      transition={context.reduce ? { duration: 0 } : SPRING_LAYOUT}
-      style={{ ...style, gridColumn }}
-      className={cn(
-        "relative z-0 flex h-12 min-w-0 items-center justify-center overflow-hidden rounded-full border border-border bg-background px-4 text-lg font-semibold tabular-nums text-foreground",
-        className,
-      )}
+    <LiquidItem
+      x={geometry.x}
+      y={0}
+      width={geometry.width}
+      height={48}
+      radius={24}
+      transition={STEPPER_LIQUID_TRANSITION}
     >
-      <span className="sr-only">{context.valueText}</span>
-      <span aria-hidden="true" className="relative grid place-items-center">
-        <AnimatePresence initial={false} mode="popLayout">
-          <motion.span
-            key={context.value}
-            initial={
-              context.reduce
-                ? { opacity: 0 }
-                : {
-                    opacity: 0,
-                    filter: "blur(4px)",
-                    transform: `translateY(${enterFrom})`,
-                  }
-            }
-            animate={{
-              opacity: 1,
-              filter: "blur(0px)",
-              transform: "translateY(0%)",
-            }}
-            exit={
-              context.reduce
-                ? { opacity: 0 }
-                : {
-                    opacity: 0,
-                    filter: "blur(4px)",
-                    transform: `translateY(${exitTo})`,
-                  }
-            }
-            transition={{ duration: 0.18, ease: EASE_OUT }}
-            className="col-start-1 row-start-1"
-          >
-            {displayValue ?? context.value}
-          </motion.span>
-        </AnimatePresence>
-      </span>
-    </motion.output>
+      <motion.output
+        {...props}
+        aria-live="polite"
+        aria-atomic="true"
+        style={style}
+        className={cn(
+          "flex size-full min-w-0 items-center justify-center overflow-hidden rounded-full border border-transparent bg-transparent bg-clip-padding px-4 text-lg font-semibold tabular-nums text-foreground",
+          className,
+        )}
+      >
+        <span className="sr-only">{context.valueText}</span>
+        <span aria-hidden="true" className="relative grid place-items-center">
+          <AnimatePresence initial={false} mode="popLayout">
+            <motion.span
+              key={context.value}
+              initial={{ opacity: 0, filter: "blur(2px)" }}
+              animate={{ opacity: 1, filter: "blur(0px)" }}
+              exit={{ opacity: 0, filter: "blur(2px)" }}
+              transition={{
+                duration: context.reduce ? 0 : 0.15,
+                ease: EASE_OUT,
+              }}
+              className="col-start-1 row-start-1"
+            >
+              {renderedValue}
+            </motion.span>
+          </AnimatePresence>
+        </span>
+      </motion.output>
+    </LiquidItem>
   );
 }
 

--- a/components/motion/liquid.tsx
+++ b/components/motion/liquid.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import {
+  createContext,
+  forwardRef,
+  type HTMLAttributes,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { EASE_OUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+type LiquidContextValue = {
+  getRoot: () => HTMLDivElement | null;
+  getPortal: () => SVGGElement | null;
+};
+
+const LiquidContext = createContext<LiquidContextValue | null>(null);
+
+function useLiquidContext() {
+  const context = useContext(LiquidContext);
+  if (!context) throw new Error("LiquidItem must be used within <Liquid>");
+  return context;
+}
+
+export type LiquidEase = readonly [number, number, number, number];
+
+export type LiquidTransition = {
+  duration?: number;
+  ease?: LiquidEase;
+};
+
+export interface LiquidProps extends HTMLAttributes<HTMLDivElement> {
+  blur?: number;
+  contrast?: number;
+  fill?: string;
+  edgeColor?: string;
+  edgeOpacity?: number;
+  edgeWidth?: number;
+  filterPadding?: number;
+}
+
+export const Liquid = forwardRef<HTMLDivElement, LiquidProps>(function Liquid(
+  {
+    blur = 6,
+    contrast = 18,
+    fill = "var(--background)",
+    edgeColor = "var(--foreground)",
+    edgeOpacity = 0.08,
+    edgeWidth = 1,
+    filterPadding = 24,
+    className,
+    style,
+    children,
+    ...props
+  },
+  forwardedRef: Ref<HTMLDivElement>,
+) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const portalRef = useRef<SVGGElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const filterId = `liquid-${useId().replace(/[^a-zA-Z0-9_-]/g, "")}`;
+  const intercept = Math.round((0.5 - contrast * (5 / 12)) * 100) / 100;
+  const padding = Math.ceil(blur * 3 + filterPadding);
+
+  const setRootRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      rootRef.current = node;
+      if (typeof forwardedRef === "function") forwardedRef(node);
+      else if (forwardedRef) forwardedRef.current = node;
+    },
+    [forwardedRef],
+  );
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const measure = () => {
+      const next = {
+        width: root.offsetWidth,
+        height: root.offsetHeight,
+      };
+      setSize((current) =>
+        current.width === next.width && current.height === next.height
+          ? current
+          : next,
+      );
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, []);
+
+  const context = useMemo<LiquidContextValue>(
+    () => ({
+      getRoot: () => rootRef.current,
+      getPortal: () => portalRef.current,
+    }),
+    [],
+  );
+
+  return (
+    <div
+      {...props}
+      ref={setRootRef}
+      className={cn("relative isolate", className)}
+      style={style}
+    >
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        className="pointer-events-none absolute inset-0 z-0 size-full overflow-visible"
+      >
+        <defs>
+          <filter
+            id={filterId}
+            x={-padding}
+            y={-padding}
+            width={size.width + padding * 2}
+            height={size.height + padding * 2}
+            filterUnits="userSpaceOnUse"
+            colorInterpolationFilters="sRGB"
+          >
+            <feGaussianBlur
+              in="SourceGraphic"
+              stdDeviation={blur}
+              result="blur"
+            />
+            <feColorMatrix
+              in="blur"
+              type="matrix"
+              values={`1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 ${contrast} ${intercept}`}
+              result="goo"
+            />
+            <feComposite
+              in="SourceGraphic"
+              in2="goo"
+              operator="atop"
+              result="shape"
+            />
+            {edgeWidth > 0 ? (
+              <>
+                <feColorMatrix
+                  in="shape"
+                  type="matrix"
+                  values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 60 -29.5"
+                  result="solid-shape"
+                />
+                <feMorphology
+                  in="solid-shape"
+                  operator="erode"
+                  radius={edgeWidth}
+                  result="inset-shape"
+                />
+                <feComposite
+                  in="solid-shape"
+                  in2="inset-shape"
+                  operator="out"
+                  result="edge-mask"
+                />
+                <feFlood
+                  floodColor={edgeColor}
+                  floodOpacity={edgeOpacity}
+                  result="edge-color"
+                />
+                <feComposite
+                  in="edge-color"
+                  in2="edge-mask"
+                  operator="in"
+                  result="edge"
+                />
+                <feMerge>
+                  <feMergeNode in="shape" />
+                  <feMergeNode in="edge" />
+                </feMerge>
+              </>
+            ) : null}
+          </filter>
+        </defs>
+        <g ref={portalRef} fill={fill} filter={`url(#${filterId})`} />
+      </svg>
+      <LiquidContext.Provider value={context}>
+        {children}
+      </LiquidContext.Provider>
+    </div>
+  );
+});
+
+type LiquidBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  radius: number;
+};
+
+export interface LiquidItemProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  children: ReactNode;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  radius?: number;
+  transition?: LiquidTransition;
+}
+
+function mix(from: number, to: number, progress: number) {
+  return from + (to - from) * progress;
+}
+
+function cubicBezier([x1, y1, x2, y2]: LiquidEase) {
+  return (progress: number) => {
+    if (progress <= 0) return 0;
+    if (progress >= 1) return 1;
+
+    let lower = 0;
+    let upper = 1;
+    for (let index = 0; index < 20; index++) {
+      const time = (lower + upper) / 2;
+      const inverse = 1 - time;
+      const x =
+        3 * inverse * inverse * time * x1 +
+        3 * inverse * time * time * x2 +
+        time ** 3;
+      if (x < progress) lower = time;
+      else upper = time;
+    }
+
+    const time = (lower + upper) / 2;
+    const inverse = 1 - time;
+    return (
+      3 * inverse * inverse * time * y1 +
+      3 * inverse * time * time * y2 +
+      time ** 3
+    );
+  };
+}
+
+export function LiquidItem({
+  children,
+  x,
+  y,
+  width,
+  height,
+  radius = Math.min(width, height) / 2,
+  transition,
+  className,
+  style,
+  ...props
+}: LiquidItemProps) {
+  const context = useLiquidContext();
+  const reduce = useReducedMotion() ?? false;
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [blob, setBlob] = useState<SVGRectElement | null>(null);
+  const currentRef = useRef<LiquidBox | null>(null);
+  const duration = reduce ? 0 : (transition?.duration ?? 280);
+  const ease = transition?.ease ?? EASE_OUT;
+  const [x1, y1, x2, y2] = ease;
+
+  useLayoutEffect(() => {
+    const portal = context.getPortal();
+    if (!portal) return;
+
+    const blob = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "rect",
+    );
+    blob.setAttribute("x", "0");
+    blob.setAttribute("y", "0");
+    blob.style.transformBox = "fill-box";
+    blob.style.transformOrigin = "center";
+    blob.style.willChange = "transform";
+    portal.append(blob);
+    setBlob(blob);
+
+    return () => {
+      blob.remove();
+    };
+  }, [context]);
+
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper || !blob || !context.getRoot()) return;
+
+    const target = { x, y, width, height, radius };
+    const write = (box: LiquidBox) => {
+      // Keep the interactive surface and its filtered silhouette on the same
+      // frame so neither can visually outrun the other during a morph.
+      const transform = `translate(${box.x}px, ${box.y}px)`;
+      wrapper.style.transform = transform;
+      wrapper.style.width = `${box.width}px`;
+      wrapper.style.height = `${box.height}px`;
+      blob.style.transform = transform;
+      blob.setAttribute("width", String(box.width));
+      blob.setAttribute("height", String(box.height));
+      blob.setAttribute("rx", String(box.radius));
+    };
+
+    const from = currentRef.current;
+    if (!from || duration === 0) {
+      currentRef.current = target;
+      write(target);
+      return;
+    }
+
+    const easing = cubicBezier([x1, y1, x2, y2]);
+    const startedAt = performance.now();
+    let frame = 0;
+
+    const tick = (now: number) => {
+      const progress = Math.min(1, (now - startedAt) / duration);
+      const eased = easing(progress);
+      const current = {
+        x: mix(from.x, target.x, eased),
+        y: mix(from.y, target.y, eased),
+        width: mix(from.width, target.width, eased),
+        height: mix(from.height, target.height, eased),
+        radius: mix(from.radius, target.radius, eased),
+      };
+      currentRef.current = current;
+      write(current);
+      if (progress < 1) frame = requestAnimationFrame(tick);
+    };
+
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [blob, context, duration, height, radius, width, x, x1, x2, y, y1, y2]);
+
+  return (
+    <div
+      {...props}
+      ref={wrapperRef}
+      className={cn("absolute left-0 top-0 z-10", className)}
+      style={{ ...style, willChange: "transform, width, height" }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -403,6 +403,11 @@ export const previews: Record<string, ComponentType> = {
       (m) => m.ExpandableControlPreview,
     ),
   ),
+  "motion/adaptive-stepper": dynamic(() =>
+    import("./motion/adaptive-stepper.preview").then(
+      (m) => m.AdaptiveStepperPreview,
+    ),
+  ),
   "motion/expanding-arrow-button": dynamic(() =>
     import("./motion/expanding-arrow-button.preview").then(
       (m) => m.ExpandingArrowButtonPreview,

--- a/components/previews/motion/adaptive-stepper.preview.tsx
+++ b/components/previews/motion/adaptive-stepper.preview.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import {
+  AdaptiveStepper,
+  AdaptiveStepperDecrement,
+  AdaptiveStepperIncrement,
+  AdaptiveStepperValue,
+} from "@/components/motion/adaptive-stepper";
+
+export function AdaptiveStepperPreview() {
+  return (
+    <div className="flex min-h-[320px] w-full items-center justify-center px-4">
+      <AdaptiveStepper defaultValue={2} min={0} max={3} aria-label="Guests">
+        <AdaptiveStepperDecrement />
+        <AdaptiveStepperValue />
+        <AdaptiveStepperIncrement />
+      </AdaptiveStepper>
+    </div>
+  );
+}

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -11,6 +11,10 @@ const COMPONENT_DATES = {
     publishedAt: "2026-08-22",
     updatedAt: "2026-08-22",
   },
+  "motion/adaptive-stepper": {
+    publishedAt: "2026-08-31",
+    updatedAt: "2026-08-31",
+  },
   "motion/expanding-arrow-button": {
     publishedAt: "2026-07-16",
     updatedAt: "2026-07-16",

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -13,7 +13,7 @@ const COMPONENT_DATES = {
   },
   "motion/adaptive-stepper": {
     publishedAt: "2026-08-31",
-    updatedAt: "2026-08-31",
+    updatedAt: "2026-09-01",
   },
   "motion/expanding-arrow-button": {
     publishedAt: "2026-07-16",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -186,6 +186,23 @@ export const registry: CategoryEntry[] = [
         ],
       },
       {
+        slug: "adaptive-stepper",
+        name: "Adaptive Stepper",
+        description:
+          "Composable numeric stepper whose fixed footprint adapts at its minimum and maximum while the value rolls between steps.",
+        file: "components/motion/adaptive-stepper.tsx",
+        badge: "new",
+        launchedAt: "2026-08-31",
+        keywords: [
+          "react number stepper",
+          "animated quantity selector",
+          "adaptive counter",
+          "increment decrement control",
+          "compound stepper component",
+          "number input animation",
+        ],
+      },
+      {
         slug: "marquee",
         name: "Marquee",
         description: "Infinite horizontal or vertical scroll with pause-on-hover.",

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -27,6 +27,12 @@ import { StreamingResponse } from "@/components/agents/streaming-response";
 import { TodoList } from "@/components/agents/todo-list";
 import { ToolApproval } from "@/components/agents/tool-approval";
 import { ToolResult } from "@/components/agents/tool-result";
+import {
+  AdaptiveStepper,
+  AdaptiveStepperDecrement,
+  AdaptiveStepperIncrement,
+  AdaptiveStepperValue,
+} from "@/components/motion/adaptive-stepper";
 import { AnimatedBadge } from "@/components/motion/animated-badge";
 import {
   AnimatedSidebar,
@@ -108,6 +114,16 @@ afterEach(cleanup);
 // no violations. Add a row here when you ship a new interactive component.
 // Render thunks (not bare JSX) keep these out of an iterable literal.
 const cases: Array<[name: string, render: () => ReactElement]> = [
+  [
+    "AdaptiveStepper",
+    () => (
+      <AdaptiveStepper defaultValue={2} min={0} max={3} aria-label="Guests">
+        <AdaptiveStepperDecrement />
+        <AdaptiveStepperValue />
+        <AdaptiveStepperIncrement />
+      </AdaptiveStepper>
+    ),
+  ],
   [
     "MultiSelect",
     () => (

--- a/tests/adaptive-stepper.test.tsx
+++ b/tests/adaptive-stepper.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import {
+  AdaptiveStepper,
+  AdaptiveStepperDecrement,
+  AdaptiveStepperIncrement,
+  AdaptiveStepperValue,
+} from "@/components/motion/adaptive-stepper";
+
+afterEach(cleanup);
+
+function Stepper() {
+  return (
+    <AdaptiveStepper defaultValue={2} min={0} max={3} aria-label="Guests">
+      <AdaptiveStepperDecrement />
+      <AdaptiveStepperValue />
+      <AdaptiveStepperIncrement />
+    </AdaptiveStepper>
+  );
+}
+
+describe("AdaptiveStepper", () => {
+  test("mounts matching interactive and liquid geometry", () => {
+    const { container } = render(<Stepper />);
+    const wrappers = container.querySelectorAll("fieldset > div > div");
+    const shapes = container.querySelectorAll("fieldset svg g rect");
+
+    expect(wrappers).toHaveLength(3);
+    expect(shapes).toHaveLength(3);
+    expect(wrappers[0]?.getAttribute("style")).toContain("width: 48px");
+    expect(wrappers[1]?.getAttribute("style")).toContain("width: 88px");
+    expect(wrappers[2]?.getAttribute("style")).toContain(
+      "translate(168px, 0px)",
+    );
+    expect(Array.from(shapes, (shape) => shape.getAttribute("width"))).toEqual([
+      "48",
+      "88",
+      "48",
+    ]);
+  });
+
+  test("keeps the boundary action mounted but removes it from interaction", () => {
+    const { getByRole } = render(<Stepper />);
+    const increment = getByRole("button", { name: "Increase value" });
+
+    fireEvent.click(increment);
+
+    expect(getByRole("group").textContent).toContain("Current value: 3");
+    expect(increment.getAttribute("aria-hidden")).toBe("true");
+    expect((increment as HTMLButtonElement).disabled).toBe(true);
+    expect(increment.tabIndex).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Summary

- add a composable adaptive numeric stepper with controlled and uncontrolled state, boundary-aware controls, and keyboard focus handoff
- add reusable dependency-free liquid primitives for the stepper’s gooey separation and joining motion
- refine directional number transitions and widen verbose API-reference default values
- register the component, preview, documentation metadata, accessibility coverage, and component tests

## Validation

- `bun run check`
- `bun test tests/adaptive-stepper.test.tsx tests/a11y.test.tsx`
- browser-verified boundary transitions, repeated value changes, and the wide API-reference layout