### PR TITLE
feat: add animated card folder

### DIFF
--- a/app/components/[category]/[slug]/page.tsx
+++ b/app/components/[category]/[slug]/page.tsx
@@ -135,7 +135,6 @@ export default async function ComponentPage({
   const cat = findCategory(category);
   const comp = findComponent(category, slug);
   if (!cat || !comp) notFound();
-  const hasMultipleVariants = (comp.examples?.length ?? 0) > 1;
   const hasVariantInstallCommands =
     comp.examples?.some((example) => example.installSlug) ?? false;
   const examplesShareSource =
@@ -237,7 +236,7 @@ export default async function ComponentPage({
               <h1 className="text-3xl font-medium tracking-tight text-foreground">
                 {comp.name}
               </h1>
-              {comp.badge === "new" && !hasMultipleVariants ? (
+              {comp.badge === "new" ? (
                 <NewBadge launchedAt={comp.launchedAt} className="mt-1" />
               ) : null}
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,13 @@
-import Link from "next/link";
 import { ArrowRight } from "lucide-react";
-import { registry } from "@/lib/registry";
-import { Hero } from "@/components/app/landing/hero";
-import { InstallCommand } from "@/components/app/docs/install-command";
-import { LandingComponentCard } from "@/components/app/landing/landing-component-card";
+import Link from "next/link";
 import { SiteFooter } from "@/components/app/chrome/site-footer";
+import { InstallCommand } from "@/components/app/docs/install-command";
+import { Hero } from "@/components/app/landing/hero";
+import { LandingComponentCard } from "@/components/app/landing/landing-component-card";
 import { Testimonials } from "@/components/app/landing/testimonials";
 import { WorkCta } from "@/components/app/landing/work-cta";
 import { isComponentNew } from "@/lib/component-status";
+import { registry } from "@/lib/registry";
 
 const CURATED: { category: string; slug: string }[] = [
   { category: "motion", slug: "button" },
@@ -38,6 +38,7 @@ const CURATED: { category: string; slug: string }[] = [
 
 const GRID_CLASS =
   "grid grid-cols-1 gap-4 [grid-auto-rows:19rem] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
+const RECENTLY_LAUNCHED_FEATURED = "blocks/card-folder";
 
 function SectionHeader({
   eyebrow,
@@ -98,10 +99,19 @@ export default function Home() {
           };
         }),
     )
-    // Newest first: most recently launched components lead the section.
-    .sort((a, b) =>
-      (b.component.launchedAt ?? "").localeCompare(a.component.launchedAt ?? ""),
-    );
+    // Keep the featured launch first, then preserve newest-first ordering.
+    .sort((a, b) => {
+      const aFeatured =
+        `${a.category}/${a.component.slug}` === RECENTLY_LAUNCHED_FEATURED;
+      const bFeatured =
+        `${b.category}/${b.component.slug}` === RECENTLY_LAUNCHED_FEATURED;
+
+      if (aFeatured !== bFeatured) return aFeatured ? -1 : 1;
+
+      return (b.component.launchedAt ?? "").localeCompare(
+        a.component.launchedAt ?? "",
+      );
+    });
   const newComponentKeys = new Set(
     newComponents.map(
       ({ category, component }) => `${category}/${component.slug}`,

--- a/components/motion/card-folder.tsx
+++ b/components/motion/card-folder.tsx
@@ -1,19 +1,24 @@
 "use client";
 
-import { EllipsisVertical } from "lucide-react";
-import { motion, useReducedMotion } from "motion/react";
-import { useCallback, useState, type ReactNode } from "react";
+import { EllipsisVertical, Eye, EyeOff } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { type ReactNode, useCallback, useState } from "react";
 import { SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
 import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
 import { cn } from "@/lib/utils";
 
 export interface CardFolderProps {
   title: string;
-  description?: string;
+  cardNumber: string;
+  expiry: string;
+  cvv: string;
   card: ReactNode;
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  detailsVisible?: boolean;
+  defaultDetailsVisible?: boolean;
+  onDetailsVisibleChange?: (visible: boolean) => void;
   onClick?: () => void;
   onAction?: () => void;
   ariaLabel?: string;
@@ -25,16 +30,21 @@ export interface CardFolderProps {
 
 /**
  * A landscape card tucked into an animated folder sleeve. Pressing the folder
- * folds its front panel away and lifts the card into view while its overflow
- * action remains a separate, valid control beside the primary button.
+ * folds its front panel away and lifts the card into view; a separate privacy
+ * control reveals its number and CVV without nesting controls in the folder.
  */
 export function CardFolder({
   title,
-  description,
+  cardNumber,
+  expiry,
+  cvv,
   card,
   open,
   defaultOpen = false,
   onOpenChange,
+  detailsVisible,
+  defaultDetailsVisible = false,
+  onDetailsVisibleChange,
   onClick,
   onAction,
   ariaLabel,
@@ -46,9 +56,20 @@ export function CardFolder({
   const reduce = useReducedMotion();
   const canHover = useHoverCapable();
   const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const [internalDetailsVisible, setInternalDetailsVisible] = useState(
+    defaultDetailsVisible,
+  );
   const openControlled = open !== undefined;
+  const detailsControlled = detailsVisible !== undefined;
   const isOpen = open ?? internalOpen;
+  const areDetailsVisible = detailsVisible ?? internalDetailsVisible;
   const transition = reduce ? { duration: 0 } : SPRING_LAYOUT;
+  const normalizedCardNumber = cardNumber.replace(/\D/g, "");
+  const visibleLastFour = normalizedCardNumber.slice(-4).padStart(4, "•");
+  const revealedCardNumber =
+    normalizedCardNumber.match(/.{1,4}/g)?.join(" ") ?? visibleLastFour;
+  const maskedCvv = "•".repeat(Math.max(3, cvv.length));
+  const defaultAriaLabel = `${isOpen ? "Close" : "Open"} ${title}, card ending in ${visibleLastFour}, expires ${expiry}`;
 
   const setOpen = useCallback(
     (nextOpen: boolean) => {
@@ -64,45 +85,54 @@ export function CardFolder({
     onClick?.();
   };
 
+  const toggleDetails = () => {
+    if (disabled) return;
+    const nextVisible = !areDetailsVisible;
+    if (!detailsControlled) setInternalDetailsVisible(nextVisible);
+    onDetailsVisibleChange?.(nextVisible);
+  };
+
   return (
     <div
       data-open={isOpen ? "true" : "false"}
+      data-details-visible={areDetailsVisible ? "true" : "false"}
       className={cn(
-        "relative aspect-[1029/592] w-full max-w-[34rem] select-none [perspective:1200px]",
+        "relative aspect-[1029/592] w-96 max-w-full select-none [perspective:1200px]",
         className,
       )}
     >
       <motion.button
         type="button"
         disabled={disabled}
-        aria-label={ariaLabel ?? `${isOpen ? "Close" : "Open"} ${title}`}
+        aria-label={ariaLabel ?? defaultAriaLabel}
         aria-expanded={isOpen}
         onClick={handleClick}
         whileTap={reduce || disabled ? undefined : { scale: 0.96 }}
         transition={reduce ? { duration: 0 } : SPRING_PRESS}
-        className="absolute inset-0 block rounded-[clamp(1.75rem,5vw,3rem)] text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+        className="absolute inset-0 block rounded-2xl text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
       >
         <motion.span
+          data-slot="card-folder-back"
           aria-hidden="true"
           initial={false}
           animate={{ rotateX: isOpen && !reduce ? 12 : 0 }}
           transition={transition}
-          className="absolute inset-x-0 bottom-0 top-[10%] rounded-[clamp(1.75rem,5vw,3rem)] bg-card shadow-[0_8px_20px_-12px_rgb(0_0_0/0.18)] ring-1 ring-black/[0.08] [transform-origin:center_bottom] dark:ring-white/10"
+          className="absolute inset-x-0 bottom-0 top-[10%] rounded-2xl border border-foreground/10 bg-background [transform-origin:center_bottom]"
         />
 
         <motion.span
           aria-hidden="true"
           initial={false}
           animate={{
-            y: isOpen && !reduce ? -18 : 0,
-            scale: isOpen && !reduce ? 1.02 : 1,
+            y: isOpen && !reduce ? -14 : 0,
+            scale: isOpen && !reduce ? 1.015 : 1,
           }}
           whileHover={
-            canHover && !disabled && !isOpen && !reduce ? { y: -8 } : undefined
+            canHover && !disabled && !isOpen && !reduce ? { y: -7 } : undefined
           }
           transition={transition}
           className={cn(
-            "absolute left-[4.3%] right-[4.3%] top-0 aspect-[1.586/1] overflow-hidden rounded-[clamp(1.25rem,4vw,2.5rem)] bg-foreground shadow-[0_14px_32px_-18px_rgb(0_0_0/0.45)] ring-1 ring-inset ring-black/10 [transform-origin:center_bottom] dark:shadow-[0_14px_32px_-18px_rgb(0_0_0/0.75)] dark:ring-white/10",
+            "absolute left-[4.7%] right-[4.7%] top-0 aspect-[1.586/1] overflow-hidden rounded-xl border border-foreground/10 bg-background [transform-origin:center_bottom]",
             cardClassName,
           )}
         >
@@ -116,26 +146,134 @@ export function CardFolder({
             reduce
               ? { opacity: isOpen ? 0.12 : 1 }
               : {
-                  y: isOpen ? 22 : 0,
+                  y: isOpen ? 18 : 0,
                   rotateX: isOpen ? -68 : 0,
                   scaleY: isOpen ? 0.96 : 1,
                 }
           }
           transition={transition}
-          className="absolute inset-x-0 bottom-0 top-[64%] z-20 overflow-hidden rounded-b-[clamp(1.75rem,5vw,3rem)] bg-card [backface-visibility:hidden] [transform-origin:center_bottom]"
+          className="absolute inset-x-0 bottom-0 top-1/2 z-20 [backface-visibility:hidden] [transform-origin:center_bottom]"
         >
-          <span className="absolute inset-x-[4.2%] inset-y-0 flex min-w-0 flex-col justify-center pr-12">
-            <span className="truncate text-[clamp(1rem,4.4vw,1.75rem)] font-medium leading-tight text-foreground">
-              {title}
-            </span>
-            {description ? (
-              <span className="mt-[2%] truncate text-[clamp(0.75rem,3.5vw,1.25rem)] leading-tight text-muted-foreground">
-                {description}
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 384 110"
+            preserveAspectRatio="none"
+            className="absolute inset-0 size-full overflow-visible"
+          >
+            <path
+              d="M0 17C15 7 31 4 49 4H87C110 4 126 17 144 32L158 44C176 59 206 59 225 43L240 30C257 16 271 4 295 4H335C354 4 370 8 384 18V94C384 103 377 110 368 110H16C7 110 0 103 0 94Z"
+              fill="var(--background)"
+              stroke="var(--foreground)"
+              strokeOpacity="0.12"
+              vectorEffect="non-scaling-stroke"
+            />
+            <path
+              d="M10 21C22 13 35 11 51 11H85C105 11 120 23 137 37L153 50C175 68 208 68 231 49L246 36C262 23 275 11 297 11H333C350 11 363 14 374 22V89C374 97 369 101 360 101H24C15 101 10 96 10 89Z"
+              fill="none"
+              stroke="var(--foreground)"
+              strokeDasharray="5 5"
+              strokeLinecap="round"
+              strokeOpacity="0.22"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+
+          <span className="absolute inset-x-[5%] inset-y-0 z-10 flex min-w-0 flex-col justify-between py-4">
+            <span className="flex justify-end pt-2 pr-2">
+              <span className="flex shrink-0 items-end gap-3.5">
+                <span className="flex flex-col gap-0.5">
+                  <span className="text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/65">
+                    Expiry
+                  </span>
+                  <span className="text-xs font-medium text-foreground tabular-nums">
+                    {expiry}
+                  </span>
+                </span>
+                <span className="flex flex-col gap-0.5">
+                  <span className="text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/65">
+                    CVV
+                  </span>
+                  <span className="text-xs font-medium text-foreground tabular-nums">
+                    {areDetailsVisible ? cvv : maskedCvv}
+                  </span>
+                </span>
               </span>
-            ) : null}
+            </span>
+            <span className="flex min-w-0 items-baseline justify-between gap-4">
+              <span className="truncate text-lg font-medium leading-tight text-foreground">
+                {title}
+              </span>
+              <span className="truncate font-mono text-xs tracking-[0.08em] tabular-nums">
+                {areDetailsVisible ? (
+                  <span className="text-foreground">{revealedCardNumber}</span>
+                ) : (
+                  <>
+                    <span className="text-muted-foreground">
+                      •••• •••• ••••{" "}
+                    </span>
+                    <span className="text-foreground">{visibleLastFour}</span>
+                  </>
+                )}
+              </span>
+            </span>
           </span>
         </motion.span>
       </motion.button>
+
+      {!isOpen ? (
+        <motion.button
+          key="card-details-visibility"
+          type="button"
+          disabled={disabled}
+          aria-label={
+            areDetailsVisible ? "Hide card details" : "Show card details"
+          }
+          aria-pressed={areDetailsVisible}
+          onClick={toggleDetails}
+          initial={
+            reduce
+              ? { opacity: 0 }
+              : { opacity: 0, scale: 0.25, filter: "blur(4px)" }
+          }
+          animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+          whileTap={reduce || disabled ? undefined : { scale: 0.96 }}
+          transition={
+            reduce
+              ? { duration: 0.12 }
+              : { type: "spring", duration: 0.3, bounce: 0 }
+          }
+          className="absolute left-[2.6%] top-[65%] z-30 flex size-10 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <AnimatePresence initial={false} mode="popLayout">
+            <motion.span
+              key={areDetailsVisible ? "hide" : "show"}
+              initial={
+                reduce
+                  ? { opacity: 0 }
+                  : { opacity: 0, scale: 0.25, filter: "blur(4px)" }
+              }
+              animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+              exit={
+                reduce
+                  ? { opacity: 0 }
+                  : { opacity: 0, scale: 0.25, filter: "blur(4px)" }
+              }
+              transition={
+                reduce
+                  ? { duration: 0.12 }
+                  : { type: "spring", duration: 0.3, bounce: 0 }
+              }
+              className="flex items-center justify-center"
+            >
+              {areDetailsVisible ? (
+                <EyeOff className="size-4" aria-hidden="true" />
+              ) : (
+                <Eye className="size-4" aria-hidden="true" />
+              )}
+            </motion.span>
+          </AnimatePresence>
+        </motion.button>
+      ) : null}
 
       {onAction ? (
         <motion.button
@@ -143,12 +281,12 @@ export function CardFolder({
           disabled={disabled}
           aria-label={actionLabel ?? `Open actions for ${title}`}
           onClick={onAction}
-          animate={{ y: isOpen && !reduce ? 14 : 0 }}
+          animate={{ y: isOpen && !reduce ? -14 : 0 }}
           whileTap={reduce || disabled ? undefined : { scale: 0.96 }}
           transition={transition}
-          className="absolute right-[2.6%] top-[82%] z-10 flex size-11 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground outline-none transition-colors hover:bg-foreground/5 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          className="absolute right-[2.6%] top-[10%] z-10 flex size-10 -translate-y-1/2 items-center justify-center rounded-full text-white/65 outline-none transition-colors hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-50"
         >
-          <EllipsisVertical className="size-5" aria-hidden="true" />
+          <EllipsisVertical className="size-4" aria-hidden="true" />
         </motion.button>
       ) : null}
     </div>

--- a/components/motion/card-folder.tsx
+++ b/components/motion/card-folder.tsx
@@ -4,9 +4,25 @@ import { EllipsisVertical, Eye, EyeOff } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { type ReactNode, useCallback, useState } from "react";
 import { DigitSwap } from "@/components/motion/digit-swap";
-import { SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
+import {
+  EASE_IN_OUT,
+  EASE_OUT,
+  SPRING_LAYOUT,
+  SPRING_PRESS,
+} from "@/lib/ease";
 import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
 import { cn } from "@/lib/utils";
+
+// The two purse layers collapse as one material surface after the card starts
+// moving, then reverse immediately so closing feels like the card is caught.
+const PURSE_MORPH_TRANSITION = {
+  duration: 0.24,
+  ease: EASE_IN_OUT,
+} as const;
+const PURSE_REDUCED_TRANSITION = {
+  duration: 0.16,
+  ease: EASE_OUT,
+} as const;
 
 export interface CardFolderProps {
   title: string;
@@ -31,8 +47,8 @@ export interface CardFolderProps {
 
 /**
  * A landscape card tucked into an animated folder sleeve. Pressing the folder
- * folds its front panel away and lifts the card into view; a separate privacy
- * control reveals its number and CVV without nesting controls in the folder.
+ * lifts the card forward while the purse compresses into its bottom seam; a
+ * separate privacy control reveals its number and CVV.
  */
 export function CardFolder({
   title,
@@ -71,6 +87,20 @@ export function CardFolder({
     normalizedCardNumber.match(/.{1,4}/g)?.join(" ") ?? visibleLastFour;
   const maskedCvv = "•".repeat(Math.max(3, cvv.length));
   const defaultAriaLabel = `${isOpen ? "Close" : "Open"} ${title}, card ending in ${visibleLastFour}, expires ${expiry}`;
+  const frontPurseAnimation = reduce
+    ? { opacity: isOpen ? 0 : 1 }
+    : {
+        opacity: isOpen ? 0 : 1,
+        transform: isOpen
+          ? "translateY(24%) rotateX(-68deg) scaleX(0.96) scaleY(0.18)"
+          : "translateY(0%) rotateX(0deg) scaleX(1) scaleY(1)",
+      };
+  const purseTransition = reduce
+    ? PURSE_REDUCED_TRANSITION
+    : {
+        ...PURSE_MORPH_TRANSITION,
+        delay: isOpen ? 0.03 : 0,
+      };
 
   const setOpen = useCallback(
     (nextOpen: boolean) => {
@@ -116,8 +146,24 @@ export function CardFolder({
           data-slot="card-folder-back"
           aria-hidden="true"
           initial={false}
-          animate={{ rotateX: isOpen && !reduce ? 12 : 0 }}
-          transition={transition}
+          animate={
+            reduce
+              ? { opacity: isOpen ? 0 : 1 }
+              : {
+                  opacity: isOpen ? 0 : 1,
+                  transform: isOpen
+                    ? "translateY(18%) scaleX(0.94) scaleY(0.16)"
+                    : "translateY(0%) scaleX(1) scaleY(1)",
+                }
+          }
+          transition={
+            reduce
+              ? PURSE_REDUCED_TRANSITION
+              : {
+                  ...PURSE_MORPH_TRANSITION,
+                  delay: isOpen ? 0.03 : 0,
+                }
+          }
           className="absolute inset-x-0 bottom-0 top-[10%] rounded-2xl border border-foreground/10 bg-background [transform-origin:center_bottom]"
         />
 
@@ -125,36 +171,34 @@ export function CardFolder({
           aria-hidden="true"
           initial={false}
           animate={{
-            y: isOpen && !reduce ? -14 : 0,
-            scale: isOpen && !reduce ? 1.015 : 1,
+            transform:
+              isOpen && !reduce
+                ? "translateY(-9%) scale(1.03)"
+                : "translateY(0%) scale(1)",
           }}
           whileHover={
-            canHover && !disabled && !isOpen && !reduce ? { y: -7 } : undefined
+            canHover && !disabled && !isOpen && !reduce
+              ? { transform: "translateY(-3%) scale(1)" }
+              : undefined
           }
           transition={transition}
           className={cn(
-            "absolute left-[4.7%] right-[4.7%] top-0 aspect-[1.586/1] overflow-hidden rounded-xl border border-foreground/10 bg-background [transform-origin:center_bottom]",
+            "absolute left-[4.7%] right-[4.7%] top-0 z-10 aspect-[1.586/1] overflow-hidden rounded-xl border border-foreground/10 bg-background [transform-origin:center_bottom]",
             cardClassName,
           )}
         >
           {card}
         </motion.span>
+      </motion.button>
 
-        <motion.span
-          aria-hidden="true"
-          initial={false}
-          animate={
-            reduce
-              ? { opacity: isOpen ? 0.12 : 1 }
-              : {
-                  y: isOpen ? 18 : 0,
-                  rotateX: isOpen ? -68 : 0,
-                  scaleY: isOpen ? 0.96 : 1,
-                }
-          }
-          transition={transition}
-          className="absolute inset-x-0 bottom-0 top-1/2 z-20 [backface-visibility:hidden] [transform-origin:center_bottom]"
-        >
+      <motion.span
+        aria-hidden={isOpen}
+        inert={isOpen}
+        initial={false}
+        animate={frontPurseAnimation}
+        transition={purseTransition}
+        className="pointer-events-none absolute inset-x-0 bottom-0 top-1/2 z-20 [backface-visibility:hidden] [transform-origin:center_bottom]"
+      >
           <svg
             aria-hidden="true"
             viewBox="0 0 384 110"
@@ -180,8 +224,57 @@ export function CardFolder({
           </svg>
 
           <span className="absolute inset-x-[5%] inset-y-0 z-10 flex min-w-0 flex-col justify-between py-4">
-            <span className="flex justify-end pt-2 pr-2">
-              <span className="flex shrink-0 items-end gap-3.5">
+            <span className="flex items-start justify-between pr-2">
+              <motion.button
+                key="card-details-visibility"
+                type="button"
+                disabled={disabled}
+                tabIndex={isOpen ? -1 : undefined}
+                aria-label={
+                  areDetailsVisible
+                    ? "Hide card details"
+                    : "Show card details"
+                }
+                aria-pressed={areDetailsVisible}
+                onClick={toggleDetails}
+                whileTap={reduce || disabled ? undefined : { scale: 0.96 }}
+                transition={reduce ? { duration: 0.12 } : SPRING_PRESS}
+                className={cn(
+                  "z-30 flex size-10 shrink-0 items-center justify-center rounded-full text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+                  isOpen ? "pointer-events-none" : "pointer-events-auto",
+                )}
+              >
+                <AnimatePresence initial={false} mode="popLayout">
+                  <motion.span
+                    key={areDetailsVisible ? "hide" : "show"}
+                    initial={
+                      reduce
+                        ? { opacity: 0 }
+                        : { opacity: 0, scale: 0.25, filter: "blur(4px)" }
+                    }
+                    animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+                    exit={
+                      reduce
+                        ? { opacity: 0 }
+                        : { opacity: 0, scale: 0.25, filter: "blur(4px)" }
+                    }
+                    transition={
+                      reduce
+                        ? { duration: 0.12 }
+                        : { type: "spring", duration: 0.3, bounce: 0 }
+                    }
+                    className="flex items-center justify-center"
+                  >
+                    {areDetailsVisible ? (
+                      <EyeOff className="size-4" aria-hidden="true" />
+                    ) : (
+                      <Eye className="size-4" aria-hidden="true" />
+                    )}
+                  </motion.span>
+                </AnimatePresence>
+              </motion.button>
+
+              <span className="flex shrink-0 items-end gap-3.5 pt-2">
                 <span className="flex flex-col gap-0.5">
                   <span className="text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/65">
                     Expiry
@@ -228,63 +321,7 @@ export function CardFolder({
               />
             </span>
           </span>
-        </motion.span>
-      </motion.button>
-
-      {!isOpen ? (
-        <motion.button
-          key="card-details-visibility"
-          type="button"
-          disabled={disabled}
-          aria-label={
-            areDetailsVisible ? "Hide card details" : "Show card details"
-          }
-          aria-pressed={areDetailsVisible}
-          onClick={toggleDetails}
-          initial={
-            reduce
-              ? { opacity: 0 }
-              : { opacity: 0, scale: 0.25, filter: "blur(4px)" }
-          }
-          animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
-          whileTap={reduce || disabled ? undefined : { scale: 0.96 }}
-          transition={
-            reduce
-              ? { duration: 0.12 }
-              : { type: "spring", duration: 0.3, bounce: 0 }
-          }
-          className="absolute left-[2.6%] top-[65%] z-30 flex size-10 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <AnimatePresence initial={false} mode="popLayout">
-            <motion.span
-              key={areDetailsVisible ? "hide" : "show"}
-              initial={
-                reduce
-                  ? { opacity: 0 }
-                  : { opacity: 0, scale: 0.25, filter: "blur(4px)" }
-              }
-              animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
-              exit={
-                reduce
-                  ? { opacity: 0 }
-                  : { opacity: 0, scale: 0.25, filter: "blur(4px)" }
-              }
-              transition={
-                reduce
-                  ? { duration: 0.12 }
-                  : { type: "spring", duration: 0.3, bounce: 0 }
-              }
-              className="flex items-center justify-center"
-            >
-              {areDetailsVisible ? (
-                <EyeOff className="size-4" aria-hidden="true" />
-              ) : (
-                <Eye className="size-4" aria-hidden="true" />
-              )}
-            </motion.span>
-          </AnimatePresence>
-        </motion.button>
-      ) : null}
+      </motion.span>
 
       {onAction ? (
         <motion.button

--- a/components/motion/card-folder.tsx
+++ b/components/motion/card-folder.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { EllipsisVertical, Eye, EyeOff } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { type ReactNode, useCallback, useState } from "react";
+import {
+  AnimatePresence,
+  animate,
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useTransform,
+} from "motion/react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { DigitSwap } from "@/components/motion/digit-swap";
 import {
   EASE_IN_OUT,
@@ -10,13 +17,12 @@ import {
   SPRING_LAYOUT,
   SPRING_PRESS,
 } from "@/lib/ease";
-import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
 import { cn } from "@/lib/utils";
 
 // The two purse layers collapse as one material surface after the card starts
 // moving, then reverse immediately so closing feels like the card is caught.
 const PURSE_MORPH_TRANSITION = {
-  duration: 0.24,
+  duration: 0.28,
   ease: EASE_IN_OUT,
 } as const;
 const PURSE_REDUCED_TRANSITION = {
@@ -71,7 +77,6 @@ export function CardFolder({
   cardClassName,
 }: CardFolderProps) {
   const reduce = useReducedMotion();
-  const canHover = useHoverCapable();
   const [internalOpen, setInternalOpen] = useState(defaultOpen);
   const [internalDetailsVisible, setInternalDetailsVisible] = useState(
     defaultDetailsVisible,
@@ -87,20 +92,32 @@ export function CardFolder({
     normalizedCardNumber.match(/.{1,4}/g)?.join(" ") ?? visibleLastFour;
   const maskedCvv = "•".repeat(Math.max(3, cvv.length));
   const defaultAriaLabel = `${isOpen ? "Close" : "Open"} ${title}, card ending in ${visibleLastFour}, expires ${expiry}`;
-  const frontPurseAnimation = reduce
-    ? { opacity: isOpen ? 0 : 1 }
-    : {
-        opacity: isOpen ? 0 : 1,
-        transform: isOpen
-          ? "translateY(24%) rotateX(-68deg) scaleX(0.96) scaleY(0.18)"
-          : "translateY(0%) rotateX(0deg) scaleX(1) scaleY(1)",
-      };
-  const purseTransition = reduce
-    ? PURSE_REDUCED_TRANSITION
-    : {
-        ...PURSE_MORPH_TRANSITION,
-        delay: isOpen ? 0.03 : 0,
-      };
+  const progress = useMotionValue(isOpen ? 1 : 0);
+  const cardTransform = useTransform(progress, (value) => {
+    const boundedProgress = Math.min(1, Math.max(0, value));
+    const lift = Math.sin(Math.PI * boundedProgress);
+    return `translateY(${-8 * lift}%) scale(${1 + 0.01 * lift})`;
+  });
+  const backTransform = useTransform(
+    progress,
+    [0, 1],
+    ["translateY(0%) scaleY(1)", "translateY(18%) scaleY(0.18)"],
+  );
+  const frontTransform = useTransform(
+    progress,
+    [0, 1],
+    ["translateY(0%) rotateX(0deg)", "translateY(18%) rotateX(-72deg)"],
+  );
+  const purseOpacity = useTransform(progress, [0, 0.76, 1], [1, 1, 0]);
+
+  useEffect(() => {
+    const controls = animate(
+      progress,
+      isOpen ? 1 : 0,
+      reduce ? { duration: 0 } : PURSE_MORPH_TRANSITION,
+    );
+    return () => controls.stop();
+  }, [isOpen, progress, reduce]);
 
   const setOpen = useCallback(
     (nextOpen: boolean) => {
@@ -146,23 +163,12 @@ export function CardFolder({
           data-slot="card-folder-back"
           aria-hidden="true"
           initial={false}
-          animate={
+          animate={reduce ? { opacity: isOpen ? 0 : 1 } : undefined}
+          transition={PURSE_REDUCED_TRANSITION}
+          style={
             reduce
-              ? { opacity: isOpen ? 0 : 1 }
-              : {
-                  opacity: isOpen ? 0 : 1,
-                  transform: isOpen
-                    ? "translateY(18%) scaleX(0.94) scaleY(0.16)"
-                    : "translateY(0%) scaleX(1) scaleY(1)",
-                }
-          }
-          transition={
-            reduce
-              ? PURSE_REDUCED_TRANSITION
-              : {
-                  ...PURSE_MORPH_TRANSITION,
-                  delay: isOpen ? 0.03 : 0,
-                }
+              ? undefined
+              : { opacity: purseOpacity, transform: backTransform }
           }
           className="absolute inset-x-0 bottom-0 top-[10%] rounded-2xl border border-foreground/10 bg-background [transform-origin:center_bottom]"
         />
@@ -170,20 +176,12 @@ export function CardFolder({
         <motion.span
           aria-hidden="true"
           initial={false}
-          animate={{
-            transform:
-              isOpen && !reduce
-                ? "translateY(-9%) scale(1.03)"
-                : "translateY(0%) scale(1)",
-          }}
-          whileHover={
-            canHover && !disabled && !isOpen && !reduce
-              ? { transform: "translateY(-3%) scale(1)" }
-              : undefined
+          animate={
+            reduce ? { transform: "translateY(0%) scale(1)" } : undefined
           }
-          transition={transition}
+          style={reduce ? undefined : { transform: cardTransform }}
           className={cn(
-            "absolute left-[4.7%] right-[4.7%] top-0 z-10 aspect-[1.586/1] overflow-hidden rounded-xl border border-foreground/10 bg-background [transform-origin:center_bottom]",
+            "absolute left-[4.7%] right-[4.7%] top-0 z-10 aspect-[1.586/1] overflow-hidden rounded-xl border border-foreground/10 bg-background [transform-origin:center_bottom] will-change-transform",
             cardClassName,
           )}
         >
@@ -195,8 +193,13 @@ export function CardFolder({
         aria-hidden={isOpen}
         inert={isOpen}
         initial={false}
-        animate={frontPurseAnimation}
-        transition={purseTransition}
+        animate={reduce ? { opacity: isOpen ? 0 : 1 } : undefined}
+        transition={PURSE_REDUCED_TRANSITION}
+        style={
+          reduce
+            ? undefined
+            : { opacity: purseOpacity, transform: frontTransform }
+        }
         className="pointer-events-none absolute inset-x-0 bottom-0 top-1/2 z-20 [backface-visibility:hidden] [transform-origin:center_bottom]"
       >
           <svg

--- a/components/motion/card-folder.tsx
+++ b/components/motion/card-folder.tsx
@@ -3,6 +3,7 @@
 import { EllipsisVertical, Eye, EyeOff } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { type ReactNode, useCallback, useState } from "react";
+import { DigitSwap } from "@/components/motion/digit-swap";
 import { SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
 import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
 import { cn } from "@/lib/utils";
@@ -193,9 +194,14 @@ export function CardFolder({
                   <span className="text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/65">
                     CVV
                   </span>
-                  <span className="text-xs font-medium text-foreground tabular-nums">
-                    {areDetailsVisible ? cvv : maskedCvv}
-                  </span>
+                  <DigitSwap
+                    value={areDetailsVisible ? cvv : maskedCvv}
+                    animationKey={
+                      areDetailsVisible ? "revealed" : "masked"
+                    }
+                    direction={areDetailsVisible ? "up" : "down"}
+                    className="text-xs font-medium text-foreground tabular-nums"
+                  />
                 </span>
               </span>
             </span>
@@ -203,18 +209,23 @@ export function CardFolder({
               <span className="truncate text-lg font-medium leading-tight text-foreground">
                 {title}
               </span>
-              <span className="truncate font-mono text-xs tracking-[0.08em] tabular-nums">
-                {areDetailsVisible ? (
-                  <span className="text-foreground">{revealedCardNumber}</span>
-                ) : (
-                  <>
-                    <span className="text-muted-foreground">
-                      •••• •••• ••••{" "}
-                    </span>
-                    <span className="text-foreground">{visibleLastFour}</span>
-                  </>
-                )}
-              </span>
+              <DigitSwap
+                value={
+                  areDetailsVisible
+                    ? revealedCardNumber
+                    : `•••• •••• •••• ${visibleLastFour}`
+                }
+                animationKey={areDetailsVisible ? "revealed" : "masked"}
+                direction={areDetailsVisible ? "up" : "down"}
+                suffixLength={4}
+                glyphClassName={
+                  areDetailsVisible
+                    ? "text-foreground"
+                    : "text-muted-foreground"
+                }
+                suffixClassName="text-foreground"
+                className="truncate font-mono text-xs tracking-[0.08em] tabular-nums"
+              />
             </span>
           </span>
         </motion.span>

--- a/components/motion/card-folder.tsx
+++ b/components/motion/card-folder.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { EllipsisVertical } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import { useCallback, useState, type ReactNode } from "react";
+import { SPRING_LAYOUT, SPRING_PRESS } from "@/lib/ease";
+import { useHoverCapable } from "@/lib/hooks/use-hover-capable";
+import { cn } from "@/lib/utils";
+
+export interface CardFolderProps {
+  title: string;
+  description?: string;
+  card: ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onClick?: () => void;
+  onAction?: () => void;
+  ariaLabel?: string;
+  actionLabel?: string;
+  disabled?: boolean;
+  className?: string;
+  cardClassName?: string;
+}
+
+/**
+ * A landscape card tucked into an animated folder sleeve. Pressing the folder
+ * folds its front panel away and lifts the card into view while its overflow
+ * action remains a separate, valid control beside the primary button.
+ */
+export function CardFolder({
+  title,
+  description,
+  card,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  onClick,
+  onAction,
+  ariaLabel,
+  actionLabel,
+  disabled = false,
+  className,
+  cardClassName,
+}: CardFolderProps) {
+  const reduce = useReducedMotion();
+  const canHover = useHoverCapable();
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const openControlled = open !== undefined;
+  const isOpen = open ?? internalOpen;
+  const transition = reduce ? { duration: 0 } : SPRING_LAYOUT;
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (disabled) return;
+      if (!openControlled) setInternalOpen(nextOpen);
+      onOpenChange?.(nextOpen);
+    },
+    [disabled, onOpenChange, openControlled],
+  );
+
+  const handleClick = () => {
+    setOpen(!isOpen);
+    onClick?.();
+  };
+
+  return (
+    <div
+      data-open={isOpen ? "true" : "false"}
+      className={cn(
+        "relative aspect-[1029/592] w-full max-w-[34rem] select-none [perspective:1200px]",
+        className,
+      )}
+    >
+      <motion.button
+        type="button"
+        disabled={disabled}
+        aria-label={ariaLabel ?? `${isOpen ? "Close" : "Open"} ${title}`}
+        aria-expanded={isOpen}
+        onClick={handleClick}
+        whileTap={reduce || disabled ? undefined : { scale: 0.96 }}
+        transition={reduce ? { duration: 0 } : SPRING_PRESS}
+        className="absolute inset-0 block rounded-[clamp(1.75rem,5vw,3rem)] text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <motion.span
+          aria-hidden="true"
+          initial={false}
+          animate={{ rotateX: isOpen && !reduce ? 12 : 0 }}
+          transition={transition}
+          className="absolute inset-x-0 bottom-0 top-[10%] rounded-[clamp(1.75rem,5vw,3rem)] bg-card shadow-[0_8px_20px_-12px_rgb(0_0_0/0.18)] ring-1 ring-black/[0.08] [transform-origin:center_bottom] dark:ring-white/10"
+        />
+
+        <motion.span
+          aria-hidden="true"
+          initial={false}
+          animate={{
+            y: isOpen && !reduce ? -18 : 0,
+            scale: isOpen && !reduce ? 1.02 : 1,
+          }}
+          whileHover={
+            canHover && !disabled && !isOpen && !reduce ? { y: -8 } : undefined
+          }
+          transition={transition}
+          className={cn(
+            "absolute left-[4.3%] right-[4.3%] top-0 aspect-[1.586/1] overflow-hidden rounded-[clamp(1.25rem,4vw,2.5rem)] bg-foreground shadow-[0_14px_32px_-18px_rgb(0_0_0/0.45)] ring-1 ring-inset ring-black/10 [transform-origin:center_bottom] dark:shadow-[0_14px_32px_-18px_rgb(0_0_0/0.75)] dark:ring-white/10",
+            cardClassName,
+          )}
+        >
+          {card}
+        </motion.span>
+
+        <motion.span
+          aria-hidden="true"
+          initial={false}
+          animate={
+            reduce
+              ? { opacity: isOpen ? 0.12 : 1 }
+              : {
+                  y: isOpen ? 22 : 0,
+                  rotateX: isOpen ? -68 : 0,
+                  scaleY: isOpen ? 0.96 : 1,
+                }
+          }
+          transition={transition}
+          className="absolute inset-x-0 bottom-0 top-[64%] z-20 overflow-hidden rounded-b-[clamp(1.75rem,5vw,3rem)] bg-card [backface-visibility:hidden] [transform-origin:center_bottom]"
+        >
+          <span className="absolute inset-x-[4.2%] inset-y-0 flex min-w-0 flex-col justify-center pr-12">
+            <span className="truncate text-[clamp(1rem,4.4vw,1.75rem)] font-medium leading-tight text-foreground">
+              {title}
+            </span>
+            {description ? (
+              <span className="mt-[2%] truncate text-[clamp(0.75rem,3.5vw,1.25rem)] leading-tight text-muted-foreground">
+                {description}
+              </span>
+            ) : null}
+          </span>
+        </motion.span>
+      </motion.button>
+
+      {onAction ? (
+        <motion.button
+          type="button"
+          disabled={disabled}
+          aria-label={actionLabel ?? `Open actions for ${title}`}
+          onClick={onAction}
+          animate={{ y: isOpen && !reduce ? 14 : 0 }}
+          whileTap={reduce || disabled ? undefined : { scale: 0.96 }}
+          transition={transition}
+          className="absolute right-[2.6%] top-[82%] z-10 flex size-11 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground outline-none transition-colors hover:bg-foreground/5 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <EllipsisVertical className="size-5" aria-hidden="true" />
+        </motion.button>
+      ) : null}
+    </div>
+  );
+}

--- a/components/motion/digit-swap.tsx
+++ b/components/motion/digit-swap.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { EASE_OUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+export type DigitSwapDirection = "up" | "down";
+
+export interface DigitSwapProps {
+  /** Numeric or masked value rendered in fixed character slots. */
+  value: string | number;
+  /** Replays every glyph when the value itself contains unchanged characters. */
+  animationKey?: string | number;
+  /** Direction the next glyph enters from. */
+  direction?: DigitSwapDirection;
+  /** Per-glyph transition duration in seconds. */
+  duration?: number;
+  /** Delay in seconds between neighboring glyphs. */
+  stagger?: number;
+  /** Number of final characters that receive `suffixClassName`. */
+  suffixLength?: number;
+  className?: string;
+  glyphClassName?: string;
+  suffixClassName?: string;
+}
+
+type GlyphMotionContext = {
+  direction: DigitSwapDirection;
+  reduceMotion: boolean;
+};
+
+const GLYPH_VARIANTS = {
+  enter: ({ direction, reduceMotion }: GlyphMotionContext) => ({
+    opacity: 0,
+    transform: reduceMotion
+      ? "none"
+      : `translateY(${direction === "up" ? "45%" : "-45%"})`,
+  }),
+  visible: {
+    opacity: 1,
+    transform: "translateY(0%)",
+  },
+  exit: ({ direction, reduceMotion }: GlyphMotionContext) => ({
+    opacity: 0,
+    transform: reduceMotion
+      ? "none"
+      : `translateY(${direction === "up" ? "-45%" : "45%"})`,
+  }),
+};
+
+/** Fixed-slot digits and mask glyphs that roll when their value changes. */
+export function DigitSwap({
+  value,
+  animationKey,
+  direction = "up",
+  duration = 0.18,
+  stagger = 0.006,
+  suffixLength = 0,
+  className,
+  glyphClassName,
+  suffixClassName,
+}: DigitSwapProps) {
+  const reduceMotion = useReducedMotion() ?? false;
+  const text = String(value);
+  const suffixStart = Math.max(0, text.length - Math.max(0, suffixLength));
+  const motionContext: GlyphMotionContext = { direction, reduceMotion };
+  const glyphs = Array.from(text, (character, position) => ({
+    character,
+    id: `glyph-${position}`,
+    position,
+  }));
+
+  return (
+    <span
+      data-slot="digit-swap"
+      data-direction={direction}
+      className={cn("inline-flex items-center whitespace-nowrap", className)}
+    >
+      <span className="sr-only">{text}</span>
+      <span aria-hidden="true" className="inline-flex items-center">
+        {glyphs.map(({ character, id, position }) => {
+          if (character === " ") {
+            return <span key={id} className="inline-block w-[0.7ch]" />;
+          }
+
+          const glyphKey =
+            animationKey === undefined
+              ? `${id}-${character}`
+              : `${id}-${character}-${animationKey}`;
+
+          return (
+            <span
+              key={id}
+              data-slot="digit-swap-glyph"
+              className="relative inline-block h-[1.1em] w-[1ch] shrink-0 overflow-hidden align-bottom"
+            >
+              <AnimatePresence initial={false} custom={motionContext}>
+                <motion.span
+                  key={glyphKey}
+                  custom={motionContext}
+                  variants={GLYPH_VARIANTS}
+                  initial="enter"
+                  animate="visible"
+                  exit="exit"
+                  transition={{
+                    duration: reduceMotion ? Math.min(duration, 0.12) : duration,
+                    delay: reduceMotion ? 0 : position * stagger,
+                    ease: EASE_OUT,
+                  }}
+                  className={cn(
+                    "absolute inset-0 flex items-center justify-center leading-none",
+                    glyphClassName,
+                    position >= suffixStart ? suffixClassName : undefined,
+                  )}
+                >
+                  {character}
+                </motion.span>
+              </AnimatePresence>
+            </span>
+          );
+        })}
+      </span>
+    </span>
+  );
+}

--- a/components/previews/blocks/card-folder.preview.tsx
+++ b/components/previews/blocks/card-folder.preview.tsx
@@ -29,11 +29,11 @@ function CardArtwork() {
 
       <span className="absolute inset-0 bg-[radial-gradient(circle_at_78%_8%,rgb(255_255_255/0.11),transparent_32%)]" />
 
-      <span className="absolute left-[6%] top-[8%] flex items-center gap-2 text-[clamp(0.8rem,3vw,1.4rem)] font-semibold tracking-[-0.04em]">
+      <span className="absolute left-[6%] top-[8%] flex items-center gap-2 text-lg font-semibold tracking-[-0.04em]">
         beUI <span className="block size-2.5 rotate-45 rounded-[2px] bg-white/85" />
       </span>
 
-      <span className="absolute bottom-[9%] right-[7%] h-[23%] w-[15%] overflow-hidden rounded-[18%] bg-[linear-gradient(135deg,#f2f0ea_0%,#b9b7b1_45%,#e4e1d9_100%)] shadow-[inset_0_0_0_1px_rgb(0_0_0/0.32),0_2px_8px_rgb(0_0_0/0.25)]">
+      <span className="absolute bottom-[9%] right-[7%] h-[23%] w-[15%] overflow-hidden rounded-[18%] border border-black/30 bg-[linear-gradient(135deg,#f2f0ea_0%,#b9b7b1_45%,#e4e1d9_100%)]">
         <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-black/30" />
         <span className="absolute inset-x-0 top-1/3 h-px bg-black/30" />
         <span className="absolute inset-x-0 bottom-1/3 h-px bg-black/30" />
@@ -42,10 +42,10 @@ function CardArtwork() {
       </span>
 
       <span className="absolute bottom-[10%] left-[6%] flex flex-col gap-1.5">
-        <span className="text-[clamp(0.45rem,1.4vw,0.65rem)] uppercase tracking-[0.22em] text-white/45">
-          Studio card
+        <span className="text-[10px] uppercase tracking-[0.22em] text-white/45">
+          Saurabh Chauhan
         </span>
-        <span className="font-mono text-[clamp(0.65rem,2vw,0.9rem)] tracking-[0.18em] text-white/80">
+        <span className="font-mono text-xs tracking-[0.18em] text-white/80">
           •••• 0806
         </span>
       </span>
@@ -55,12 +55,13 @@ function CardArtwork() {
 
 export function CardFolderPreview() {
   return (
-    <div className="flex min-h-80 w-full items-center justify-center px-5 py-10 sm:px-10">
+    <div className="flex min-h-72 w-full items-center justify-center px-6 py-9">
       <CardFolder
-        title="Studio card (•••• 0806)"
-        description="Auto-matching funds"
+        title="Saurabh Chauhan"
+        cardNumber="3745698740960806"
+        expiry="08/29"
+        cvv="123"
         card={<CardArtwork />}
-        onAction={() => {}}
       />
     </div>
   );

--- a/components/previews/blocks/card-folder.preview.tsx
+++ b/components/previews/blocks/card-folder.preview.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { useState } from "react";
 import { CardFolder } from "@/components/motion/card-folder";
+import { DigitSwap } from "@/components/motion/digit-swap";
 
+const CARD_NUMBER = "3745 6987 4096 0806";
+const MASKED_CARD_NUMBER = "•••• •••• •••• 0806";
 const CONTOUR_RADII = Array.from({ length: 18 }, (_, index) => 72 + index * 24);
-function CardArtwork() {
+
+function CardArtwork({ detailsVisible }: { detailsVisible: boolean }) {
   return (
     <span className="relative block h-full w-full overflow-hidden bg-[linear-gradient(135deg,#383a38_0%,#202120_48%,#111211_100%)] text-white">
       <svg
@@ -21,7 +26,7 @@ function CardArtwork() {
             r={radius}
             fill="none"
             stroke="currentColor"
-            strokeOpacity={0.72 - index * 0.025}
+            strokeOpacity={0.32 - index * 0.009}
             strokeWidth="1.5"
           />
         ))}
@@ -29,11 +34,22 @@ function CardArtwork() {
 
       <span className="absolute inset-0 bg-[radial-gradient(circle_at_78%_8%,rgb(255_255_255/0.11),transparent_32%)]" />
 
-      <span className="absolute left-[6%] top-[8%] flex items-center gap-2 text-lg font-semibold tracking-[-0.04em]">
-        beUI <span className="block size-2.5 rotate-45 rounded-[2px] bg-white/85" />
+      <span className="absolute left-[6%] top-[8%] flex flex-col gap-2">
+        <span className="text-[10px] font-medium uppercase tracking-[0.22em] text-white/55">
+          Saurabh Chauhan
+        </span>
+        <DigitSwap
+          value={detailsVisible ? CARD_NUMBER : MASKED_CARD_NUMBER}
+          animationKey={detailsVisible ? "revealed" : "masked"}
+          direction={detailsVisible ? "up" : "down"}
+          suffixLength={4}
+          glyphClassName={detailsVisible ? "text-white/90" : "text-white/65"}
+          suffixClassName="text-white/90"
+          className="font-mono text-xs tracking-[0.13em]"
+        />
       </span>
 
-      <span className="absolute bottom-[9%] right-[7%] h-[23%] w-[15%] overflow-hidden rounded-[18%] border border-black/30 bg-[linear-gradient(135deg,#f2f0ea_0%,#b9b7b1_45%,#e4e1d9_100%)]">
+      <span className="absolute top-[8%] right-[7%] h-[20%] w-[13%] overflow-hidden rounded-[18%] border border-black/30 bg-[linear-gradient(135deg,#f2f0ea_0%,#b9b7b1_45%,#e4e1d9_100%)]">
         <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-black/30" />
         <span className="absolute inset-x-0 top-1/3 h-px bg-black/30" />
         <span className="absolute inset-x-0 bottom-1/3 h-px bg-black/30" />
@@ -41,12 +57,29 @@ function CardArtwork() {
         <span className="absolute right-0 top-1/2 h-[34%] w-[28%] -translate-y-1/2 rounded-l-[35%] border border-r-0 border-black/30" />
       </span>
 
-      <span className="absolute bottom-[10%] left-[6%] flex flex-col gap-1.5">
-        <span className="text-[10px] uppercase tracking-[0.22em] text-white/45">
-          Saurabh Chauhan
+      <span className="absolute bottom-[9%] left-[6%] flex items-center gap-2 text-lg font-semibold tracking-[-0.04em]">
+        beUI <span className="block size-2.5 rotate-45 rounded-[2px] bg-white/85" />
+      </span>
+
+      <span className="absolute right-[7%] bottom-[10%] flex items-end gap-5">
+        <span className="flex flex-col gap-1">
+          <span className="text-[8px] font-medium uppercase tracking-[0.16em] text-white/40">
+            Expiry
+          </span>
+          <span className="text-xs font-medium text-white/90 tabular-nums">
+            08/29
+          </span>
         </span>
-        <span className="font-mono text-xs tracking-[0.18em] text-white/80">
-          •••• 0806
+        <span className="flex flex-col gap-1">
+          <span className="text-[8px] font-medium uppercase tracking-[0.16em] text-white/40">
+            CVV
+          </span>
+          <DigitSwap
+            value={detailsVisible ? "123" : "•••"}
+            animationKey={detailsVisible ? "revealed" : "masked"}
+            direction={detailsVisible ? "up" : "down"}
+            className="font-mono text-xs font-medium text-white/90"
+          />
         </span>
       </span>
     </span>
@@ -54,14 +87,18 @@ function CardArtwork() {
 }
 
 export function CardFolderPreview() {
+  const [detailsVisible, setDetailsVisible] = useState(false);
+
   return (
     <div className="flex min-h-72 w-full items-center justify-center px-6 py-9">
       <CardFolder
         title="Saurabh Chauhan"
-        cardNumber="3745698740960806"
+        cardNumber={CARD_NUMBER}
         expiry="08/29"
         cvv="123"
-        card={<CardArtwork />}
+        detailsVisible={detailsVisible}
+        onDetailsVisibleChange={setDetailsVisible}
+        card={<CardArtwork detailsVisible={detailsVisible} />}
       />
     </div>
   );

--- a/components/previews/blocks/card-folder.preview.tsx
+++ b/components/previews/blocks/card-folder.preview.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { CardFolder } from "@/components/motion/card-folder";
+
+const CONTOUR_RADII = Array.from({ length: 18 }, (_, index) => 72 + index * 24);
+function CardArtwork() {
+  return (
+    <span className="relative block h-full w-full overflow-hidden bg-[linear-gradient(135deg,#383a38_0%,#202120_48%,#111211_100%)] text-white">
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 640 404"
+        className="absolute inset-0 h-full w-full"
+      >
+        {CONTOUR_RADII.map((radius, index) => (
+          <circle
+            // The concentric contours deliberately begin outside the card so
+            // their cropped curves read like the reference artwork.
+            key={radius}
+            cx="-20"
+            cy="-28"
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeOpacity={0.72 - index * 0.025}
+            strokeWidth="1.5"
+          />
+        ))}
+      </svg>
+
+      <span className="absolute inset-0 bg-[radial-gradient(circle_at_78%_8%,rgb(255_255_255/0.11),transparent_32%)]" />
+
+      <span className="absolute left-[6%] top-[8%] flex items-center gap-2 text-[clamp(0.8rem,3vw,1.4rem)] font-semibold tracking-[-0.04em]">
+        beUI <span className="block size-2.5 rotate-45 rounded-[2px] bg-white/85" />
+      </span>
+
+      <span className="absolute bottom-[9%] right-[7%] h-[23%] w-[15%] overflow-hidden rounded-[18%] bg-[linear-gradient(135deg,#f2f0ea_0%,#b9b7b1_45%,#e4e1d9_100%)] shadow-[inset_0_0_0_1px_rgb(0_0_0/0.32),0_2px_8px_rgb(0_0_0/0.25)]">
+        <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-black/30" />
+        <span className="absolute inset-x-0 top-1/3 h-px bg-black/30" />
+        <span className="absolute inset-x-0 bottom-1/3 h-px bg-black/30" />
+        <span className="absolute left-0 top-1/2 h-[34%] w-[28%] -translate-y-1/2 rounded-r-[35%] border border-l-0 border-black/30" />
+        <span className="absolute right-0 top-1/2 h-[34%] w-[28%] -translate-y-1/2 rounded-l-[35%] border border-r-0 border-black/30" />
+      </span>
+
+      <span className="absolute bottom-[10%] left-[6%] flex flex-col gap-1.5">
+        <span className="text-[clamp(0.45rem,1.4vw,0.65rem)] uppercase tracking-[0.22em] text-white/45">
+          Studio card
+        </span>
+        <span className="font-mono text-[clamp(0.65rem,2vw,0.9rem)] tracking-[0.18em] text-white/80">
+          •••• 0806
+        </span>
+      </span>
+    </span>
+  );
+}
+
+export function CardFolderPreview() {
+  return (
+    <div className="flex min-h-80 w-full items-center justify-center px-5 py-10 sm:px-10">
+      <CardFolder
+        title="Studio card (•••• 0806)"
+        description="Auto-matching funds"
+        card={<CardArtwork />}
+        onAction={() => {}}
+      />
+    </div>
+  );
+}

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -257,6 +257,9 @@ export const previews: Record<string, ComponentType> = {
   "motion/number-ticker": dynamic(() =>
     import("./motion/number-ticker.preview").then((m) => m.NumberTickerPreview),
   ),
+  "motion/digit-swap": dynamic(() =>
+    import("./motion/digit-swap.preview").then((m) => m.DigitSwapPreview),
+  ),
   "motion/animated-badge": dynamic(() =>
     import("./motion/animated-badge.preview").then((m) => m.AnimatedBadgePreview),
   ),

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -143,6 +143,9 @@ export const previews: Record<string, ComponentType> = {
       (m) => m.ProjectFolderPreview,
     ),
   ),
+  "blocks/card-folder": dynamic(() =>
+    import("./blocks/card-folder.preview").then((m) => m.CardFolderPreview),
+  ),
   "blocks/knockout-bracket": dynamic(() =>
     import("./blocks/knockout-bracket.preview").then(
       (m) => m.KnockoutBracketPreview,

--- a/components/previews/motion/digit-swap.preview.tsx
+++ b/components/previews/motion/digit-swap.preview.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { DigitSwap } from "@/components/motion/digit-swap";
+
+const CARD_NUMBER = "4242 4242 4242 0806";
+const MASKED_NUMBER = "•••• •••• •••• 0806";
+
+export function DigitSwapPreview() {
+  const [revealed, setRevealed] = useState(false);
+
+  return (
+    <div className="flex w-80 flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-muted-foreground">
+          Card number
+        </span>
+        <DigitSwap
+          value={revealed ? CARD_NUMBER : MASKED_NUMBER}
+          animationKey={revealed ? "revealed" : "masked"}
+          direction={revealed ? "up" : "down"}
+          suffixLength={4}
+          glyphClassName={
+            revealed ? "text-foreground" : "text-muted-foreground"
+          }
+          suffixClassName="text-foreground"
+          className="font-mono text-lg tracking-[0.08em] tabular-nums"
+        />
+      </div>
+
+      <button
+        type="button"
+        aria-label={revealed ? "Animate masked number" : "Animate card number"}
+        aria-pressed={revealed}
+        onClick={() => setRevealed((current) => !current)}
+        className="h-10 self-start rounded-lg border border-border px-3 text-sm font-medium text-foreground outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Animate
+      </button>
+    </div>
+  );
+}

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -48,7 +48,7 @@ const COMPONENT_DATES = {
     updatedAt: "2026-08-20",
   },
   "motion/text-animation": { publishedAt: "2026-05-17", updatedAt: "2026-08-19" },
-  "motion/number": { publishedAt: "2026-05-17", updatedAt: "2026-06-28" },
+  "motion/number": { publishedAt: "2026-05-17", updatedAt: "2026-09-04" },
   "motion/animated-badge": { publishedAt: "2026-06-05", updatedAt: "2026-06-10" },
   "motion/action-swap": { publishedAt: "2026-06-10", updatedAt: "2026-06-28" },
   "motion/animated-toast-stack": { publishedAt: "2026-06-05", updatedAt: "2026-07-13" },

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -133,6 +133,7 @@ const COMPONENT_DATES = {
   "blocks/infinite-masonry": { publishedAt: "2026-07-15", updatedAt: "2026-07-15" },
   "blocks/notification-stack": { publishedAt: "2026-07-14", updatedAt: "2026-07-14" },
   "blocks/project-folder": { publishedAt: "2026-08-15", updatedAt: "2026-08-20" },
+  "blocks/card-folder": { publishedAt: "2026-09-04", updatedAt: "2026-09-04" },
   "blocks/knockout-bracket": { publishedAt: "2026-07-12", updatedAt: "2026-07-27" },
   "blocks/availability-scheduler": { publishedAt: "2026-07-10", updatedAt: "2026-08-24" },
   "blocks/swap": { publishedAt: "2026-05-19", updatedAt: "2026-06-13" },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1516,7 +1516,7 @@ export const registry: CategoryEntry[] = [
         slug: "card-folder",
         name: "Card Folder",
         description:
-          "A landscape card tucked into a rounded folder sleeve that opens on press and lifts the complete card into view, with controlled state and a separate overflow action.",
+          "A landscape card tucked into a stitched purse pocket that folds open on press and lifts the complete card into view, with controlled open and card-detail visibility plus a separate overflow action.",
         file: "components/motion/card-folder.tsx",
         badge: "new",
         launchedAt: "2026-09-04",
@@ -1526,6 +1526,7 @@ export const registry: CategoryEntry[] = [
           "payment card component",
           "credit card folder",
           "interactive wallet card",
+          "card purse component",
         ],
       },
       {

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1513,6 +1513,22 @@ export const registry: CategoryEntry[] = [
         ],
       },
       {
+        slug: "card-folder",
+        name: "Card Folder",
+        description:
+          "A landscape card tucked into a rounded folder sleeve that opens on press and lifts the complete card into view, with controlled state and a separate overflow action.",
+        file: "components/motion/card-folder.tsx",
+        badge: "new",
+        launchedAt: "2026-09-04",
+        keywords: [
+          "react card folder",
+          "animated card sleeve",
+          "payment card component",
+          "credit card folder",
+          "interactive wallet card",
+        ],
+      },
+      {
         slug: "knockout-bracket",
         name: "Fixtures",
         description: "Animated tournament fixtures in two styles: a knockout bracket that pages through rounds, and a wheel that wraps the same tree around the champion. Both read the same array of rounds, so one dataset draws either.",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -592,6 +592,8 @@ export const registry: CategoryEntry[] = [
         description:
           "Animated number primitives for count-up values, rolling tickers, and fixed-slot digit swaps.",
         file: "components/motion/animated-number.tsx",
+        badge: "new",
+        launchedAt: "2026-09-04",
         extraFiles: [
           "components/motion/number-ticker.tsx",
           "components/motion/digit-swap.tsx",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -589,10 +589,26 @@ export const registry: CategoryEntry[] = [
       {
         slug: "number",
         name: "Number Animation",
-        description: "Animated number primitives for count-up values and rolling digit tickers.",
+        description:
+          "Animated number primitives for count-up values, rolling tickers, and fixed-slot digit swaps.",
         file: "components/motion/animated-number.tsx",
-        extraFiles: ["components/motion/number-ticker.tsx"],
+        extraFiles: [
+          "components/motion/number-ticker.tsx",
+          "components/motion/digit-swap.tsx",
+        ],
         examples: [
+          {
+            slug: "digit-swap",
+            name: "Digit Swap",
+            description:
+              "Fixed-slot digits and mask glyphs that roll on change with controllable direction, stagger, replay, and suffix emphasis.",
+            badge: "new",
+            launchedAt: "2026-09-04",
+            installSlug: "digit-swap",
+            file: "components/motion/digit-swap.tsx",
+            previewKey: "motion/digit-swap",
+            previewFile: "components/previews/motion/digit-swap.preview.tsx",
+          },
           {
             slug: "ticker",
             name: "Number Ticker",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1534,7 +1534,7 @@ export const registry: CategoryEntry[] = [
         slug: "card-folder",
         name: "Card Folder",
         description:
-          "A landscape card tucked into a stitched purse pocket that folds open on press and lifts the complete card into view, with controlled open and card-detail visibility plus a separate overflow action.",
+          "A landscape card tucked into a stitched purse pocket that lifts forward as the purse compresses into its bottom seam, with controlled open and card-detail visibility plus a separate overflow action.",
         file: "components/motion/card-folder.tsx",
         badge: "new",
         launchedAt: "2026-09-04",

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -550,7 +550,9 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
     () => (
       <CardFolder
         title="Studio card"
-        description="Auto-matching funds"
+        cardNumber="4242424242420806"
+        expiry="08/29"
+        cvv="123"
         card={<span>Card artwork</span>}
         onAction={() => {}}
       />

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -45,6 +45,7 @@ import { BloomMenu } from "@/components/motion/bloom-menu";
 import { BottomSheet } from "@/components/motion/bottom-sheet";
 import { BounceSidebar } from "@/components/motion/bounce-sidebar";
 import { Button } from "@/components/motion/button";
+import { CardFolder } from "@/components/motion/card-folder";
 import {
   CenterMorphModal,
   CenterMorphModalContent,
@@ -544,6 +545,17 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
   ["Button disabled", () => <Button disabled>Subscribe</Button>],
   ["Button ripple", () => <Button ripple>Subscribe</Button>],
   ["BloomMenu", () => <BloomMenu />],
+  [
+    "CardFolder",
+    () => (
+      <CardFolder
+        title="Studio card"
+        description="Auto-matching funds"
+        card={<span>Card artwork</span>}
+        onAction={() => {}}
+      />
+    ),
+  ],
   [
     "ProjectFolder",
     () => (

--- a/tests/card-folder.test.tsx
+++ b/tests/card-folder.test.tsx
@@ -1,30 +1,42 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { CardFolder } from "@/components/motion/card-folder";
 
 afterEach(cleanup);
 
 describe("CardFolder", () => {
-  test("toggles the folder and keeps the overflow action separate", () => {
+  test("toggles the folder and keeps purse controls separate", async () => {
     const openStates: boolean[] = [];
     let actionsOpened = 0;
-    const { getByRole } = render(
+    const { container, getByRole, queryByRole } = render(
       <CardFolder
         title="Studio card"
-        description="Auto-matching funds"
+        cardNumber="4242424242420806"
+        expiry="08/29"
+        cvv="123"
         card={<span>Card artwork</span>}
         onOpenChange={(open) => openStates.push(open)}
         onAction={() => actionsOpened++}
       />,
     );
 
-    const folder = getByRole("button", { name: "Open Studio card" });
+    const folder = getByRole("button", { name: /^Open Studio card/ });
+    const back = container.querySelector('[data-slot="card-folder-back"]');
+    expect(back?.className).toContain("border-foreground/10");
+    expect(
+      getByRole("button", { name: "Show card details" }).className,
+    ).toContain("z-30");
     expect(folder.getAttribute("aria-expanded")).toBe("false");
 
     fireEvent.click(folder);
     expect(folder.getAttribute("aria-expanded")).toBe("true");
     expect(openStates).toEqual([true]);
     expect(actionsOpened).toBe(0);
+    await waitFor(() => {
+      expect(
+        queryByRole("button", { name: "Show card details" }),
+      ).toBeNull();
+    });
 
     fireEvent.click(
       getByRole("button", { name: "Open actions for Studio card" }),
@@ -32,7 +44,7 @@ describe("CardFolder", () => {
     expect(openStates).toEqual([true]);
     expect(actionsOpened).toBe(1);
 
-    fireEvent.click(getByRole("button", { name: "Close Studio card" }));
+    fireEvent.click(getByRole("button", { name: /^Close Studio card/ }));
     expect(openStates).toEqual([true, false]);
   });
 
@@ -41,6 +53,9 @@ describe("CardFolder", () => {
     const { getByRole } = render(
       <CardFolder
         title="Studio card"
+        cardNumber="4242424242420806"
+        expiry="08/29"
+        cvv="123"
         card={<span>Card artwork</span>}
         open
         onOpenChange={(open) => {
@@ -49,17 +64,71 @@ describe("CardFolder", () => {
       />,
     );
 
-    const folder = getByRole("button", { name: "Close Studio card" });
+    const folder = getByRole("button", { name: /^Close Studio card/ });
     fireEvent.click(folder);
 
     expect(requestedOpen).toBe(false);
     expect(folder.getAttribute("aria-expanded")).toBe("true");
   });
 
+  test("reveals and hides the full number and CVV", () => {
+    const { getByRole, getByText, queryByText } = render(
+      <CardFolder
+        title="Studio card"
+        cardNumber="4242424242420806"
+        expiry="08/29"
+        cvv="123"
+        card={<span>Card artwork</span>}
+      />,
+    );
+
+    expect(queryByText("4242 4242 4242 0806")).toBeNull();
+    expect(queryByText("123")).toBeNull();
+
+    fireEvent.click(getByRole("button", { name: "Show card details" }));
+
+    expect(getByText("4242 4242 4242 0806")).toBeTruthy();
+    expect(getByText("123")).toBeTruthy();
+    expect(
+      getByRole("button", { name: "Hide card details" }).getAttribute(
+        "aria-pressed",
+      ),
+    ).toBe("true");
+
+    fireEvent.click(getByRole("button", { name: "Hide card details" }));
+    expect(queryByText("4242 4242 4242 0806")).toBeNull();
+    expect(queryByText("123")).toBeNull();
+  });
+
+  test("reports a controlled detail visibility change", () => {
+    let requestedVisible = false;
+    const { getByRole, queryByText } = render(
+      <CardFolder
+        title="Studio card"
+        cardNumber="4242424242420806"
+        expiry="08/29"
+        cvv="123"
+        card={<span>Card artwork</span>}
+        detailsVisible={false}
+        onDetailsVisibleChange={(visible) => {
+          requestedVisible = visible;
+        }}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Show card details" }));
+
+    expect(requestedVisible).toBe(true);
+    expect(queryByText("4242 4242 4242 0806")).toBeNull();
+  });
+
   test("disables both controls together", () => {
     const { getAllByRole } = render(
       <CardFolder
         title="Studio card"
+        cardNumber="4242424242420806"
+        expiry="08/29"
+        cvv="123"
         card={<span>Card artwork</span>}
         onAction={() => {}}
         disabled

--- a/tests/card-folder.test.tsx
+++ b/tests/card-folder.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { CardFolder } from "@/components/motion/card-folder";
+
+afterEach(cleanup);
+
+describe("CardFolder", () => {
+  test("toggles the folder and keeps the overflow action separate", () => {
+    const openStates: boolean[] = [];
+    let actionsOpened = 0;
+    const { getByRole } = render(
+      <CardFolder
+        title="Studio card"
+        description="Auto-matching funds"
+        card={<span>Card artwork</span>}
+        onOpenChange={(open) => openStates.push(open)}
+        onAction={() => actionsOpened++}
+      />,
+    );
+
+    const folder = getByRole("button", { name: "Open Studio card" });
+    expect(folder.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(folder);
+    expect(folder.getAttribute("aria-expanded")).toBe("true");
+    expect(openStates).toEqual([true]);
+    expect(actionsOpened).toBe(0);
+
+    fireEvent.click(
+      getByRole("button", { name: "Open actions for Studio card" }),
+    );
+    expect(openStates).toEqual([true]);
+    expect(actionsOpened).toBe(1);
+
+    fireEvent.click(getByRole("button", { name: "Close Studio card" }));
+    expect(openStates).toEqual([true, false]);
+  });
+
+  test("supports controlled open state", () => {
+    let requestedOpen = false;
+    const { getByRole } = render(
+      <CardFolder
+        title="Studio card"
+        card={<span>Card artwork</span>}
+        open
+        onOpenChange={(open) => {
+          requestedOpen = open;
+        }}
+      />,
+    );
+
+    const folder = getByRole("button", { name: "Close Studio card" });
+    fireEvent.click(folder);
+
+    expect(requestedOpen).toBe(false);
+    expect(folder.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  test("disables both controls together", () => {
+    const { getAllByRole } = render(
+      <CardFolder
+        title="Studio card"
+        card={<span>Card artwork</span>}
+        onAction={() => {}}
+        disabled
+      />,
+    );
+
+    for (const button of getAllByRole("button")) {
+      expect(button.hasAttribute("disabled")).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a compact card-folder block with a stitched purse surface, synchronized detail reveal, and reversible extraction/insertion motion
- add the reusable DigitSwap primitive and Number Animation catalog variant
- refine the card artwork, registry metadata, grouped NEW badge, and homepage launch placement

## Validation

- bun run check
- bun test tests/card-folder.test.tsx