### PR TITLE
Feat/inline slider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Before building a new component, check this list. If it exists, import it. If it
 | `switch` | `components/motion/switch.tsx` | Toggle with spring-driven thumb and press feedback |
 | `select` | `components/motion/select.tsx`, `select-morph.tsx` | Composable select primitives (`Select`, `SelectTrigger`, `SelectValue`, `SelectContent`, `SelectItem`); panel bouncily unfolds out of the trigger and separates (position-aware). `MorphSelect` (`select-morph.tsx`) is a shared-layout variant where the trigger grows into the panel and back |
 | `combobox` | `components/motion/combobox.tsx` | Composable searchable selection primitives whose input is the trigger; the measured list springs open from the field and detaches without page reflow, with stable collision-aware placement through exit, grouped filtering, keyboard navigation that is live as soon as the list appears, a spring-gliding active row and controlled/uncontrolled state |
-| `range-slider` | `components/motion/range-slider.tsx`, `range-slider-fluid.tsx`, `range-slider-wave.tsx`, `range-slider-bubble.tsx`, `range-slider-ruler.tsx` | Five slider designs, one per `examples` entry with its own `installSlug`. `RangeSlider` (base) has tick dots and a vertical-bar thumb that bounces onto each step. `FluidSlider` has no thumb: the fill runs behind a rounded liquid cap and the label flips color under it. `WaveSlider` is equalizer bars that peak around the handle. `BubbleSlider` pops a value bubble that tilts and squashes with drag velocity. `RulerSlider` scrolls the scale under a fixed needle with drag momentum. All share value/step/drag/keyboard plumbing from `lib/hooks/use-slider.ts`; controlled/uncontrolled, reduced-motion safe |
+| `range-slider` | `components/motion/range-slider.tsx`, `range-slider-inline.tsx`, `range-slider-fluid.tsx`, `range-slider-wave.tsx`, `range-slider-bubble.tsx`, `range-slider-ruler.tsx` | Six slider designs, one per `examples` entry with its own `installSlug`. `RangeSlider` (base) has tick dots and a vertical-bar thumb that bounces onto each step. `InlineSlider` keeps its label and value inside the track, hides dots beneath either label, and snaps to ten evenly spaced stops. `FluidSlider` has no thumb: the fill runs behind a rounded liquid cap and the label flips color under it. `WaveSlider` is equalizer bars that peak around the handle. `BubbleSlider` pops a value bubble that tilts and squashes with drag velocity. `RulerSlider` scrolls the scale under a fixed needle with drag momentum. All share value/step/drag/keyboard plumbing from `lib/hooks/use-slider.ts`; controlled/uncontrolled, reduced-motion safe |
 | `wheel-picker` | `components/motion/wheel-picker.tsx` | iOS-style picker wheel (`WheelPicker`): a 3D drum on custom momentum physics (velocity-projected coast, spring-back settle) with a crisp clipped center band; drag, wheel and keyboard, optional synthesized tick sound per row crossed (`sound` prop, default off), composes side by side for date/time pickers, controlled/uncontrolled, reduced-motion safe |
 | `bottom-sheet` | `components/motion/bottom-sheet.tsx` | Draggable bottom sheet with snap points, inertia and glass surface |
 | `pull-to-refresh` | `components/motion/pull-to-refresh.tsx` | Native-feeling refresh container with touch and mouse pull resistance, threshold feedback and async refresh handling |
@@ -158,3 +158,13 @@ Before building a new component, check this list. If it exists, import it. If it
 ## Commits
 
 Conventional lowercase prefixes (`feat:`, `fix:`, `refactor:`, `docs:`), imperative subject. No AI attribution or Co-Authored-By lines.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/components/motion/range-slider-inline.tsx
+++ b/components/motion/range-slider-inline.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import {
+  animate,
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useTransform,
+} from "motion/react";
+import {
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { SPRING_GLIDE } from "@/lib/ease";
+import { type SliderOptions, snapSliderValue, useSlider } from "@/lib/hooks/use-slider";
+import { capturePointer, releasePointer, TOUCH_GESTURE_CLASS } from "@/lib/touch";
+import { cn } from "@/lib/utils";
+
+const STOP_COUNT = 10;
+const HANDLE_START = 8;
+const HANDLE_END_INSET = 12;
+const TEXT_INSET = 20;
+// Matches RangeSlider's bouncy grab and release feedback.
+const SPRING_BOUNCY = { type: "spring", stiffness: 500, damping: 14, mass: 0.7 } as const;
+
+type Stop = { value: number; x: number };
+
+function mapBetweenStops(
+  stops: Stop[],
+  point: number,
+  from: keyof Stop,
+  to: keyof Stop,
+) {
+  const upperIndex = stops.findIndex((stop) => stop[from] >= point);
+  const upper = stops[upperIndex < 0 ? stops.length - 1 : upperIndex];
+  const lower = stops[Math.max(0, upperIndex - 1)];
+  if (lower[from] === upper[from]) return upper[to];
+  return lower[to] +
+    ((point - lower[from]) / (upper[from] - lower[from])) * (upper[to] - lower[to]);
+}
+
+function nearestStop(stops: Stop[], x: number) {
+  return stops.reduce((nearest, stop) =>
+    Math.abs(stop.x - x) < Math.abs(nearest.x - x) ? stop : nearest,
+  );
+}
+
+export interface InlineSliderProps extends SliderOptions {
+  /** Rounds snap-stop values. While dragging, the readout keeps this step's decimal precision. */
+  step?: number;
+  /** Compact label inside the left edge of the track. */
+  label?: string;
+  /** Formats the inline value without changing its precision. */
+  format?: (value: number) => string;
+  /** Show markers for the ten evenly spaced snap stops, except where they overlap inline text. */
+  showTicks?: boolean;
+  className?: string;
+}
+
+/** An always-visible inline slider with an inset fill and a thumb that parts
+ * around its labels, keeping their text readable as the handle passes them. */
+export function InlineSlider({
+  label = "W/H",
+  format = String,
+  showTicks = true,
+  className,
+  ...options
+}: InlineSliderProps) {
+  const reduce = useReducedMotion();
+  const step = options.step && options.step > 0 ? options.step : 1;
+  const precision = step.toFixed(6).replace(/0+$/, "").split(".")[1]?.length ?? 0;
+  const { current, min, max, commit, trackProps, sliderProps } = useSlider({
+    ...options,
+    step: 10 ** -precision,
+    "aria-label": options["aria-label"] ?? label,
+    formatValueText: options.formatValueText ?? format,
+  });
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const readoutRef = useRef<HTMLSpanElement>(null);
+  const [geometry, setGeometry] = useState({
+    width: 292,
+    labelWidth: 22,
+    readoutWidth: 24,
+  });
+  const [dragging, setDragging] = useState(false);
+  const dragFrame = useRef<number | null>(null);
+  const pendingDragValue = useRef<number | null>(null);
+  const gesture = useRef<{
+    id: number;
+    left: number;
+    offset: number;
+    x: number;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    const track = trackProps.ref.current;
+    const labelElement = labelRef.current;
+    const readout = readoutRef.current;
+    if (!track || !labelElement || !readout) return;
+    const measure = () => {
+      const width = track.getBoundingClientRect().width;
+      if (!width) return;
+      const next = {
+        width,
+        labelWidth: labelElement.getBoundingClientRect().width,
+        readoutWidth: readout.getBoundingClientRect().width,
+      };
+      setGeometry((previous) =>
+        previous.width === next.width && previous.labelWidth === next.labelWidth &&
+        previous.readoutWidth === next.readoutWidth ? previous : next,
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(track);
+    observer.observe(labelElement);
+    observer.observe(readout);
+    return () => observer.disconnect();
+  }, [trackProps.ref]);
+
+  // Each stop owns both a value and a physical position. As in RangeSlider,
+  // the stops span the entire track at even intervals; text only affects
+  // whether a marker is painted, never whether its stop remains interactive.
+  const endX = Math.max(HANDLE_START, geometry.width - HANDLE_END_INSET);
+  const stops = useMemo(() => {
+    const values = [...new Set(Array.from({ length: STOP_COUNT }, (_, index) =>
+      snapSliderValue(min + (index / (STOP_COUNT - 1)) * (max - min), min, max, step),
+    ))];
+    return values.map((value, index) => ({
+      value,
+      x: values.length === 1
+        ? HANDLE_START
+        : HANDLE_START + (index / (values.length - 1)) * (endX - HANDLE_START),
+    }));
+  }, [min, max, step, endX]);
+  const restingX = mapBetweenStops(stops, current, "value", "x");
+  // One motion value owns the thumb for the entire gesture. Pointer movement
+  // writes pixels directly; only release/click/keyboard changes use a spring.
+  // Never derive dragging pixels from a rounded value or swap to a lagging spring.
+  const handleX = useMotionValue(restingX);
+  const restingTarget = useRef(restingX);
+  const settleTo = useCallback((x: number) => {
+    restingTarget.current = x;
+    handleX.jump(handleX.get());
+    if (reduce) handleX.jump(x);
+    else animate(handleX, x, { type: "spring", ...SPRING_GLIDE });
+  }, [handleX, reduce]);
+  useLayoutEffect(() => {
+    if (gesture.current || restingTarget.current === restingX) return;
+    settleTo(restingX);
+  }, [restingX, settleTo]);
+  useEffect(() => () => {
+    handleX.stop();
+    if (dragFrame.current !== null) cancelAnimationFrame(dragFrame.current);
+  }, [handleX]);
+  const fillRight = useTransform(handleX, (x) =>
+    x >= endX ? geometry.width - 2 : x + 8,
+  );
+  // Slide a fixed-size fill inside the inset clipping window. The labels and
+  // dots stay above it, and only transforms animate.
+  const fillX = useTransform(fillRight, (right) => right - geometry.width + 2);
+  // Part progressively over six pixels at each text edge instead of
+  // toggling the stem on/off in a single pointer frame. The thumb uses the
+  // same two-dot treatment across both the label and numeric readout.
+  const split = useTransform(handleX, (x) => {
+    const overlap = (start: number, end: number) => Math.max(0, Math.min(
+      1,
+      (x + 4 - start) / 6,
+      (end - x) / 6,
+    ));
+    return Math.max(
+      overlap(TEXT_INSET, TEXT_INSET + geometry.labelWidth),
+      overlap(
+        geometry.width - TEXT_INSET - geometry.readoutWidth,
+        geometry.width - TEXT_INSET,
+      ),
+    );
+  });
+  const stemOpacity = useTransform(split, (amount) => 1 - amount);
+  const capTop = useTransform(split, (amount) => -amount);
+  const capBottom = useTransform(split, (amount) => amount);
+  const labelBounds = { start: TEXT_INSET, end: TEXT_INSET + geometry.labelWidth };
+  const readoutBounds = {
+    start: geometry.width - TEXT_INSET - geometry.readoutWidth,
+    end: geometry.width - TEXT_INSET,
+  };
+  const overlapsText = (x: number, bounds: { start: number; end: number }) =>
+    x + 2 >= bounds.start && x - 2 <= bounds.end;
+  const ticks = showTicks
+    ? stops
+      .map((stop) => stop.x)
+      .filter((x) => !overlapsText(x, labelBounds) && !overlapsText(x, readoutBounds))
+    : [];
+
+  const queueDragCommit = (value: number) => {
+    pendingDragValue.current = value;
+    if (dragFrame.current !== null) return;
+    dragFrame.current = requestAnimationFrame(() => {
+      dragFrame.current = null;
+      if (pendingDragValue.current !== null) commit(pendingDragValue.current);
+      pendingDragValue.current = null;
+    });
+  };
+
+  const cancelDragCommit = () => {
+    if (dragFrame.current !== null) cancelAnimationFrame(dragFrame.current);
+    dragFrame.current = null;
+    pendingDragValue.current = null;
+  };
+
+  const endGesture = (event: PointerEvent<HTMLDivElement>) => {
+    const active = gesture.current;
+    if (!active || active.id !== event.pointerId) return;
+    // Clear before releasing capture: its lost-capture event must not commit twice.
+    gesture.current = null;
+    cancelDragCommit();
+    setDragging(false);
+    if (!options.disabled && geometry.width > 0) {
+      const x = event.type === "pointerup"
+        ? event.clientX - active.left - active.offset
+        : active.x;
+      const stop = nearestStop(stops, x);
+      commit(stop.value);
+      settleTo(options.value === undefined ? stop.x : restingX);
+    } else {
+      settleTo(restingX);
+    }
+    releasePointer(event.currentTarget, event.pointerId);
+  };
+
+  return (
+    <div
+      {...trackProps}
+      onPointerDown={(event) => {
+        if (options.disabled || event.button !== 0 || gesture.current) return;
+        const rect = event.currentTarget.getBoundingClientRect();
+        if (!rect.width) return;
+        event.preventDefault();
+        const pointerX = event.clientX - rect.left;
+        const thumbX = handleX.get();
+        // Grabbing the thumb preserves the exact grab point. A track click
+        // waits for release, so it glides to a dot without an intermediate jump.
+        const offset = Math.abs(pointerX - thumbX - 2) <= 12 ? pointerX - thumbX : 2;
+        gesture.current = { id: event.pointerId, left: rect.left, offset, x: thumbX };
+        setDragging(true);
+        handleX.stop();
+        cancelDragCommit();
+        capturePointer(event.currentTarget, event.pointerId);
+        event.currentTarget.querySelector<HTMLButtonElement>("[role=slider]")?.focus({ preventScroll: true });
+      }}
+      onPointerMove={(event) => {
+        const active = gesture.current;
+        if (!active || active.id !== event.pointerId || options.disabled) return;
+        const x = Math.min(
+          endX,
+          Math.max(HANDLE_START, event.clientX - active.left - active.offset),
+        );
+        active.x = x;
+        handleX.set(x);
+        // Use the same piecewise map as the resting stops, so value and
+        // position agree throughout the drag.
+        queueDragCommit(mapBetweenStops(stops, x, "x", "value"));
+      }}
+      onPointerUp={endGesture}
+      onPointerCancel={endGesture}
+      onLostPointerCapture={endGesture}
+      className={cn(
+        "relative h-10 w-full touch-none select-none overflow-hidden rounded-lg bg-muted",
+        "focus-within:ring-2 focus-within:ring-ring/40",
+        TOUCH_GESTURE_CLASS,
+        options.disabled
+          ? "pointer-events-none opacity-50"
+          : "cursor-grab active:cursor-grabbing",
+        className,
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-[2px] inset-y-0 overflow-hidden rounded-lg"
+      >
+        <motion.div
+          className="absolute inset-0 rounded-lg bg-foreground/15"
+          style={{ x: fillX }}
+        />
+      </div>
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0 text-foreground">
+        <span
+          ref={labelRef}
+          className="absolute left-5 top-1/2 max-w-[40%] -translate-y-1/2 truncate text-sm font-medium leading-5"
+        >
+          {label}
+        </span>
+        <span
+          ref={readoutRef}
+          className="absolute right-5 top-1/2 max-w-[40%] -translate-y-1/2 truncate text-[13px] font-semibold leading-[18px] tracking-tight tabular-nums"
+        >
+          {format(current)}
+        </span>
+        {ticks.map((left) => (
+          <span
+            key={left}
+            className="absolute top-1/2 size-1 -translate-y-1/2 rounded-full bg-foreground/25"
+            style={{ left }}
+          />
+        ))}
+      </div>
+      <motion.div
+        aria-hidden="true"
+        animate={reduce ? undefined : { scaleY: dragging ? 1.35 : 1 }}
+        transition={SPRING_BOUNCY}
+        className="pointer-events-none absolute left-0 top-2 h-6 w-1 text-foreground"
+        style={{ x: handleX }}
+      >
+        <motion.span className="absolute top-0 size-1 rounded-full bg-current" style={{ y: reduce ? 0 : capTop }} />
+        <motion.span className="absolute inset-y-0 w-1 rounded-full bg-current" style={{ opacity: stemOpacity }} />
+        <motion.span className="absolute bottom-0 size-1 rounded-full bg-current" style={{ y: reduce ? 0 : capBottom }} />
+      </motion.div>
+      <button
+        type="button"
+        {...sliderProps}
+        onKeyDown={(event) => {
+          if (options.disabled) return;
+          const next = {
+            ArrowRight: stops.find((stop) => stop.value > current)?.value ?? max,
+            ArrowUp: stops.find((stop) => stop.value > current)?.value ?? max,
+            ArrowLeft: stops.findLast((stop) => stop.value < current)?.value ?? min,
+            ArrowDown: stops.findLast((stop) => stop.value < current)?.value ?? min,
+            Home: min,
+            End: max,
+            PageUp: max,
+            PageDown: min,
+          }[event.key];
+          if (next !== undefined) {
+            event.preventDefault();
+            commit(next);
+          }
+        }}
+        className="absolute inset-0 cursor-inherit touch-none rounded-lg border border-transparent outline-none transition-colors duration-200 focus:border-foreground/40"
+      />
+    </div>
+  );
+}

--- a/components/motion/range-slider-inline.tsx
+++ b/components/motion/range-slider-inline.tsx
@@ -55,7 +55,7 @@ export interface InlineSliderProps extends SliderOptions {
   /** Rounds snap-stop values. While dragging, the readout keeps this step's decimal precision. */
   step?: number;
   /** Compact label inside the left edge of the track. */
-  label?: string;
+  label: string;
   /** Formats the inline value without changing its precision. */
   format?: (value: number) => string;
   /** Show markers for the ten evenly spaced snap stops, except where they overlap inline text. */
@@ -66,7 +66,7 @@ export interface InlineSliderProps extends SliderOptions {
 /** An always-visible inline slider with an inset fill and a thumb that parts
  * around its labels, keeping their text readable as the handle passes them. */
 export function InlineSlider({
-  label = "W/H",
+  label,
   format = String,
   showTicks = true,
   className,

--- a/components/previews/index.tsx
+++ b/components/previews/index.tsx
@@ -450,6 +450,9 @@ export const previews: Record<string, ComponentType> = {
   "motion/range-slider": dynamic(() =>
     import("./motion/range-slider.preview").then((m) => m.RangeSliderPreview),
   ),
+  "motion/range-slider-inline": dynamic(() =>
+    import("./motion/range-slider-inline.preview").then((m) => m.InlineSliderPreview),
+  ),
   "motion/range-slider-fluid": dynamic(() =>
     import("./motion/range-slider-fluid.preview").then(
       (m) => m.RangeSliderFluidPreview,

--- a/components/previews/motion/range-slider-inline.preview.tsx
+++ b/components/previews/motion/range-slider-inline.preview.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { InlineSlider } from "@/components/motion/range-slider-inline";
+
+export function InlineSliderPreview() {
+  return (
+    <div className="w-full max-w-sm">
+      <InlineSlider
+        defaultValue={48}
+        min={8}
+        max={128}
+        step={8}
+        label="Icon size"
+        aria-label="Icon size"
+        formatValueText={(value) => `${value} pixels`}
+      />
+    </div>
+  );
+}

--- a/lib/component-dates.ts
+++ b/lib/component-dates.ts
@@ -56,7 +56,7 @@ const COMPONENT_DATES = {
   "motion/bouncy-accordion": { publishedAt: "2026-06-16", updatedAt: "2026-07-13" },
   "motion/drawer": { publishedAt: "2026-06-22", updatedAt: "2026-08-20" },
   "motion/scroll-animation": { publishedAt: "2026-06-24", updatedAt: "2026-06-28" },
-  "motion/range-slider": { publishedAt: "2026-06-24", updatedAt: "2026-07-31" },
+  "motion/range-slider": { publishedAt: "2026-06-24", updatedAt: "2026-09-09" },
   "motion/wheel-picker": { publishedAt: "2026-07-09", updatedAt: "2026-07-09" },
   "motion/table": { publishedAt: "2026-07-01", updatedAt: "2026-07-13" },
   "motion/shader-background": { publishedAt: "2026-07-02", updatedAt: "2026-07-13" },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -784,6 +784,7 @@ export const registry: CategoryEntry[] = [
           "range slider",
           "range input",
           "stepped slider",
+          "inline slider",
           "ticks",
           "volume slider",
           "ruler picker",
@@ -798,6 +799,18 @@ export const registry: CategoryEntry[] = [
             file: "components/motion/range-slider.tsx",
             previewKey: "motion/range-slider",
             previewFile: "components/previews/motion/range-slider.preview.tsx",
+          },
+          {
+            slug: "inline",
+            name: "Inline Slider",
+            description:
+              "An inset fill and inline label and value. Ten evenly spaced stops span the track; markers under text stay hidden but remain interactive, and the thumb parts around either label as it passes.",
+            installSlug: "range-slider-inline",
+            badge: "new",
+            launchedAt: "2026-09-09",
+            file: "components/motion/range-slider-inline.tsx",
+            previewKey: "motion/range-slider-inline",
+            previewFile: "components/previews/motion/range-slider-inline.preview.tsx",
           },
           {
             slug: "fluid",

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -778,7 +778,7 @@ export const registry: CategoryEntry[] = [
         description: "Slider with tick dots and a vertical-bar thumb that bounces as it lands on each step. Drag or keyboard, reduced-motion safe.",
         file: "components/motion/range-slider.tsx",
         badge: "new",
-        launchedAt: "2026-07-31",
+        launchedAt: "2026-09-09",
         keywords: [
           "slider",
           "range slider",
@@ -791,16 +791,6 @@ export const registry: CategoryEntry[] = [
         ],
         examples: [
           {
-            slug: "stepped",
-            name: "Range Slider",
-            description:
-              "Tick dots, and a vertical-bar thumb that bounces as it lands on each step.",
-            installSlug: "range-slider",
-            file: "components/motion/range-slider.tsx",
-            previewKey: "motion/range-slider",
-            previewFile: "components/previews/motion/range-slider.preview.tsx",
-          },
-          {
             slug: "inline",
             name: "Inline Slider",
             description:
@@ -811,6 +801,16 @@ export const registry: CategoryEntry[] = [
             file: "components/motion/range-slider-inline.tsx",
             previewKey: "motion/range-slider-inline",
             previewFile: "components/previews/motion/range-slider-inline.preview.tsx",
+          },
+          {
+            slug: "stepped",
+            name: "Range Slider",
+            description:
+              "Tick dots, and a vertical-bar thumb that bounces as it lands on each step.",
+            installSlug: "range-slider",
+            file: "components/motion/range-slider.tsx",
+            previewKey: "motion/range-slider",
+            previewFile: "components/previews/motion/range-slider.preview.tsx",
           },
           {
             slug: "fluid",

--- a/skills/beui/SKILL.md
+++ b/skills/beui/SKILL.md
@@ -85,6 +85,7 @@ The live registry is the source of truth. Use the table below only to resolve co
 | Rolling digits | `number-ticker` | `animated-number` |
 | Count-up on view | `animated-number` | `number-ticker` |
 | Tick-dot slider | `range-slider` | other `range-slider-*` |
+| Inline label slider | `range-slider-inline` | `range-slider` |
 | Liquid fill slider | `range-slider-fluid` | `range-slider` |
 | Equalizer slider | `range-slider-wave` | `range-slider` |
 | Tilting value bubble slider | `range-slider-bubble` | `range-slider` |

--- a/tests/a11y.test.tsx
+++ b/tests/a11y.test.tsx
@@ -89,6 +89,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/motion/radio";
 import { RangeSlider } from "@/components/motion/range-slider";
 import { BubbleSlider } from "@/components/motion/range-slider-bubble";
 import { FluidSlider } from "@/components/motion/range-slider-fluid";
+import { InlineSlider } from "@/components/motion/range-slider-inline";
 import { RulerSlider } from "@/components/motion/range-slider-ruler";
 import { WaveSlider } from "@/components/motion/range-slider-wave";
 import { ScrollProgress } from "@/components/motion/scroll-progress";
@@ -715,6 +716,7 @@ const cases: Array<[name: string, render: () => ReactElement]> = [
   ],
   ["ScrollTo", () => <ScrollTo to="#top">Back to top</ScrollTo>],
   ["RangeSlider", () => <RangeSlider defaultValue={40} aria-label="Volume" />],
+  ["InlineSlider", () => <InlineSlider defaultValue={48} label="Icon size" />],
   [
     "FluidSlider",
     () => <FluidSlider defaultValue={35} label="Brightness" aria-label="Brightness" />,

--- a/tests/range-slider-inline.test.tsx
+++ b/tests/range-slider-inline.test.tsx
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import { InlineSlider } from "@/components/motion/range-slider-inline";
+
+afterEach(cleanup);
+
+describe("InlineSlider snap stops", () => {
+  test("tracks single-pixel moves independently of the readout and snaps from the release position", async () => {
+    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} />);
+    const slider = getByRole("slider");
+    const track = slider.parentElement as HTMLElement;
+    track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
+    const thumb = track.querySelector<HTMLElement>(".h-6") as HTMLElement;
+    const readX = () => Number.parseFloat(thumb.style.transform.match(/translateX\(([^p]+)px\)/)?.[1] ?? "NaN");
+    const startX = readX();
+    // Grabbing three pixels into the thumb must preserve that grab point.
+    fireEvent.pointerDown(track, { clientX: startX + 3, pointerId: 1, button: 0 });
+    expect(readX()).toBe(startX);
+    fireEvent.pointerMove(track, { clientX: startX + 8, pointerId: 1 });
+    await waitFor(() => expect(readX()).toBeCloseTo(startX + 5, 2));
+    expect(slider.getAttribute("aria-valuenow")).toBe("51");
+    fireEvent.pointerMove(track, { clientX: startX + 9, pointerId: 1 });
+    await waitFor(() => expect(readX()).toBeCloseTo(startX + 6, 2));
+    // The thumb still responds to a single-pixel move when the rounded
+    // readout happens to remain on the same integer.
+    expect(slider.getAttribute("aria-valuenow")).toBe("51");
+    const releaseX = readX();
+    fireEvent.pointerUp(track, { clientX: startX + 9, pointerId: 1 });
+    expect(readX()).toBeCloseTo(releaseX, 2);
+    expect(slider.getAttribute("aria-valuenow")).toBe("48");
+    await waitFor(() => expect(readX()).toBeCloseTo(startX, 1), {
+      interval: 30, mutationObserverOptions: { childList: true },
+    });
+  });
+
+  test("follows one-pixel direction changes without a startup dead zone", async () => {
+    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} />);
+    const slider = getByRole("slider");
+    const track = slider.parentElement as HTMLElement;
+    track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
+    const thumb = track.querySelector<HTMLElement>(".h-6") as HTMLElement;
+    const readX = () => Number.parseFloat(thumb.style.transform.match(/translateX\(([^p]+)px\)/)?.[1] ?? "NaN");
+    const startX = readX();
+
+    fireEvent.pointerDown(track, { clientX: startX + 3, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(track, { clientX: startX + 4, pointerId: 1 });
+    await waitFor(() => expect(readX()).toBeCloseTo(startX + 1, 2));
+    fireEvent.pointerMove(track, { clientX: startX + 2, pointerId: 1 });
+    await waitFor(() => expect(readX()).toBeCloseTo(startX - 1, 2));
+    fireEvent.pointerUp(track, { clientX: startX + 2, pointerId: 1 });
+  });
+
+  test("a track click glides directly to its dot without an intermediate value", () => {
+    const onValueChange = mock(() => {});
+    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} onValueChange={onValueChange} />);
+    const slider = getByRole("slider");
+    const track = slider.parentElement as HTMLElement;
+    track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
+    const thumb = track.querySelector<HTMLElement>(".h-6") as HTMLElement;
+    const startTransform = thumb.style.transform;
+    fireEvent.pointerDown(track, { clientX: 190, pointerId: 1, button: 0 });
+    expect(document.activeElement).toBe(slider);
+    expect(thumb.style.transform).toBe(startTransform);
+    expect(onValueChange).not.toHaveBeenCalled();
+    fireEvent.pointerUp(track, { clientX: 190, pointerId: 1 });
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenLastCalledWith(88);
+  });
+
+  test("parts the thumb into two dots across both inline labels", async () => {
+    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} />);
+    const slider = getByRole("slider");
+    const track = slider.parentElement as HTMLElement;
+    track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
+    const stem = track.querySelector<HTMLElement>(".inset-y-0.w-1") as HTMLElement;
+
+    fireEvent.pointerDown(track, { clientX: 100, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(track, { clientX: 36, pointerId: 1 });
+    await waitFor(() => expect(stem.style.opacity).toBe("0"));
+
+    fireEvent.pointerMove(track, { clientX: 150, pointerId: 1 });
+    await waitFor(() => expect(stem.style.opacity).toBe("1"));
+
+    fireEvent.pointerMove(track, { clientX: 260, pointerId: 1 });
+    await waitFor(() => expect(stem.style.opacity).toBe("0"));
+  });
+
+  for (const width of [292, 384]) {
+    test(`lands on every evenly spaced stop at ${width}px, including hidden markers`, async () => {
+      const rect = spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+        const measuredWidth = this.classList.contains("h-10") ? width : 24;
+        return { left: 100, width: measuredWidth, right: 100 + measuredWidth,
+          top: 0, bottom: 40, height: 40, x: 100, y: 0, toJSON() {} } as DOMRect;
+      });
+      try {
+        const onValueChange = mock(() => {});
+        const { getByRole } = render(
+          <InlineSlider min={8} max={128} step={8} defaultValue={48} onValueChange={onValueChange} />,
+        );
+        const slider = getByRole("slider");
+        const track = slider.parentElement as HTMLElement;
+        const dots = [...track.querySelectorAll<HTMLElement>("span[style*='left']")];
+        const endX = width - 12;
+        const stopXs = Array.from({ length: 10 }, (_, index) =>
+          8 + (index / 9) * (endX - 8),
+        );
+        const visibleIndexes = width === 292 ? [0, 2, 3, 4, 5, 6, 7, 9] :
+          Array.from({ length: 10 }, (_, index) => index);
+        for (const [dotIndex, stopIndex] of visibleIndexes.entries()) {
+          expect(Number.parseFloat(dots[dotIndex].style.left)).toBeCloseTo(stopXs[stopIndex], 5);
+        }
+        const thumb = track.querySelector<HTMLElement>(".h-6") as HTMLElement;
+        for (const [index, value] of [8, 24, 32, 48, 64, 72, 88, 104, 112, 128].entries()) {
+          const stopX = stopXs[index];
+          fireEvent.pointerDown(track, { clientX: 100 + stopX + 2, pointerId: 1, button: 0 });
+          fireEvent.pointerUp(track, { clientX: 100 + stopX + 2, pointerId: 1 });
+          expect(slider.getAttribute("aria-valuenow")).toBe(String(value));
+          expect(onValueChange).toHaveBeenLastCalledWith(value);
+          await waitFor(() => {
+            const x = Number.parseFloat(thumb.style.transform.match(/translateX\(([^p]+)px\)/)?.[1] ?? "NaN");
+            expect(x).toBeCloseTo(stopX, 1);
+          }, { interval: 30, mutationObserverOptions: { childList: true } });
+        }
+      } finally {
+        cleanup();
+        rect.mockRestore();
+      }
+    });
+  }
+
+  test("keyboard advances between dots and reaches both edges", () => {
+    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={8} />);
+    const slider = getByRole("slider");
+    for (const value of [24, 32, 48, 64, 72, 88, 104, 112, 128, 128]) {
+      fireEvent.keyDown(slider, { key: "ArrowRight" });
+      expect(slider.getAttribute("aria-valuenow")).toBe(String(value));
+    }
+    for (const value of [112, 104, 88, 72, 64, 48, 32, 24, 8, 8]) {
+      fireEvent.keyDown(slider, { key: "ArrowLeft" });
+      expect(slider.getAttribute("aria-valuenow")).toBe(String(value));
+    }
+    for (const [key, value] of [["End", 128], ["Home", 8], ["PageUp", 128], ["PageDown", 8]] as const) {
+      fireEvent.keyDown(slider, { key });
+      expect(slider.getAttribute("aria-valuenow")).toBe(String(value));
+    }
+  });
+
+  test("reports the nearest stop without changing a controlled value", () => {
+    const onValueChange = mock(() => {});
+    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} value={48} onValueChange={onValueChange} />);
+    const slider = getByRole("slider");
+    fireEvent.keyDown(slider, { key: "ArrowRight" });
+    expect(onValueChange).toHaveBeenLastCalledWith(64);
+    expect(slider.getAttribute("aria-valuenow")).toBe("48");
+  });
+
+  test("handles coarse steps, fractional stops, and an empty range", () => {
+    const { getByRole, rerender } = render(<InlineSlider min={0} max={10} step={4} defaultValue={0} />);
+    const slider = getByRole("slider");
+    for (const value of [4, 8, 10]) {
+      fireEvent.keyDown(slider, { key: "ArrowRight" });
+      expect(slider.getAttribute("aria-valuenow")).toBe(String(value));
+    }
+    rerender(<InlineSlider min={0} max={3} step={0.5} value={1} />);
+    const onValueChange = mock(() => {});
+    rerender(<InlineSlider min={0} max={3} step={0.5} value={1} onValueChange={onValueChange} />);
+    fireEvent.keyDown(slider, { key: "ArrowRight" });
+    expect(onValueChange).toHaveBeenLastCalledWith(1.5);
+    rerender(<InlineSlider min={5} max={5} value={5} onValueChange={onValueChange} />);
+    fireEvent.keyDown(slider, { key: "ArrowRight" });
+    expect(onValueChange).toHaveBeenLastCalledWith(5);
+    expect(slider.getAttribute("aria-valuenow")).toBe("5");
+  });
+
+  for (const ending of ["pointerUp", "pointerCancel", "lostPointerCapture"] as const) {
+    test(`${ending} snaps once and ends the drag`, () => {
+      const onValueChange = mock(() => {});
+      const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} onValueChange={onValueChange} />);
+      const slider = getByRole("slider");
+      const track = slider.parentElement as HTMLElement;
+      track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
+      fireEvent.pointerDown(track, { clientX: 100, pointerId: 1, button: 0 });
+      fireEvent.pointerMove(track, { clientX: 190, pointerId: 1 });
+      onValueChange.mockClear();
+      fireEvent[ending](track, { clientX: ending === "pointerUp" ? 190 : 0, pointerId: 1 });
+      expect(onValueChange).toHaveBeenCalledTimes(1);
+      expect(onValueChange).toHaveBeenLastCalledWith(88);
+      fireEvent.lostPointerCapture(track, { pointerId: 1 });
+      fireEvent.pointerMove(track, { clientX: 0, pointerId: 1 });
+      expect(onValueChange).toHaveBeenCalledTimes(1);
+      expect(slider.getAttribute("aria-valuenow")).toBe("88");
+    });
+  }
+
+  test("ignores disabled and secondary-button gestures", () => {
+    const onValueChange = mock(() => {});
+    const { getByRole, rerender } = render(<InlineSlider defaultValue={48} disabled onValueChange={onValueChange} />);
+    const slider = getByRole("slider");
+    const track = slider.parentElement as HTMLElement;
+    track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
+    fireEvent.pointerDown(track, { clientX: 200, pointerId: 1, button: 0 });
+    fireEvent.pointerUp(track, { clientX: 200, pointerId: 1 });
+    fireEvent.keyDown(slider, { key: "ArrowRight" });
+    expect(slider.tabIndex).toBe(-1);
+    expect(onValueChange).not.toHaveBeenCalled();
+    rerender(<InlineSlider defaultValue={48} onValueChange={onValueChange} />);
+    fireEvent.pointerDown(track, { clientX: 200, pointerId: 1, button: 2 });
+    fireEvent.pointerUp(track, { clientX: 200, pointerId: 1, button: 2 });
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+});

--- a/tests/range-slider-inline.test.tsx
+++ b/tests/range-slider-inline.test.tsx
@@ -7,7 +7,7 @@ afterEach(cleanup);
 
 describe("InlineSlider snap stops", () => {
   test("tracks single-pixel moves independently of the readout and snaps from the release position", async () => {
-    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} />);
+    const { getByRole } = render(<InlineSlider label="Size" min={8} max={128} step={8} defaultValue={48} />);
     const slider = getByRole("slider");
     const track = slider.parentElement as HTMLElement;
     track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
@@ -35,7 +35,7 @@ describe("InlineSlider snap stops", () => {
   });
 
   test("follows one-pixel direction changes without a startup dead zone", async () => {
-    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} />);
+    const { getByRole } = render(<InlineSlider label="Size" min={8} max={128} step={8} defaultValue={48} />);
     const slider = getByRole("slider");
     const track = slider.parentElement as HTMLElement;
     track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
@@ -53,7 +53,7 @@ describe("InlineSlider snap stops", () => {
 
   test("a track click glides directly to its dot without an intermediate value", () => {
     const onValueChange = mock(() => {});
-    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} onValueChange={onValueChange} />);
+    const { getByRole } = render(<InlineSlider label="Size" min={8} max={128} step={8} defaultValue={48} onValueChange={onValueChange} />);
     const slider = getByRole("slider");
     const track = slider.parentElement as HTMLElement;
     track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
@@ -69,7 +69,7 @@ describe("InlineSlider snap stops", () => {
   });
 
   test("parts the thumb into two dots across both inline labels", async () => {
-    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} />);
+    const { getByRole } = render(<InlineSlider label="Size" min={8} max={128} step={8} defaultValue={48} />);
     const slider = getByRole("slider");
     const track = slider.parentElement as HTMLElement;
     track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
@@ -96,7 +96,7 @@ describe("InlineSlider snap stops", () => {
       try {
         const onValueChange = mock(() => {});
         const { getByRole } = render(
-          <InlineSlider min={8} max={128} step={8} defaultValue={48} onValueChange={onValueChange} />,
+          <InlineSlider label="Size" min={8} max={128} step={8} defaultValue={48} onValueChange={onValueChange} />,
         );
         const slider = getByRole("slider");
         const track = slider.parentElement as HTMLElement;
@@ -130,7 +130,7 @@ describe("InlineSlider snap stops", () => {
   }
 
   test("keyboard advances between dots and reaches both edges", () => {
-    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={8} />);
+    const { getByRole } = render(<InlineSlider label="Size" min={8} max={128} step={8} defaultValue={8} />);
     const slider = getByRole("slider");
     for (const value of [24, 32, 48, 64, 72, 88, 104, 112, 128, 128]) {
       fireEvent.keyDown(slider, { key: "ArrowRight" });
@@ -148,7 +148,7 @@ describe("InlineSlider snap stops", () => {
 
   test("reports the nearest stop without changing a controlled value", () => {
     const onValueChange = mock(() => {});
-    const { getByRole } = render(<InlineSlider min={8} max={128} step={8} value={48} onValueChange={onValueChange} />);
+    const { getByRole } = render(<InlineSlider label="Size" min={8} max={128} step={8} value={48} onValueChange={onValueChange} />);
     const slider = getByRole("slider");
     fireEvent.keyDown(slider, { key: "ArrowRight" });
     expect(onValueChange).toHaveBeenLastCalledWith(64);
@@ -156,18 +156,18 @@ describe("InlineSlider snap stops", () => {
   });
 
   test("handles coarse steps, fractional stops, and an empty range", () => {
-    const { getByRole, rerender } = render(<InlineSlider min={0} max={10} step={4} defaultValue={0} />);
+    const { getByRole, rerender } = render(<InlineSlider label="Size" min={0} max={10} step={4} defaultValue={0} />);
     const slider = getByRole("slider");
     for (const value of [4, 8, 10]) {
       fireEvent.keyDown(slider, { key: "ArrowRight" });
       expect(slider.getAttribute("aria-valuenow")).toBe(String(value));
     }
-    rerender(<InlineSlider min={0} max={3} step={0.5} value={1} />);
+    rerender(<InlineSlider label="Size" min={0} max={3} step={0.5} value={1} />);
     const onValueChange = mock(() => {});
-    rerender(<InlineSlider min={0} max={3} step={0.5} value={1} onValueChange={onValueChange} />);
+    rerender(<InlineSlider label="Size" min={0} max={3} step={0.5} value={1} onValueChange={onValueChange} />);
     fireEvent.keyDown(slider, { key: "ArrowRight" });
     expect(onValueChange).toHaveBeenLastCalledWith(1.5);
-    rerender(<InlineSlider min={5} max={5} value={5} onValueChange={onValueChange} />);
+    rerender(<InlineSlider label="Size" min={5} max={5} value={5} onValueChange={onValueChange} />);
     fireEvent.keyDown(slider, { key: "ArrowRight" });
     expect(onValueChange).toHaveBeenLastCalledWith(5);
     expect(slider.getAttribute("aria-valuenow")).toBe("5");
@@ -176,7 +176,7 @@ describe("InlineSlider snap stops", () => {
   for (const ending of ["pointerUp", "pointerCancel", "lostPointerCapture"] as const) {
     test(`${ending} snaps once and ends the drag`, () => {
       const onValueChange = mock(() => {});
-      const { getByRole } = render(<InlineSlider min={8} max={128} step={8} defaultValue={48} onValueChange={onValueChange} />);
+      const { getByRole } = render(<InlineSlider label="Size" min={8} max={128} step={8} defaultValue={48} onValueChange={onValueChange} />);
       const slider = getByRole("slider");
       const track = slider.parentElement as HTMLElement;
       track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
@@ -195,7 +195,7 @@ describe("InlineSlider snap stops", () => {
 
   test("ignores disabled and secondary-button gestures", () => {
     const onValueChange = mock(() => {});
-    const { getByRole, rerender } = render(<InlineSlider defaultValue={48} disabled onValueChange={onValueChange} />);
+    const { getByRole, rerender } = render(<InlineSlider label="Size" defaultValue={48} disabled onValueChange={onValueChange} />);
     const slider = getByRole("slider");
     const track = slider.parentElement as HTMLElement;
     track.getBoundingClientRect = () => ({ left: 0, width: 292 }) as DOMRect;
@@ -204,7 +204,7 @@ describe("InlineSlider snap stops", () => {
     fireEvent.keyDown(slider, { key: "ArrowRight" });
     expect(slider.tabIndex).toBe(-1);
     expect(onValueChange).not.toHaveBeenCalled();
-    rerender(<InlineSlider defaultValue={48} onValueChange={onValueChange} />);
+    rerender(<InlineSlider label="Size" defaultValue={48} onValueChange={onValueChange} />);
     fireEvent.pointerDown(track, { clientX: 200, pointerId: 1, button: 2 });
     fireEvent.pointerUp(track, { clientX: 200, pointerId: 1, button: 2 });
     expect(onValueChange).not.toHaveBeenCalled();

--- a/tests/range-slider-variants.test.tsx
+++ b/tests/range-slider-variants.test.tsx
@@ -6,6 +6,7 @@ import { type SliderOptions, snapSliderValue } from "@/lib/hooks/use-slider";
 import { RangeSlider } from "@/components/motion/range-slider";
 import { BubbleSlider } from "@/components/motion/range-slider-bubble";
 import { FluidSlider } from "@/components/motion/range-slider-fluid";
+import { InlineSlider } from "@/components/motion/range-slider-inline";
 import { RulerSlider } from "@/components/motion/range-slider-ruler";
 import { WaveSlider } from "@/components/motion/range-slider-wave";
 
@@ -30,7 +31,7 @@ function stubTrackRect(element: Element, left = 0, width = 200) {
     ({ left, width, right: left + width, top: 0, bottom: 40, height: 40, x: left, y: 0 }) as DOMRect;
 }
 
-// The four track-style variants share every value path through useSlider, so
+// The track-style variants share every value path through useSlider, so
 // they run the same suite; the ruler drives its scale differently and has its own.
 const variants: Array<{ name: string; render: (props?: SliderOptions) => ReactElement }> = [
   { name: "RangeSlider", render: (props) => <RangeSlider aria-label="Level" {...props} /> },
@@ -205,6 +206,41 @@ describe("RangeSlider", () => {
     );
     // the tick dots are the only spans the slider renders
     expect(container.querySelectorAll("span")).toHaveLength(4);
+  });
+});
+
+describe("InlineSlider", () => {
+  test("keeps the inline readout visible after pointer release and blur", () => {
+    const { getByRole, getAllByText, queryByRole } = render(
+      <InlineSlider defaultValue={48} min={8} max={128} aria-label="Size" />,
+    );
+    const slider = getByRole("slider");
+    const track = slider.parentElement as HTMLElement;
+    stubTrackRect(track);
+    fireEvent.pointerDown(track, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerUp(track, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerLeave(track);
+    fireEvent.blur(slider);
+
+    expect(slider.getAttribute("aria-valuenow")).toBe("48");
+    expect(getAllByText("48")).toHaveLength(1);
+    expect(getAllByText("W/H")).toHaveLength(1);
+    expect(queryByRole("textbox")).toBeNull();
+  });
+
+  test("keeps fractional display and accessible formatting consistent", () => {
+    const { getByRole, getAllByText } = render(
+      <InlineSlider defaultValue={72.5} step={0.5} format={(value) => `${value}%`} label="Opacity" />,
+    );
+    expect(getByRole("slider", { name: "Opacity" }).getAttribute("aria-valuetext")).toBe("72.5%");
+    expect(getAllByText("72.5%")).toHaveLength(1);
+  });
+
+  test("lets callers supply a spoken unit separately from the display", () => {
+    const { getByRole } = render(
+      <InlineSlider defaultValue={48} formatValueText={(value) => `${value} pixels`} />,
+    );
+    expect(getByRole("slider").getAttribute("aria-valuetext")).toBe("48 pixels");
   });
 });
 

--- a/tests/range-slider-variants.test.tsx
+++ b/tests/range-slider-variants.test.tsx
@@ -212,7 +212,7 @@ describe("RangeSlider", () => {
 describe("InlineSlider", () => {
   test("keeps the inline readout visible after pointer release and blur", () => {
     const { getByRole, getAllByText, queryByRole } = render(
-      <InlineSlider defaultValue={48} min={8} max={128} aria-label="Size" />,
+      <InlineSlider label="Size" defaultValue={48} min={8} max={128} aria-label="Size" />,
     );
     const slider = getByRole("slider");
     const track = slider.parentElement as HTMLElement;
@@ -224,7 +224,7 @@ describe("InlineSlider", () => {
 
     expect(slider.getAttribute("aria-valuenow")).toBe("48");
     expect(getAllByText("48")).toHaveLength(1);
-    expect(getAllByText("W/H")).toHaveLength(1);
+    expect(getAllByText("Size")).toHaveLength(1);
     expect(queryByRole("textbox")).toBeNull();
   });
 
@@ -238,7 +238,7 @@ describe("InlineSlider", () => {
 
   test("lets callers supply a spoken unit separately from the display", () => {
     const { getByRole } = render(
-      <InlineSlider defaultValue={48} formatValueText={(value) => `${value} pixels`} />,
+      <InlineSlider label="Size" defaultValue={48} formatValueText={(value) => `${value} pixels`} />,
     );
     expect(getByRole("slider").getAttribute("aria-valuetext")).toBe("48 pixels");
   });


### PR DESCRIPTION
Inclusion of net new inline slider variant under the range slider component. Following functionalities with this include:

- Dots hidden beneath text while retaining their snap behavior
- Direct pointer tracking and spring-settling to the nearest stop on release
- Precise thumb grab handling and track-click interaction
- Handle that splits into two dots over the label 
- Keyboard controls: arrows, Home, End, Page Up, Page Down